### PR TITLE
set default timeout in standalone scripts

### DIFF
--- a/misc/scripts/standalone/server.cmd
+++ b/misc/scripts/standalone/server.cmd
@@ -3,7 +3,8 @@
 REM BRouter standalone server
 REM java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads>
 
-set JAVA_OPTS=-Xmx128M -Xms128M -Xmn8M
+REM maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
+set JAVA_OPTS=-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300
 set CLASSPATH=../brouter.jar
 
 java %JAVA_OPTS% -cp %CLASSPATH% btools.server.RouteServer ..\segments3 ..\profiles2 ..\customprofiles 17777 1

--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -3,7 +3,8 @@
 # BRouter standalone server
 # java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads>
 
-JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M"
+# maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
+JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300"
 CLASSPATH=../brouter.jar
 
 java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments3 ../profiles2 ../customprofiles 17777 1


### PR DESCRIPTION
I guess it makes sense to set a longer timeout (5 min) for the standalone server, a default entry also makes it easier to customize.

Could you please update the scripts in your release process, so they get included the next time.

In addition, the shell script in the release zips has Windows line breaks, not sure where this happens, but could you please convert these to Unix line endings (e.g. in an editor) after copying?

Not sure if it would make sense to automate this, e.g. using Ant.