### PR TITLE
decode query-string by standard URLDecoder

### DIFF
--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -5,9 +5,11 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -216,10 +218,11 @@ public class RouteServer extends Thread
   }
 
 
-  private static HashMap<String,String> getUrlParams( String url )
+  private static HashMap<String,String> getUrlParams( String url ) throws UnsupportedEncodingException
   {
 	  HashMap<String,String> params = new HashMap<String,String>();
-	  StringTokenizer tk = new StringTokenizer( url, "?&" );
+	  String decoded = URLDecoder.decode( url, "UTF-8" );
+	  StringTokenizer tk = new StringTokenizer( decoded, "?&" );
 	  while( tk.hasMoreTokens() )
 	  {
 	    String t = tk.nextToken();

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -73,18 +73,14 @@ public class ServerHandler extends RequestHandler {
 
     String[] coords = lonLats.split("\\|");
     if (coords.length < 2) 
-      coords = lonLats.split("%7C");
-      if (coords.length < 2) 
-        throw new IllegalArgumentException( "we need two lat/lon points at least!" );
+      throw new IllegalArgumentException( "we need two lat/lon points at least!" );
     
     List<OsmNodeNamed> wplist = new ArrayList<OsmNodeNamed>();
     for (int i = 0; i < coords.length; i++)
     {
       String[] lonLat = coords[i].split(",");
       if (lonLat.length < 2) 
-        lonLat = coords[i].split("%2C");
-        if (lonLat.length < 2) 
-          throw new IllegalArgumentException( "we need two lat/lon points at least!" );
+        throw new IllegalArgumentException( "we need two lat/lon points at least!" );
       wplist.add( readPosition( lonLat[0], lonLat[1], "via" + i ) );
     }
 


### PR DESCRIPTION
standalone mode fails if nogos are send with "|" being encoded as %7C resulting in java.lang.NumberFormatException: For input string: "300%7C12.0093".
%7C is standard url-encoding for "|" (as being defined in RFC-3986 https://tools.ietf.org/html/rfc3986#section-2.3).
This fix applies standard-based URLDecoding to the whole query-string before it is being parsed and removes the now obsolete explicit handing of %7C and %2C.