### PR TITLE
Nogo polygons / polylines

### DIFF
--- a/brouter-core/pom.xml
+++ b/brouter-core/pom.xml
@@ -32,5 +32,10 @@
             <artifactId>brouter-expressions</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -160,12 +160,26 @@ public class OsmNogoPolygon extends OsmNodeNamed
   }
 
  /**
-  * intersectsOrIsWithin
-  * 
+  * tests whether a point is within the polygon. 
+  * The current implementation doesn't produce consistent results for points
+  * being located exactly on the edge of the polygon. That doesn't have
+  * major impact on the routing-results though.
+  * For this method the winding-number algorithm is being used. That means a 
+  * point being within an overlapping region of the polygon is also taken as
+  * being 'inside' the polygon.
+  * @param lon longitude of point
+  * @param lat latitude of point
+  * @return true if point is inside of polygon, false otherwise
+  */
+  public boolean isWithin(int lon, int lat)
+  {
+	  return wn_PnPoly(new Point(lon,lat),points) > 0;
+  }
+  
+ /**
   * tests whether a segment defined by lon and lat of two points does either
   * intersect the polygon or any of the endpoints (or both) are enclosed by
-  * the polygon. Any point being positioned on any of the polygons edges is
-  * defined as being 'inside'. For this test the winding-number algorithm is
+  * the polygon. For this test the winding-number algorithm is
   * being used. That means a point being within an overlapping region of the
   * polygon is also taken as being 'inside' the polygon.
   * 
@@ -177,8 +191,8 @@ public class OsmNogoPolygon extends OsmNodeNamed
   */
   public boolean intersectsOrIsWithin(int lon0, int lat0, int lon1, int lat1)
   {
-    Point p0 = new Point (lon0,lat0);
-    Point p1 = new Point (lon1,lat1);
+    final Point p0 = new Point (lon0,lat0);
+    final Point p1 = new Point (lon1,lat1);
     // is start or endpoint within polygon?
     if ((wn_PnPoly(p0, points) > 0) || (wn_PnPoly(p1, points) > 0))
     {
@@ -199,7 +213,7 @@ public class OsmNogoPolygon extends OsmNodeNamed
     return false;
   }
 
-/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchses
+/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchsess
    This code may be freely used and modified for any purpose providing that
    this copyright notice is included with it. SoftSurfer makes no warranty for
    this code, and cannot be held liable for any real or imagined damage
@@ -242,7 +256,7 @@ public class OsmNogoPolygon extends OsmNodeNamed
     return ((cn & 1) > 0);                     // 0 if even (out), and 1 if odd (in)
   }
 
-/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchses
+/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchsess
    This code may be freely used and modified for any purpose providing that
    this copyright notice is included with it. SoftSurfer makes no warranty for
    this code, and cannot be held liable for any real or imagined damage
@@ -259,8 +273,8 @@ public class OsmNogoPolygon extends OsmNodeNamed
   private static int wn_PnPoly(final Point p, final List<Point> v) {
     int wn = 0; // the winding number counter
     
-    final int px = p.x;
-    final int py = p.y;
+    final long px = p.x;
+    final long py = p.y;
     
     // loop through all edges of the polygon
     final int i_last = v.size()-1;
@@ -283,7 +297,9 @@ public class OsmNogoPolygon extends OsmNodeNamed
             ++wn;     // have a valid up intersect
           }
         }
-      } else {         // start y > p.y (no test needed)
+      }
+      else // start y > p.y (no test needed)
+      {         
         if (p1y <= py) // a downward crossing
         {              // p right of edge
           if (((p1x - p0x) * (py - p0y) - (px - p0x) * (p1y - p0y)) < 0)
@@ -298,7 +314,7 @@ public class OsmNogoPolygon extends OsmNodeNamed
     return wn;
   }
 
-/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchses
+/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchsess
    This code may be freely used and modified for any purpose providing that
    this copyright notice is included with it. SoftSurfer makes no warranty for
    this code, and cannot be held liable for any real or imagined damage
@@ -348,7 +364,7 @@ public class OsmNogoPolygon extends OsmNodeNamed
     return false;
   }
   
