### PR TITLE
NegativeArraySizeException during map creation

### DIFF
--- a/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
@@ -29,7 +29,7 @@ public class NodeData extends MapCreatorBase
     ilon = (int)dis.readDiffed( 1 );
     ilat = (int)dis.readDiffed( 2 );
     int mode = dis.readByte();
-    if ( ( mode & 1 ) != 0 ) { int dlen = dis.readByte(); description = new byte[dlen]; dis.readFully( description ); }
+    if ( ( mode & 1 ) != 0 ) { int dlen = dis.read(); description = new byte[dlen]; dis.readFully( description ); }
     if ( ( mode & 2 ) != 0 ) selev = dis.readShort();
   }
 
@@ -38,9 +38,9 @@ public class NodeData extends MapCreatorBase
     dos.writeDiffed( nid,  0 );
     dos.writeDiffed( ilon, 1 );
     dos.writeDiffed( ilat, 2 );
-    int mode = ( description == null ? 0 : 1 ) | ( selev == Short.MIN_VALUE ? 0 : 2 );
-    dos.writeByte( (byte)mode );
-    if ( ( mode & 1 ) != 0 ) { dos.writeByte( description.length ); dos.write( description ); }
-    if ( ( mode & 2 ) != 0 ) dos.writeShort( selev );
+    int mode = (description == null ? 0 : 1) | (selev == Short.MIN_VALUE ? 0 : 2);
+    dos.writeByte((byte) mode);
+    if ((mode & 1) != 0) { dos.write(description.length); dos.write(description); }
+    if ((mode & 2) != 0) dos.writeShort(selev);
   }
 }

--- a/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
@@ -29,7 +29,7 @@ public class NodeData extends MapCreatorBase
     ilon = (int)dis.readDiffed( 1 );
     ilat = (int)dis.readDiffed( 2 );
     int mode = dis.readByte();
-    if ( ( mode & 1 ) != 0 ) { int dlen = dis.read(); description = new byte[dlen]; dis.readFully( description ); }
+    if ( ( mode & 1 ) != 0 ) { int dlen = dis.readShort(); description = new byte[dlen]; dis.readFully( description ); }
     if ( ( mode & 2 ) != 0 ) selev = dis.readShort();
   }
 
@@ -43,10 +43,10 @@ public class NodeData extends MapCreatorBase
       System.out.printf("Node id (%s): description length (%d) is longer then maximum allowed (%d). The description will NOT be written.", nid, description.length, Byte.MAX_VALUE);
       dos.writeByte((byte) 0);
     } else {
-      int mode = (description == null ? 0 : 1) | (selev == Short.MIN_VALUE ? 0 : 2);
-      dos.writeByte((byte) mode);
-      if ((mode & 1) != 0) { dos.write(description.length); dos.write(description); }
-      if ((mode & 2) != 0) dos.writeShort(selev);
+      int mode = (description == null ? 0 : 1 ) | ( selev == Short.MIN_VALUE ? 0 : 2 );
+      dos.writeShort( (byte) mode);
+      if ( ( mode & 1 ) != 0 ) { dos.write( description.length ); dos.write( description ); }
+      if ( ( mode & 2 ) != 0 ) dos.writeShort( selev );
     }
   }
 }

--- a/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/NodeData.java
@@ -38,9 +38,15 @@ public class NodeData extends MapCreatorBase
     dos.writeDiffed( nid,  0 );
     dos.writeDiffed( ilon, 1 );
     dos.writeDiffed( ilat, 2 );
-    int mode = (description == null ? 0 : 1) | (selev == Short.MIN_VALUE ? 0 : 2);
-    dos.writeByte((byte) mode);
-    if ((mode & 1) != 0) { dos.write(description.length); dos.write(description); }
-    if ((mode & 2) != 0) dos.writeShort(selev);
+    if (description != null && description.length > Byte.MAX_VALUE) {
+      System.err.printf("Node id (%s): description length (%d) is longer then maximum allowed (%d). The description will NOT be written.", nid, description.length, Byte.MAX_VALUE);
+      System.out.printf("Node id (%s): description length (%d) is longer then maximum allowed (%d). The description will NOT be written.", nid, description.length, Byte.MAX_VALUE);
+      dos.writeByte((byte) 0);
+    } else {
+      int mode = (description == null ? 0 : 1) | (selev == Short.MIN_VALUE ? 0 : 2);
+      dos.writeByte((byte) mode);
+      if ((mode & 1) != 0) { dos.write(description.length); dos.write(description); }
+      if ((mode & 2) != 0) dos.writeShort(selev);
+    }
   }
 }


### PR DESCRIPTION
I do not thing this is cure, but during map creation I got

  Exception in thread "main" java.lang.NegativeArraySizeException
        at btools.mapcreator.NodeData.<init>(NodeData.java:32)

which is strange, because array length (description.length) cannot be negative. So either description length was > 127 or ... ?

This pull request contains sanity check during serialization so description lengt cannot be bigger than 1 byte.
Also changes data format. Patch changes signed description lenght to unsigned byte. This change MAY be backward compatitble, but I did not bothered to check. I appologize for that.