### PR TITLE
Don't require server.sh to be launched from standalone directory

### DIFF
--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd "$(dirname "$0")"
 # BRouter standalone server
 # java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads>
 


### PR DESCRIPTION
Instead of doing `cd standalone/ && sh server.sh`, one can directly do `sh standalone/server.sh`.
