### PR TITLE
add scripts to run standalone server to release zip

### DIFF
--- a/misc/scripts/standalone/server.cmd
+++ b/misc/scripts/standalone/server.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+REM BRouter standalone server
+REM java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <port>
+
+set JAVA_OPTS=-Xmx128M -Xms128M -Xmn8M
+set CLASSPATH=../brouter.jar
+
+java %JAVA_OPTS% -cp %CLASSPATH% btools.server.RouteServer ..\segments2 ..\profiles2 17777

--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# BRouter standalone server
+# java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <port>
+
+JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M"
+CLASSPATH=../brouter.jar
+
+java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments2 ../profiles2 17777


### PR DESCRIPTION
Proposing to add these scripts e.g. in a `bin` directory to the release zip, in order to run the standalone server (brouter.jar) for desktop applications. Additionally adding an empty `segments2` directory for storing the data files. 

I couldn't find a build script for the release, just put the scripts under `misc/scripts/standalone`. Use case is to provide the server part for [brouter-web](https://github.com/nrenner/brouter-web) - that would be hosted online - with the normal BRouter revisions (unlike my first idea to provide a separate all-in-one download).

The installation procedure would then be:
Install
1. download latest BRouter revision - as an example [a modified version ](http://www.norbertrenner.de/share/brouter_0_9_8.zip) with bin and segments2 dirs
2. download a [data file](http://h2096617.stratoserver.net/brouter/segments2/) and save into segments2 dir

Run
1. start server in the bin directory with `server.sh` or `server.cmd` (Windows)
2. open http://nrenner.github.io/brouter-web/

What do you think?