-/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchses
+/* Copyright 2001 softSurfer, 2012 Dan Sunday, 2018 Norbert Truchsess
    This code may be freely used and modified for any purpose providing that
    this copyright notice is included with it. SoftSurfer makes no warranty for
    this code, and cannot be held liable for any real or imagined damage

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -27,6 +27,11 @@ import java.util.List;
 
 public class OsmNogoPolygon extends OsmNodeNamed
 {
+  public OsmNogoPolygon()
+  {
+    isNogo = true;
+  }
+
   private final static class Point
   {
     final int y;

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -29,8 +29,8 @@ public class OsmNogoPolygon extends OsmNodeNamed
 {
   public final static class Point
   {
-    final int y;
-    final int x;
+    public final int y;
+    public final int x;
 
     Point(final int lon, final int lat)
     {

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -169,23 +169,6 @@ public class OsmNogoPolygon extends OsmNodeNamed
   }
 
  /**
-  * tests whether a point is within the polygon.
-  * The current implementation doesn't produce consistent results for points
-  * being located exactly on the edge of the polygon. That doesn't have
-  * major impact on the routing-results though.
-  * For this method the winding-number algorithm is being used. That means a 
-  * point being within an overlapping region of the polygon is also taken as
-  * being 'inside' the polygon.
-  * @param lon longitude of point
-  * @param lat latitude of point
-  * @return true if point is inside of polygon, false otherwise
-  */
-//  public boolean isWithin(int lon, int lat)
-//  {
-//    return wn_PnPoly(lon,lat,points) != 0;
-//  }
-  
- /**
   * tests whether a segment defined by lon and lat of two points does either
   * intersect the polygon or any of the endpoints (or both) are enclosed by
   * the polygon. For this test the winding-number algorithm is
@@ -200,18 +183,6 @@ public class OsmNogoPolygon extends OsmNodeNamed
   */
   public boolean intersects(int lon0, int lat0, int lon1, int lat1)
   {
-    // is start or endpoint within closed polygon?
-//    if (isClosed)
-//    {
-//      if (wn_PnPoly(lon1,lat1, points) != 0)
-//      {
-//        return true;
-//      }
-      // check of wn_PnPoly(lon0,lat0, points) would return true only very few times.
-      // in the majority of cases (point within bounding-circle but outside of
-      // polygon both wn_PnPoly and intersect would both run, but intersect-check
-      // will catch all points inside the polygon as well.
-//    }
     final Point p0 = new Point (lon0,lat0);
     final Point p1 = new Point (lon1,lat1);
     int i_last = points.size()-1;

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2018 Norbert Truchsess <norbert.truchsess@t-online.de>
+ * 
+ * this code is based on work of Dan Sunday published at:
+ * http://geomalgorithms.com/a03-_inclusion.html
+ * (implementation of winding number algorithm in c)
+ * http://geomalgorithms.com/a08-_containers.html
+ * (fast computation of bounding circly in c)
+ * 
+ * Copyright 2001 softSurfer, 2012 Dan Sunday
+ * This code may be freely used and modified for any purpose providing that
+ * this copyright notice is included with it. SoftSurfer makes no warranty for
+ * this code, and cannot be held liable for any real or imagined damage
+ * resulting from its use. Users of this code must verify correctness for
+ * their application.
+ */
+package btools.router;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OsmNogoPolygon extends OsmNodeNamed
+{
+  public final class Point {
+    /**
+     * The latitude
+     */
+    public final int y;
+
+    /**
+     * The longitude
+     */
+    public final int x;
+
+    public Point(final int lon, final int lat)
+    {
+      x = lon;
+      y = lat;
+    }
+  }
+
+  public List<Point> P = new ArrayList<Point>();
+
+  public void addVertex(int lon, int lat)
+  {
+    P.add(new Point(lon, lat));
+  }
+
+  public void calcBoundingCircle()
+  {
+    double Cx, Cy;    // Center of ball
+    double rad, rad2; // radius and radius squared
+    double xmin, xmax, ymin, ymax; // bounding box extremes
+    int i_xmin, i_xmax, i_ymin, i_ymax; // index of P[] at box extreme
+
+    // find a large diameter to start with
+    // first get the bounding box and P[] extreme points for it
+    xmin = xmax = P.get(0).x;
+    ymin = ymax = P.get(0).y;
+    i_xmin = i_xmax = i_ymin = i_ymax = 0;
+    for (int i = 1; i < P.size(); i++)
+    {
+      Point Pi = P.get(i);
+      if (Pi.x < xmin)
+      {
+        xmin = Pi.x;
+        i_xmin = i;
+      }
+      else if (Pi.x > xmax)
+      {
+        xmax = Pi.x;
+        i_xmax = i;
+      }
+      if (Pi.y < ymin)
+      {
+        ymin = Pi.y;
+        i_ymin = i;
+      }
+      else if (Pi.y > ymax)
+      {
+        ymax = Pi.y;
+        i_ymax = i;
+      }
+    }
+    // select the largest extent as an initial diameter for the ball
+    Point Pi_xmax = P.get(i_xmax);
+    Point Pi_xmin = P.get(i_xmin);
+    Point Pi_ymax = P.get(i_ymax);
+    Point Pi_ymin = P.get(i_ymin);
+    
+    int dPx_x = (Pi_xmax.x - Pi_xmin.x); // diff of Px max and min
+    int dPx_y = Pi_xmax.y - Pi_xmin.y;
+    
+    int dPy_x = Pi_ymax.x - Pi_ymin.x; // diff of Py max and min
+    int dPy_y = Pi_ymax.y - Pi_ymin.y;
+
+    int dx2 = dPx_x * dPx_x + dPx_y * dPx_y; // Px diff squared
+    int dy2 = dPy_x * dPy_x + dPy_y * dPy_y; // Py diff squared
+    
+    if (dx2 >= dy2) // x direction is largest extent
+    {
+      Cx = Pi_xmin.x + dPx_x / 2.0; // Center = midpoint of extremes
+      Cy = Pi_xmin.y + dPx_x / 2.0;
+      
+      double dPC_x = Pi_xmax.x - Cx;
+      double dPC_y = Pi_xmax.y - Cy;
+      
+      rad2 = dPC_x * dPC_x + dPC_y * dPC_y; // radius squared
+      
+    }
+    else // y direction is largest extent
+    {
+      Cx = Pi_ymin.x + dPy_x / 2.0; // Center = midpoint of extremes
+      Cy = Pi_ymin.y + dPy_y / 2.0;
+      
+      double dPC_x = Pi_ymax.x - Cx;
+      double dPC_y = Pi_ymax.y - Cy;
+      
+      rad2 = dPC_x * dPC_x + dPC_y * dPC_y; // radius squared
+    }
+    rad = Math.sqrt(rad2);
+
+    // now check that all points P[i] are in the ball
+    // and if not, expand the ball just enough to include them
+    double dist, dist2;
+    for (int i = 0; i < P.size(); i++)
+    {  
+      Point Pi = P.get(i);
+      
+      double dPC_x = Pi.x - Cx;
+      double dPC_y = Pi.y - Cy;
+      
+      dist2 = dPC_x * dPC_x + dPC_y * dPC_y;
+
+      if (dist2 <= rad2) // P[i] is inside the ball already
+      {
+        continue;
+      }
+      // P[i] not in ball, so expand ball to include it
+      dist = Math.sqrt(dist2);
+      rad = (rad + dist) / 2.0; // enlarge radius just enough
+      rad2 = rad * rad;
+      
+      double dd = (dist - rad) / dist;
+      
+      Cx = Cx + dd * dPC_x; // shift Center toward
+      Cy = Cy + dd * dPC_y;
+    }
+    ilon = (int) Math.round(Cx);
+    ilat = (int) Math.round(Cy);
+    // compensate rounding error of center-point
+    radius = rad + Math.max(Math.abs(Cx - ilon), Math.abs(Cy - ilat));
+    return;
+  }
+
+  public boolean intersectsOrIsWithin(int lon0, int lat0, int lon1, int lat1)
+  {
+    Point P0 = new Point (lon0,lat0);
+    Point P1 = new Point (lon1,lat1);
+    // is start or endpoint within polygon?
+    if ((wn_PnPoly(P0, P) > 0) || (wn_PnPoly(P1, P) > 0))
+    {
+      return true;
+    }
+    Point P2 = P.get(0);
+    for (int i = 1; i < P.size(); i++)
+    {
+      Point P3 = P.get(i);
+      // does it intersect with at least one of the polygon's segments?
+      if (intersect2D_2Segments(P0,P1,P2,P3) > 0)
+      {
+        return true;
+      }
+      P2 = P3;
+    }
+    return false;
+  }
+
+  /**
+   * isLeft(): tests if a point is Left|On|Right of an infinite line. Input:
+   * three points P0, P1, and P2 Return: >0 for P2 left of the line through P0
+   * and P1 =0 for P2 on the line <0 for P2 right of the line See: Algorithm 1
+   * "Area of Triangles and Polygons"
+   */
+
+  private static int isLeft(Point P0, Point P1, Point P2) {
+    return ((P1.x - P0.x) * (P2.y - P0.y) - (P2.x - P0.x) * (P1.y - P0.y));
+  }
+
+  /**
+   * cn_PnPoly(): crossing number test for a point in a polygon Input: P = a
+   * point, V[] = vertex points of a polygon V[n+1] with V[n]=V[0] Return: 0 =
+   * outside, 1 = inside This code is patterned after [Franklin, 2000]
+   */
+
+  private static boolean cn_PnPoly(Point P, List<Point> V)
+  {
+    int cn = 0; // the crossing number counter
+
+    // loop through all edges of the polygon
+    int last = V.size()-1;
+    Point Vi = V.get(last);
+    for (int i = 0; i <= last; i++)            // edge from V[i] to V[i+1]
+    {
+      Point Vi1 = V.get(i);
+
+      if (((Vi.y <= P.y) && (Vi1.y > P.y))     // an upward crossing
+          || ((Vi.y > P.y) && (Vi1.y <= P.y))) // a downward crossing
+      {
+        // compute the actual edge-ray intersect x-coordinate
+        float vt = (float) (P.y - Vi.y) / (Vi1.y - Vi.y);
+
+        if (P.x < Vi.x + vt * (Vi1.x - Vi.x))  // P.x < intersect
+        {
+          ++cn;                                // a valid crossing of y=P.y right of P.x
+        }
+      }
+      Vi = Vi1;
+    }
+    return ((cn & 1) > 0);                     // 0 if even (out), and 1 if odd (in)
+  }
+
+  /**
+   * wn_PnPoly(): winding number test for a point in a polygon Input: P = a
+   * point, V = vertex points of a polygon V[n+1] with V[n]=V[0] Return: wn =
+   * the winding number (=0 only when P is outside)
+   */
+
+  private static int wn_PnPoly(Point P, List<Point> V) {
+    int wn = 0; // the winding number counter
+
+    // loop through all edges of the polygon
+    int last = V.size()-1;
+    Point Vi = V.get(last);
+    for (int i = 0; i <= last; i++)      // edge from V[i] to V[i+1]
+    {
+      Point Vi1 = V.get(i);
+
+      if (Vi.y <= P.y) {                 // start y <= P.y
+        if (Vi1.y > P.y) {               // an upward crossing
+          if (isLeft(Vi, Vi1, P) > 0) {  // P left of edge
+            ++wn;                        // have a valid up intersect
+          }
+        }
+      } else {                           // start y > P.y (no test needed)
+        if (Vi1.y <= P.y) {              // a downward crossing
+          if (isLeft(Vi, Vi1, P) < 0) {  // P right of edge
+            --wn;                        // have a valid down intersect
+          }
+        }
+      }
+      Vi = Vi1;
+    }
+    return wn;
+  }
+
+  /**
+   * inSegment(): determine if a point is inside a segment
+   * Input:  a point P, and a collinear segment S
+   * Return: 1 = P is inside S
+   *         0 = P is not inside S
+   */
+  
+  private static boolean inSegment( Point P, Point SP0, Point SP1)
+  {
+    if (SP0.x != SP1.x)    // S is not  vertical
+    {
+      if (SP0.x <= P.x && P.x <= SP1.x)
+      {
+        return true;
+      }
+      if (SP0.x >= P.x && P.x >= SP1.x)
+      {
+        return true;
+      }
+    }
+    else    // S is vertical, so test y  coordinate
+    {
+      if (SP0.y <= P.y && P.y <= SP1.y)
+      {
+        return true;
+      }
+      if (SP0.y >= P.y && P.y >= SP1.y)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+  
+  /**
+   * intersect2D_2Segments(): find the 2D intersection of 2 finite segments 
+   * Input:  two finite segments S1 and S2
+   * Return: 0=disjoint (no intersect)
+   *         1=intersect in unique point I0
+   *         2=overlap in segment from I0 to I1
+   */
+  private static int intersect2D_2Segments( Point S1P0, Point S1P1, Point S2P0, Point S2P1 )
+  {     
+    int ux = S1P1.x - S1P0.x; // vector u = S1P1-S1P0 (segment 1)
+    int uy = S1P1.y - S1P0.y;
+    int vx = S2P1.x - S2P0.x; // vector v = S2P1-S2P0 (segment 2)
+    int vy = S2P1.y - S2P0.y;
+    int wx = S1P0.x - S2P0.x; // vector w = S1P0-S2P0 (from start of segment 2 to start of segment 1
+    int wy = S1P0.y - S2P0.y;
+    
+    int D = ux * vy - uy * vx;
+
+    // test if  they are parallel (includes either being a point)
+    if (D == 0)           // S1 and S2 are parallel
+    {
+      if ((ux * wy - uy * wx) != 0 || (vx * wy - vy * wx) != 0)
+      {
+        return 0; // they are NOT collinear
+      }
+
+      // they are collinear or degenerate
+      // check if they are degenerate  points
+      boolean du = ux == 0 && uy == 0;
+      boolean dv = vx == 0 && vy == 0;
+      if (du && dv)            // both segments are points
+      {
+        return (wx == 0 && wy == 0) ? 0 : 1; // return 0 if they are distinct points
+      }
+      if (du)                     // S1 is a single point
+      {
+        return inSegment(S1P0, S2P0, S2P1) ? 1 : 0; // is it part of S2?
+      }
+      if (dv)                     // S2 a single point
+      {
+        return inSegment(S2P0, S1P0, S1P1) ? 1 : 0;  // is it part of S1?
+      }
+      // they are collinear segments - get  overlap (or not)
+      float t0, t1;                    // endpoints of S1 in eqn for S2
+      int w2x = S1P1.x - S2P0.x; // vector w2 = S1P1-S2P0 (from start of segment 2 to end of segment 1)
+      int w2y = S1P1.y - S2P0.y;
+      if (vx != 0)
+      {
+        t0 = wx / vx;
+        t1 = w2x / vx;
+      }
+      else
+      {
+        t0 = wy / vy;
+        t1 = w2y / vy;
+      }
+      if (t0 > t1)                   // must have t0 smaller than t1
+      {
+        float t=t0;     // swap if not
+        t0=t1;
+        t1=t;
+      }
+      if (t0 > 1 || t1 < 0)
+      {
+        return 0;      // NO overlap
+      }
+      t0 = t0<0? 0 : t0;               // clip to min 0
+      t1 = t1>1? 1 : t1;               // clip to max 1
+    
+      return (t0 == t1) ? 1 : 2;        // return 1 if intersect is a point
+    }
+
+    // the segments are skew and may intersect in a point
+    // get the intersect parameter for S1
+    
+    double sI = (vx * wy - vy * wx) / D;
+    if (sI < 0 || sI > 1)               // no intersect with S1
+    {
+      return 0;
+    }
+
+    // get the intersect parameter for S2
+    double tI = (ux * wy - uy * wx) / D;
+    return (tI < 0 || tI > 1) ? 0 : 1; // return 0 if no intersect with S2
+  }
+}

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -215,7 +215,9 @@ public final class RoutingContext
       boolean goodGuy = true;
       for( OsmNodeNamed wp : waypoints )
       {
-        if ( wp.calcDistance( nogo ) < radiusInMeter )
+        if ( wp.calcDistance( nogo ) < radiusInMeter
+            && (!(nogo instanceof OsmNogoPolygon)
+                || ((OsmNogoPolygon)nogo).isWithin(wp.ilon, wp.ilat)))
         {
           goodGuy = false;
           break;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -296,11 +296,13 @@ public final class RoutingContext
             radius = Math.sqrt( s1 < s2 ? r12 : r22 );
             if ( radius > nogo.radius ) continue; // 20m ^ 2
           }
-          if ( nogo.isNogo 
-              && (!(nogo instanceof OsmNogoPolygon) 
-                  || ((OsmNogoPolygon)nogo).intersectsOrIsWithin(lon1, lat1, lon2, lat2)))
+          if ( nogo.isNogo )
           {
-            nogomatch = true;
+            if (!(nogo instanceof OsmNogoPolygon)
+                || ((OsmNogoPolygon)nogo).intersectsOrIsWithin(lon1, lat1, lon2, lat2))
+            {
+              nogomatch = true;
+            }
           }
           else
           {

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -192,16 +192,20 @@ public final class RoutingContext
   {
     for( OsmNodeNamed nogo : nogos )
     {
-        String s = nogo.name;
-        int idx = s.indexOf( ' ' );
-        if ( idx > 0 ) s = s.substring( 0 , idx );
-        int ir = 20; // default radius
-        if ( s.length() > 4 )
-        {
-          try { ir = Integer.parseInt( s.substring( 4 ) ); }
-          catch( Exception e ) { /* ignore */ }
-        }
-        nogo.radius = ir / 110984.; //  6378000. / 57.3;
+      if (nogo instanceof OsmNogoPolygon)
+      {
+        continue;
+      }
+      String s = nogo.name;
+      int idx = s.indexOf( ' ' );
+      if ( idx > 0 ) s = s.substring( 0 , idx );
+      int ir = 20; // default radius
+      if ( s.length() > 4 )
+      {
+        try { ir = Integer.parseInt( s.substring( 4 ) ); }
+        catch( Exception e ) { /* ignore */ }
+      }
+      nogo.radius = ir / 110984.; //  6378000. / 57.3;
     }
   }
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -294,7 +294,12 @@ public final class RoutingContext
             radius = Math.sqrt( s1 < s2 ? r12 : r22 );
             if ( radius > nogo.radius ) continue; // 20m ^ 2
           }
-          if ( nogo.isNogo ) nogomatch = true;
+          if ( nogo.isNogo 
+              && (!(nogo instanceof OsmNogoPolygon) 
+                  || ((OsmNogoPolygon)nogo).intersectsOrIsWithin(lon1, lat1, lon2, lat2)))
+          {
+            nogomatch = true;
+          }
           else
           {
             shortestmatch = true;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -217,7 +217,9 @@ public final class RoutingContext
       {
         if ( wp.calcDistance( nogo ) < radiusInMeter
             && (!(nogo instanceof OsmNogoPolygon)
-                || ((OsmNogoPolygon)nogo).isWithin(wp.ilon, wp.ilat)))
+                || (((OsmNogoPolygon)nogo).isClosed 
+                    ? ((OsmNogoPolygon)nogo).isWithin(wp.ilon, wp.ilat)
+                        : ((OsmNogoPolygon)nogo).isOnPolyline(wp.ilon, wp.ilat))))
         {
           goodGuy = false;
           break;
@@ -299,7 +301,7 @@ public final class RoutingContext
           if ( nogo.isNogo )
           {
             if (!(nogo instanceof OsmNogoPolygon)
-                || ((OsmNogoPolygon)nogo).intersectsOrIsWithin(lon1, lat1, lon2, lat2))
+                || ((OsmNogoPolygon)nogo).intersects(lon1, lat1, lon2, lat2))
             {
               nogomatch = true;
             }

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -62,7 +62,7 @@ public class OsmNogoPolygonTest {
       double py = toOsmLat(lats[i]);
       double dpx = (toOsmLon(lons[i]) - p.ilon) * coslat(p.ilat);
       double dpy = py - p.ilat;
-      double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
+      double r1 = Math.sqrt(dpx * dpx + dpy * dpy) * 0.000001;
       double diff = r-r1;
       assertTrue("i: "+i+" r("+r+") >= r1("+r1+")", diff >= 0);
     }

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -61,7 +61,6 @@ public class OsmNogoPolygonTest {
   
   @AfterClass
   public static void tearDown() throws Exception {
-    polygon.waitForTracker();
   }
 
   @Test

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -1,3 +1,20 @@
+/**********************************************************************************************
+   Copyright (C) 2018 Norbert Truchsess norbert.truchsess@t-online.de
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************************************************************/
 package btools.router;
 
 import static org.junit.Assert.*;
@@ -8,40 +25,60 @@ import org.junit.Test;
 public class OsmNogoPolygonTest {
 
   OsmNogoPolygon p;
+
+  final double[] lons = {  1.0,  1.0,  0.5, 0.5, 1.0, 1.0, -1.0, -1.0 };
+  final double[] lats = { -1.0, -0.1, -0.1, 0.1, 0.1, 1.0,  1.0, -1.0 };
+
+  int toOsmLon(double lon) {
+    return (int)( ( lon + 180. ) *1000000. + 0.5); // see ServerHandler.readPosition()
+  }
+  
+  int toOsmLat(double lat) {
+    return (int)( ( lat +  90. ) *1000000. + 0.5);
+  }
+  
+  double coslat(int lat) // see RoutingContext.calcDistance()
+  {
+    final double l = (lat - 90000000) * 0.00000001234134; // 0.01234134 = Pi/(sqrt(2)*180)
+    final double l2 = l*l;
+    final double l4 = l2*l2;
+//    final double l6 = l4*l2;
+    return 1.- l2 + l4 / 6.; // - l6 / 90;
+  }
   
   @Before
   public void setUp() throws Exception {
     p = new OsmNogoPolygon();
-    p.addVertex(1000, 1000);
-    p.addVertex(2001, 1000);
-    p.addVertex(2001, 1250);
-    p.addVertex(1750, 1250);
-    p.addVertex(1750, 1750);
-    p.addVertex(2001, 1750);
-    p.addVertex(2001, 2001);
-    p.addVertex(1000, 2001);
+    for (int i = 0; i<lons.length; i++) {
+      p.addVertex(toOsmLon(lons[i]),toOsmLat(lats[i]));
+    }
   }
 
   @Test
   public void testCalcBoundingCircle() {
     p.calcBoundingCircle();
-    assertEquals(1501,p.ilat);
-    assertEquals(1501,p.ilon);
-    assertEquals(707.813887968,p.radius,0.5);
+    double r = p.radius;
+    for (int i=0; i<lons.length; i++) {
+      double py = toOsmLat(lats[i]);
+      double dpx = (toOsmLon(lons[i]) - p.ilon) * coslat(p.ilat);
+      double dpy = py - p.ilat;
+      double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
+      double diff = r-r1;
+      assertTrue("i: "+i+" r("+r+") >= r1("+r1+")", diff >= 0);
+    }
   }
 
   @Test
   public void testIntersectsOrIsWithin() {
-    assertFalse(p.intersectsOrIsWithin(0,0, 0,0));
-    assertFalse(p.intersectsOrIsWithin(1800,1500, 1800,1500));
-    assertFalse(p.intersectsOrIsWithin(1500,2002, 1500,2002));
-    assertTrue(p.intersectsOrIsWithin(1750, 1500, 1800,1500));
-    assertTrue(p.intersectsOrIsWithin(1500, 2001, 1500,2002));
-    assertTrue(p.intersectsOrIsWithin(1100, 1000, 1900, 1000));
-    assertTrue(p.intersectsOrIsWithin(0, 0, 1500,1500));
-    assertTrue(p.intersectsOrIsWithin(500, 1500, 1500, 1500));
-    assertTrue(p.intersectsOrIsWithin(500, 1500, 2000, 1500));
-    assertTrue(p.intersectsOrIsWithin(1400, 1500, 1500, 1500));
+    double[] p0lons  = {  0.0,   1.0, -0.5,  0.5,  0.7,  0.7,  0.7,  -1.5, };
+    double[] p0lats  = {  0.0,   0.0,  0.5,  0.5,  0.5,  0.05, 0.05, -1.5, };
+    double[] p1lons  = {  0.0,   1.0,  0.5,  1.0,  0.7,  0.7,  0.7,  -0.5, };
+    double[] p1lats  = {  0.0,   0.0,  0.5,  0.5, -0.5, -0.5, -0.05, -0.5, };
+    boolean[] within = { true, false, true, true, true, true, false, true, };
+    
+    for (int i=0; i<p0lons.length; i++) {
+      assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],p.intersectsOrIsWithin(toOsmLon(p0lons[i]), toOsmLat(p0lats[i]), toOsmLon(p1lons[i]), toOsmLat(p1lats[i])));
+    }
   }
 
 }

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -1,0 +1,47 @@
+package btools.router;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class OsmNogoPolygonTest {
+
+  OsmNogoPolygon p;
+  
+  @Before
+  public void setUp() throws Exception {
+    p = new OsmNogoPolygon();
+    p.addVertex(1000, 1000);
+    p.addVertex(2001, 1000);
+    p.addVertex(2001, 1250);
+    p.addVertex(1750, 1250);
+    p.addVertex(1750, 1750);
+    p.addVertex(2001, 1750);
+    p.addVertex(2001, 2001);
+    p.addVertex(1000, 2001);
+  }
+
+  @Test
+  public void testCalcBoundingCircle() {
+    p.calcBoundingCircle();
+    assertEquals(1501,p.ilat);
+    assertEquals(1501,p.ilon);
+    assertEquals(707.813887968,p.radius,0.5);
+  }
+
+  @Test
+  public void testIntersectsOrIsWithin() {
+    assertFalse(p.intersectsOrIsWithin(0,0, 0,0));
+    assertFalse(p.intersectsOrIsWithin(1800,1500, 1800,1500));
+    assertFalse(p.intersectsOrIsWithin(1500,2002, 1500,2002));
+    assertTrue(p.intersectsOrIsWithin(1750, 1500, 1800,1500));
+    assertTrue(p.intersectsOrIsWithin(1500, 2001, 1500,2002));
+    assertTrue(p.intersectsOrIsWithin(1100, 1000, 1900, 1000));
+    assertTrue(p.intersectsOrIsWithin(0, 0, 1500,1500));
+    assertTrue(p.intersectsOrIsWithin(500, 1500, 1500, 1500));
+    assertTrue(p.intersectsOrIsWithin(500, 1500, 2000, 1500));
+    assertTrue(p.intersectsOrIsWithin(1400, 1500, 1500, 1500));
+  }
+
+}

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -69,13 +69,26 @@ public class OsmNogoPolygonTest {
   }
 
   @Test
+  public void testIsWithin() {
+	  // for points exactly on the edge of the polygon the result is not the same for all directions.
+	  // that doesn't have a major impact on routing though.
+    double[] plons   = {  0.0,   0.5,   1.0,  -1.5,  -0.5, }; //  1.0,   1.0,   0.5,   0.5,   0.5, 
+    double[] plats   = {  0.0,   1.5,   0.0,   0.5,  -1.5, }; // -1.0,  -0.1,  -0.1,   0.0,   0.1,
+    boolean[] within = { true, false, false, false, false, }; // false, false, false, false, false, 
+
+    for (int i=0; i<plons.length; i++) {
+      assertEquals("("+plons[i]+","+plats[i]+")",within[i],p.isWithin(toOsmLon(plons[i]), toOsmLat(plats[i])));
+    }
+  }
+
+  @Test
   public void testIntersectsOrIsWithin() {
     double[] p0lons  = {  0.0,   1.0, -0.5,  0.5,  0.7,  0.7,  0.7,  -1.5, };
     double[] p0lats  = {  0.0,   0.0,  0.5,  0.5,  0.5,  0.05, 0.05, -1.5, };
     double[] p1lons  = {  0.0,   1.0,  0.5,  1.0,  0.7,  0.7,  0.7,  -0.5, };
     double[] p1lats  = {  0.0,   0.0,  0.5,  0.5, -0.5, -0.5, -0.05, -0.5, };
     boolean[] within = { true, false, true, true, true, true, false, true, };
-    
+
     for (int i=0; i<p0lons.length; i++) {
       assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],p.intersectsOrIsWithin(toOsmLon(p0lons[i]), toOsmLat(p0lats[i]), toOsmLon(p1lons[i]), toOsmLat(p1lats[i])));
     }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -67,7 +67,7 @@ public class BRouterWorker
     }
 
     readNogos( params ); // add interface provided nogos
-    rc.prepareNogoPoints( nogoList );
+    RoutingContext.prepareNogoPoints( nogoList );
     rc.nogopoints = nogoList;
 
     waypoints = readPositions(params);

--- a/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReaderOsmAnd.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReaderOsmAnd.java
@@ -3,9 +3,15 @@ package btools.routingapp;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+
 import btools.router.OsmNodeNamed;
+import btools.router.OsmNogoPolygon;
 
 /**
  * Read coordinates from a gpx-file
@@ -65,6 +71,13 @@ public class CoordinateReaderOsmAnd extends CoordinateReader
     {
       _readPointmap( osmandDir + "/favourites.gpx" );
     }
+    try
+    {
+      _readNogoLines( basedir+tracksdir );
+    }
+    catch( IOException ioe )
+    {    
+    }
   }
 
   private void _readPointmap( String filename ) throws Exception
@@ -106,5 +119,72 @@ public class CoordinateReaderOsmAnd extends CoordinateReader
         }
       }
       br.close();
+  }
+  
+  private void _readNogoLines( String dirname ) throws IOException
+  {
+    
+    File dir = new File( dirname );
+    
+    if (dir.exists() && dir.isDirectory())
+    {
+      for (final File file : dir.listFiles())
+      {
+        final String name = file.getName();
+        if (name.startsWith("nogo") && name.endsWith(".gpx"))
+        {
+          try
+          {
+            _readNogoLine(file);
+          }
+          catch (Exception e)
+          {
+          }
+        }
+      }
+    }
+  }
+  
+  private void _readNogoLine( File file ) throws Exception
+  {
+    XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+    factory.setNamespaceAware(false);
+    XmlPullParser xpp = factory.newPullParser();
+
+    xpp.setInput(new FileReader(file));
+    OsmNogoPolygon nogo = new OsmNogoPolygon(true);
+    int eventType = xpp.getEventType();
+    int numSeg = 0;
+    while (eventType != XmlPullParser.END_DOCUMENT) {
+      switch(eventType) {
+      case XmlPullParser.START_TAG: {
+        if (xpp.getName().equals("trkpt")) {
+          final String lon = xpp.getAttributeValue(null,"lon");
+          final String lat = xpp.getAttributeValue(null,"lat");
+          if (lon != null && lat != null) {
+            nogo.addVertex(
+                (int)( ( Double.parseDouble(lon) + 180. ) *1000000. + 0.5),
+                (int)( ( Double.parseDouble(lat) +  90. ) *1000000. + 0.5));
+          }
+        }
+        break;
+      }
+      case XmlPullParser.END_TAG: {
+        if (xpp.getName().equals("trkseg")) {
+          nogo.calcBoundingCircle();
+          final String name = file.getName();
+          nogo.name = name.substring(0, name.length()-4);
+          if (numSeg > 0)
+          {
+            nogo.name += Integer.toString(numSeg+1);
+          }
+          numSeg++;
+          checkAddPoint( "(one-for-all)", nogo );
+        }
+        break;
+      }
+      }
+      eventType = xpp.next();
+    }
   }
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReaderOsmAnd.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReaderOsmAnd.java
@@ -152,7 +152,7 @@ public class CoordinateReaderOsmAnd extends CoordinateReader
     XmlPullParser xpp = factory.newPullParser();
 
     xpp.setInput(new FileReader(file));
-    OsmNogoPolygon nogo = new OsmNogoPolygon(true);
+    OsmNogoPolygon nogo = new OsmNogoPolygon(false);
     int eventType = xpp.getEventType();
     int numSeg = 0;
     while (eventType != XmlPullParser.END_DOCUMENT) {

--- a/brouter-server/src/main/java/btools/server/BRouter.java
+++ b/brouter-server/src/main/java/btools/server/BRouter.java
@@ -88,7 +88,7 @@ public class BRouter
       }
       System.exit(0);
     }
-    System.out.println("BRouter 1.4.9 / 24092017 / abrensch");
+    System.out.println("BRouter 1.4.10 / 26022018 / abrensch+ntruchsess");
     if ( args.length < 6 )
     {
       System.out.println("Find routes in an OSM map");

--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -157,7 +157,7 @@ public class RouteServer extends Thread
 
   public static void main(String[] args) throws Exception
   {
-        System.out.println("BRouter 1.4.9 / 24092017");
+        System.out.println("BRouter 1.4.10 / 26022018 abrensch+ntruchsess");
         if ( args.length != 5 && args.length != 6)
         {
           System.out.println("serve BRouter protocol");

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -240,35 +240,38 @@ public class ServerHandler extends RequestHandler {
 
   private List<OsmNodeNamed> readNogoPolygons()
   {
-    String polygons = params.get( "polygons" );
-    if ( polygons == null ) return null;
-
-    String[] polygonList = polygons.split("\\|");
-
-    List<OsmNodeNamed> nogoPolygonList = new ArrayList<OsmNodeNamed>();
-    for (int i = 0; i < polygonList.length; i++)
+    List<OsmNodeNamed> result = new ArrayList<OsmNodeNamed>();
+    parseNogoPolygons( params.get("polylines"), result, false );
+    parseNogoPolygons( params.get("polygons"), result, true );
+    return result.size() > 0 ? result : null;
+  }
+  
+  private static void parseNogoPolygons(String polygons, List<OsmNodeNamed> result, boolean closed )
+  {
+    if ( polygons != null )
     {
-      String[] lonLatList = polygonList[i].split(",");
-      if ( lonLatList.length > 1 )
+      String[] polygonList = polygons.split("\\|");
+      for (int i = 0; i < polygonList.length; i++)
       {
-        OsmNogoPolygon polygon = new OsmNogoPolygon();
-        for (int j = 0; j < lonLatList.length-1;)
+        String[] lonLatList = polygonList[i].split(",");
+        if ( lonLatList.length > 1 )
         {
-          String slon = lonLatList[j++];
-          String slat = lonLatList[j++];
-          int lon = (int)( ( Double.parseDouble(slon) + 180. ) *1000000. + 0.5);
-          int lat = (int)( ( Double.parseDouble(slat) +  90. ) *1000000. + 0.5);
-          polygon.addVertex(lon, lat);
-        }
-        if ( polygon.points.size() > 0 )
-        {
-          polygon.name = "";
-          polygon.isNogo = true;
-          polygon.calcBoundingCircle();
-          nogoPolygonList.add(polygon);
+          OsmNogoPolygon polygon = new OsmNogoPolygon(closed);
+          for (int j = 0; j < lonLatList.length-1;)
+          {
+            String slon = lonLatList[j++];
+            String slat = lonLatList[j++];
+            int lon = (int)( ( Double.parseDouble(slon) + 180. ) *1000000. + 0.5);
+            int lat = (int)( ( Double.parseDouble(slat) +  90. ) *1000000. + 0.5);
+            polygon.addVertex(lon, lat);
+          }
+          if ( polygon.points.size() > 0 )
+          {
+            polygon.calcBoundingCircle();
+            result.add(polygon);
+          }
         }
       }
-    }
-    return nogoPolygonList;
+    }  
   }
 }

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -62,10 +62,17 @@ public class ServerHandler extends RequestHandler {
       rc.nogopoints = nogoList;
     }
 
-    List<OsmNogoPolygon> nogoPolygonsList = readNogoPolygons();
+    List<OsmNodeNamed> nogoPolygonsList = readNogoPolygons();
     if ( nogoPolygonsList != null )
     {
-      rc.nogopoints.addAll(nogoPolygonsList);
+      if (rc.nogopoints == null)
+      {
+        rc.nogopoints = nogoPolygonsList;
+      }
+      else
+      {
+        rc.nogopoints.addAll(nogoPolygonsList);
+      }
     }
 
     return rc;
@@ -233,22 +240,22 @@ public class ServerHandler extends RequestHandler {
     return n;
   }
 
-  private List<OsmNogoPolygon> readNogoPolygons()
+  private List<OsmNodeNamed> readNogoPolygons()
   {
     String polygons = params.get( "polygons" );
     if ( polygons == null ) return null;
 
     String[] polygonList = polygons.split("\\|");
 
-    List<OsmNogoPolygon> nogoPolygonList = new ArrayList<OsmNogoPolygon>();
+    List<OsmNodeNamed> nogoPolygonList = new ArrayList<OsmNodeNamed>();
     for (int i = 0; i < polygonList.length; i++)
     {
       String[] lonLatList = polygonList[i].split(",");
       OsmNogoPolygon polygon = new OsmNogoPolygon();
-      for (int j = 0; j < lonLatList.length; j++)
+      for (int j = 0; j < lonLatList.length-1;)
       {
-        String slon = lonLatList[i++];
-        String slat = lonLatList[i];
+        String slon = lonLatList[j++];
+        String slat = lonLatList[j++];
         int lon = (int)( ( Double.parseDouble(slon) + 180. ) *1000000. + 0.5);
         int lat = (int)( ( Double.parseDouble(slat) +  90. ) *1000000. + 0.5);
         polygon.addVertex(lon, lat);

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
             <name>Arndt Brenschede</name>
             <email>Arndt.Brenschede@web.de</email>
         </developer>
+        <developer>
+            <id>norbert.truchsess</id>
+            <name>Norbert Truchsess</name>
+            <email>norbert.truchsess@t-online.de</email>
+        </developer>
     </developers>
 
     <properties>
@@ -146,7 +151,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.11</version>
+				<version>4.12</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
This pull-request adds support for nogo-polygons and polylines. A nogo-polygon is being used as a nogo-area being defined by an (arbitrary shaped) polygon. A nogo-polyline is simmilar to this with the difference that the polygon is not taken as closed, so it defines a border that is not to be crossed when routing.
I currently can be utilized via the standalone server (new query-parameters 'polygons' and 'polylines') and on Android from OsmAnd (by saving tracks with the filename beginning with 'nogo').
(The web-frontend does not yet support this, but QMapshack already has full support for this feature).