### PR TITLE
add optional parameter bindaddress for standalone mode

### DIFF
--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -156,10 +156,10 @@ public class RouteServer extends Thread
   public static void main(String[] args) throws Exception
   {
         System.out.println("BRouter 1.4.9 / 24092017");
-        if ( args.length != 5 )
+        if ( args.length != 5 && args.length != 6)
         {
           System.out.println("serve BRouter protocol");
-          System.out.println("usage: java RouteServer <segmentdir> <profiledir> <customprofiledir> <port> <maxthreads>");
+          System.out.println("usage: java RouteServer <segmentdir> <profiledir> <customprofiledir> <port> <maxthreads> [bindaddress]");
           return;
         }
 
@@ -173,7 +173,7 @@ public class RouteServer extends Thread
 
         TreeMap<Long,RouteServer> threadMap = new TreeMap<Long,RouteServer>();
 
-        ServerSocket serverSocket = new ServerSocket(Integer.parseInt(args[3]));
+        ServerSocket serverSocket = args.length > 5 ? new ServerSocket(Integer.parseInt(args[3]),50,InetAddress.getByName(args[5])) : new ServerSocket(Integer.parseInt(args[3]));
         long last_ts = 0;
         for (;;)
         {

--- a/misc/scripts/standalone/local.sh
+++ b/misc/scripts/standalone/local.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# BRouter standalone server
+# java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads> [bindaddress]
+
+# maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
+JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300"
+CLASSPATH=../brouter.jar
+
+java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments4 ../profiles2 ../customprofiles 17777 1 localhost


### PR DESCRIPTION
when running brouter in standalone mode it binds to all ip-addresses. This is fine for a real server on the internet, but for local use this is a security-issue. A software never should open ports reachable by the outside world if not explicitly required for this task.

This pull-requests adds an optional 'bindadress'-parameter. Usage see new startupscript local.sh