### PR TITLE
Allow custom nogo weights

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
+++ b/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
@@ -28,9 +28,8 @@ public class OsmNodeNamed extends OsmNode
   public double distanceWithinRadius(int lon1, int lat1, int lon2, int lat2, double totalSegmentLength) {
     double[] lonlat2m = CheapRulerSingleton.getLonLatToMeterScales( (lat1 + lat2) >> 1 );
 
-    double realRadius = radius * 110984.;
-    boolean isFirstPointWithinCircle = CheapRulerSingleton.distance(lon1, lat1, ilon, ilat) < realRadius;
-    boolean isLastPointWithinCircle = CheapRulerSingleton.distance(lon2, lat2, ilon, ilat) < realRadius;
+    boolean isFirstPointWithinCircle = CheapRulerSingleton.distance(lon1, lat1, ilon, ilat) < radius;
+    boolean isLastPointWithinCircle = CheapRulerSingleton.distance(lon2, lat2, ilon, ilat) < radius;
     // First point is within the circle
     if (isFirstPointWithinCircle) {
       // Last point is within the circle
@@ -62,7 +61,7 @@ public class OsmNodeNamed extends OsmNode
     double initialToCenter = CheapRulerSingleton.distance(ilon, ilat, lon1, lat1);
     // Half length of the segment within the circle
     double halfDistanceWithin = Math.sqrt(
-      realRadius*realRadius - (
+      radius*radius - (
         initialToCenter*initialToCenter -
         initialToProject*initialToProject
       )

--- a/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
+++ b/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
@@ -11,12 +11,13 @@ public class OsmNodeNamed extends OsmNode
 {
   public String name;
   public double radius; // radius of nogopoint (in meters)
+  public double nogoWeight;  // weight for nogopoint
   public boolean isNogo = false;
 
   @Override
   public String toString()
   {
-    return ilon + "," + ilat + "," + name;
+    return ilon + "," + ilat + "," + name + "," + nogoWeight;
   }
 
   public static OsmNodeNamed decodeNogo( String s )
@@ -26,7 +27,14 @@ public class OsmNodeNamed extends OsmNode
     n.ilon = Integer.parseInt( s.substring( 0, idx1 ) );
     int idx2 = s.indexOf( ',', idx1+1 );
     n.ilat = Integer.parseInt( s.substring( idx1+1, idx2 ) );
-    n.name = s.substring( idx2+1 );
+    int idx3 = s.indexOf( ',', idx2+1 );
+    if ( idx3 == -1) {
+        n.name = s.substring( idx2 + 1 );
+        n.nogoWeight = 100000;
+    } else {
+        n.name = s.substring( idx2+1, idx3 );
+        n.nogoWeight = Double.parseDouble( s.substring( idx3 + 1 ) );
+    }
     n.isNogo = true;
     return n;
   }

--- a/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
+++ b/brouter-core/src/main/java/btools/router/OsmNodeNamed.java
@@ -17,7 +17,11 @@ public class OsmNodeNamed extends OsmNode
   @Override
   public String toString()
   {
-    return ilon + "," + ilat + "," + name + "," + nogoWeight;
+    if ( Double.isNaN(nogoWeight ) ) {
+      return ilon + "," + ilat + "," + name;
+    } else {
+      return ilon + "," + ilat + "," + name + "," + nogoWeight;
+    }
   }
 
   public static OsmNodeNamed decodeNogo( String s )
@@ -30,7 +34,7 @@ public class OsmNodeNamed extends OsmNode
     int idx3 = s.indexOf( ',', idx2+1 );
     if ( idx3 == -1) {
         n.name = s.substring( idx2 + 1 );
-        n.nogoWeight = 100000;
+        n.nogoWeight = Double.NaN;
     } else {
         n.name = s.substring( idx2+1, idx3 );
         n.nogoWeight = Double.parseDouble( s.substring( idx3 + 1 ) );

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -143,7 +143,7 @@ abstract class OsmPath implements OsmLinkHolder
 
     boolean recordTransferNodes = detailMode || rc.countTraffic;
 
-    rc.nogomatch = false;
+    rc.nogomatch = null;
 
     // extract the 3 positions of the first section
     int lon0 = origin.originLon;
@@ -425,9 +425,9 @@ abstract class OsmPath implements OsmLinkHolder
             originElement.message = message;
           }
         }
-        if ( rc.nogomatch )
+        if ( rc.nogomatch != null )
         {
-          cost = -1;
+          cost += rc.nogomatch.nogoWeight;
         }
         return;
       }
@@ -460,10 +460,9 @@ abstract class OsmPath implements OsmLinkHolder
     }
 
     // check for nogo-matches (after the *actual* start of segment)
-    if ( rc.nogomatch )
+    if ( rc.nogomatch != null )
     {
-      cost = -1;
-      return;
+      cost += rc.nogomatch.nogoWeight;
     }
 
     // add target-node costs

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -427,7 +427,11 @@ abstract class OsmPath implements OsmLinkHolder
         }
         if ( rc.nogomatch != null )
         {
-          cost += rc.nogomatch.nogoWeight;
+          if ( Double.isNaN(rc.nogomatch.nogoWeight) ) {
+            cost = -1;
+          } else {
+            cost += rc.nogomatch.nogoWeight;
+          }
         }
         return;
       }
@@ -462,7 +466,12 @@ abstract class OsmPath implements OsmLinkHolder
     // check for nogo-matches (after the *actual* start of segment)
     if ( rc.nogomatch != null )
     {
-      cost += rc.nogomatch.nogoWeight;
+      if ( Double.isNaN(rc.nogomatch.nogoWeight) ) {
+        cost = -1;
+        return;
+      } else {
+        cost += rc.nogomatch.nogoWeight;
+      }
     }
 
     // add target-node costs

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -143,7 +143,7 @@ abstract class OsmPath implements OsmLinkHolder
 
     boolean recordTransferNodes = detailMode || rc.countTraffic;
 
-    rc.nogomatch = null;
+    rc.nogoCost = 0.;
 
     // extract the 3 positions of the first section
     int lon0 = origin.originLon;
@@ -425,13 +425,13 @@ abstract class OsmPath implements OsmLinkHolder
             originElement.message = message;
           }
         }
-        if ( rc.nogomatch != null )
+        if ( rc.nogoCost < 0)
         {
-          if ( Double.isNaN(rc.nogomatch.nogoWeight) ) {
-            cost = -1;
-          } else {
-            cost += rc.nogomatch.nogoWeight;
-          }
+          cost = -1;
+        }
+        else
+        {
+          cost += rc.nogoCost;
         }
         return;
       }
@@ -464,14 +464,14 @@ abstract class OsmPath implements OsmLinkHolder
     }
 
     // check for nogo-matches (after the *actual* start of segment)
-    if ( rc.nogomatch != null )
+    if ( rc.nogoCost < 0)
     {
-      if ( Double.isNaN(rc.nogomatch.nogoWeight) ) {
-        cost = -1;
-        return;
-      } else {
-        cost += rc.nogomatch.nogoWeight;
-      }
+      cost = -1;
+      return;
+    }
+    else
+    {
+      cost += rc.nogoCost;
     }
 
     // add target-node costs

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -426,7 +426,7 @@ public final class RoutingContext
 
     double dd = Math.sqrt( (dx10*dx10 + dy10*dy10)*(dx21*dx21 + dy21*dy21) );
     if ( dd == 0. ) { cosangle = 1.; return 0.; }
-    double sinp = (dy10*dy21 - dx10*dx21)/dd;
+    double sinp = (dx10*dy21 - dy10*dx21)/dd;
     double cosp = (dy10*dy21 + dx10*dx21)/dd;
     cosangle = cosp;
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -194,7 +194,7 @@ public final class RoutingContext
   public boolean startDirectionValid;
 
   private double cosangle;
-  public boolean nogomatch = false;
+  public OsmNodeNamed nogomatch = null;
   public boolean isEndpoint = false;
 
   public boolean shortestmatch = false;
@@ -347,7 +347,7 @@ public final class RoutingContext
             if (!(nogo instanceof OsmNogoPolygon)
                 || ((OsmNogoPolygon)nogo).intersects(lon1, lat1, lon2, lat2))
             {
-              nogomatch = true;
+              nogomatch = nogo;
             }
           }
           else
@@ -388,7 +388,7 @@ public final class RoutingContext
             }
             else
             {
-              nogomatch = false;
+              nogomatch = null;
               lon1 = ilonshortest;
               lat1 = ilatshortest;
             }

--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -180,7 +180,6 @@ final class StdPath extends OsmPath
     return 0.;
   }
 
-
   @Override
   public int elevationCorrection( RoutingContext rc )
   {

--- a/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
@@ -29,7 +29,7 @@ public class OsmNodeNamedTest {
     node.ilon = toOsmLon(2.334243);
     node.ilat = toOsmLat(48.824017);
     // Radius
-    node.radius = 30 / 110984.;
+    node.radius = 30;
 
     // Check distance within radius is correctly computed if the segment passes through the center
     lon1 = toOsmLon(2.332559);
@@ -39,9 +39,9 @@ public class OsmNodeNamedTest {
     double totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
     assertEquals(
       "Works for segment aligned with the nogo center",
-      2 * node.radius * 110984.,
+      2 * node.radius,
       node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
-      0.01 * (2 * node.radius * 110984.)
+      0.01 * (2 * node.radius)
     );
 
     // Check distance within radius is correctly computed for a given circle

--- a/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
@@ -1,0 +1,117 @@
+package btools.router;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import btools.util.CheapRulerSingleton;
+
+public class OsmNodeNamedTest {
+  static int toOsmLon(double lon) {
+    return (int)( ( lon + 180. ) / CheapRulerSingleton.ILATLNG_TO_LATLNG + 0.5);
+  }
+
+  static int toOsmLat(double lat) {
+    return (int)( ( lat +  90. ) / CheapRulerSingleton.ILATLNG_TO_LATLNG + 0.5);
+  }
+
+  @Test
+  public void testDistanceWithinRadius() {
+    // Segment ends
+    int lon1, lat1, lon2, lat2;
+    // Circle definition
+    OsmNodeNamed node = new OsmNodeNamed();
+    // Center
+    node.ilon = toOsmLon(2.334243);
+    node.ilat = toOsmLat(48.824017);
+    // Radius
+    node.radius = 30 / 110984.;
+
+    // Check distance within radius is correctly computed if the segment passes through the center
+    lon1 = toOsmLon(2.332559);
+    lat1 = toOsmLat(48.823822);
+    lon2 = toOsmLon(2.335018);
+    lat2 = toOsmLat(48.824105);
+    double totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+    assertEquals(
+      "Works for segment aligned with the nogo center",
+      2 * node.radius * 110984.,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.01 * (2 * node.radius * 110984.)
+    );
+
+    // Check distance within radius is correctly computed for a given circle
+    node.ilon = toOsmLon(2.33438);
+    node.ilat = toOsmLat(48.824275);
+    assertEquals(
+      "Works for a segment with no particular properties",
+      27.5,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.1 * 27.5
+    );
+
+    // Check distance within radius is the same if we reverse start and end point
+    assertEquals(
+      "Works if we switch firs and last point",
+      node.distanceWithinRadius(lon2, lat2, lon1, lat1, totalSegmentLength),
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.01
+    );
+
+    // Check distance within radius is correctly computed if a point is inside the circle
+    lon2 = toOsmLon(2.334495);
+    lat2 = toOsmLat(48.824045);
+    totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+    assertEquals(
+      "Works if last point is within the circle",
+      17,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.1 * 17
+    );
+
+    lon1 = toOsmLon(2.334495);
+    lat1 = toOsmLat(48.824045);
+    lon2 = toOsmLon(2.335018);
+    lat2 = toOsmLat(48.824105);
+    totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+    assertEquals(
+      "Works if first point is within the circle",
+      9,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.1 * 9
+    );
+
+    lon1 = toOsmLon(2.33427);
+    lat1 = toOsmLat(48.82402);
+    lon2 = toOsmLon(2.334587);
+    lat2 = toOsmLat(48.824061);
+    totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+    assertEquals(
+      "Works if both points are within the circle",
+      25,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.1 * 25
+    );
+
+    // Check distance within radius is correctly computed if both points are on
+    // the same side of the center.
+    // Note: the only such case possible is with one point outside and one
+    // point within the circle, as we expect the segment to have a non-empty
+    // intersection with the circle.
+    lon1 = toOsmLon(2.332559);
+    lat1 = toOsmLat(48.823822);
+    lon2 = toOsmLon(2.33431);
+    lat2 = toOsmLat(48.824027);
+    totalSegmentLength = CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+    assertEquals(
+      "Works if both points are on the same side of the circle center",
+      5,
+      node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+      0.1 * 5
+    );
+  }
+}

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -30,8 +30,8 @@ import btools.util.CheapRulerSingleton;
 
 public class OsmNogoPolygonTest {
 
-  static final int offset_x = 11000000;
-  static final int offset_y = 50000000;
+  static final int OFFSET_X = 11000000;
+  static final int OFFSET_Y = 50000000;
 
   static OsmNogoPolygon polygon;
   static OsmNogoPolygon polyline;
@@ -39,11 +39,11 @@ public class OsmNogoPolygonTest {
   static final double[] lons = {  1.0,  1.0,  0.5, 0.5, 1.0, 1.0, -1.1, -1.0 };
   static final double[] lats = { -1.0, -0.1, -0.1, 0.1, 0.1, 1.0,  1.1, -1.0 };
 
-  static int toOsmLon(double lon) {
+  static int toOsmLon(double lon, int offset_x) {
     return (int)( ( lon + 180. ) *1000000. + 0.5)+offset_x; // see ServerHandler.readPosition()
   }
 
-  static int toOsmLat(double lat) {
+  static int toOsmLat(double lat, int offset_y) {
     return (int)( ( lat +  90. ) *1000000. + 0.5)+offset_y;
   }
 
@@ -51,11 +51,11 @@ public class OsmNogoPolygonTest {
   public static void setUp() throws Exception {
     polygon = new OsmNogoPolygon(true);
     for (int i = 0; i<lons.length; i++) {
-      polygon.addVertex(toOsmLon(lons[i]),toOsmLat(lats[i]));
+      polygon.addVertex(toOsmLon(lons[i], OFFSET_X),toOsmLat(lats[i], OFFSET_Y));
     }
     polyline = new OsmNogoPolygon(false);
     for (int i = 0; i<lons.length; i++) {
-      polyline.addVertex(toOsmLon(lons[i]),toOsmLat(lats[i]));
+      polyline.addVertex(toOsmLon(lons[i], OFFSET_X),toOsmLat(lats[i], OFFSET_Y));
     }
   }
 
@@ -72,8 +72,8 @@ public class OsmNogoPolygonTest {
     polygon.calcBoundingCircle();
     double r = polygon.radius;
     for (int i=0; i<lons.length; i++) {
-      double dpx = (toOsmLon(lons[i]) - polygon.ilon) * dlon2m;
-      double dpy = (toOsmLon(lats[i]) - polygon.ilon) * dlat2m;
+      double dpx = (toOsmLon(lons[i], OFFSET_X) - polygon.ilon) * dlon2m;
+      double dpy = (toOsmLat(lats[i], OFFSET_Y) - polygon.ilat) * dlat2m;
       double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
       double diff = r-r1;
       assertTrue("i: "+i+" r("+r+") >= r1("+r1+")", diff >= 0);
@@ -81,8 +81,8 @@ public class OsmNogoPolygonTest {
     polyline.calcBoundingCircle();
     r = polyline.radius;
     for (int i=0; i<lons.length; i++) {
-      double dpx = (toOsmLon(lons[i]) - polyline.ilon) * dlon2m;
-      double dpy = (toOsmLon(lats[i]) - polyline.ilon) * dlat2m;
+      double dpx = (toOsmLon(lons[i], OFFSET_X) - polyline.ilon) * dlon2m;
+      double dpy = (toOsmLat(lats[i], OFFSET_Y) - polyline.ilat) * dlat2m;
       double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
       double diff = r-r1;
       assertTrue("i: "+i+" r("+r+") >= r1("+r1+")", diff >= 0);
@@ -96,7 +96,7 @@ public class OsmNogoPolygonTest {
     boolean[] within = { true, false, false, false, false, true, true, true, true, true, };
 
     for (int i=0; i<plons.length; i++) {
-      assertEquals("("+plons[i]+","+plats[i]+")",within[i],polygon.isWithin(toOsmLon(plons[i]), toOsmLat(plats[i])));
+      assertEquals("("+plons[i]+","+plats[i]+")",within[i],polygon.isWithin(toOsmLon(plons[i], OFFSET_X), toOsmLat(plats[i], OFFSET_Y)));
     }
   }
 
@@ -109,7 +109,7 @@ public class OsmNogoPolygonTest {
     boolean[] within = { false, false, false, true, true, true, false, true, true, true };
 
     for (int i=0; i<p0lons.length; i++) {
-      assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],polygon.intersects(toOsmLon(p0lons[i]), toOsmLat(p0lats[i]), toOsmLon(p1lons[i]), toOsmLat(p1lats[i])));
+      assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],polygon.intersects(toOsmLon(p0lons[i], OFFSET_X), toOsmLat(p0lats[i], OFFSET_Y), toOsmLon(p1lons[i], OFFSET_X), toOsmLat(p1lats[i], OFFSET_Y)));
     }
   }
 
@@ -122,7 +122,7 @@ public class OsmNogoPolygonTest {
     boolean[] within = { false, false, false, true, true, true, false, true, true, false };
 
     for (int i=0; i<p0lons.length; i++) {
-      assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],polyline.intersects(toOsmLon(p0lons[i]), toOsmLat(p0lats[i]), toOsmLon(p1lons[i]), toOsmLat(p1lats[i])));
+      assertEquals("("+p0lons[i]+","+p0lats[i]+")-("+p1lons[i]+","+p1lats[i]+")",within[i],polyline.intersects(toOsmLon(p0lons[i], OFFSET_X), toOsmLat(p0lats[i], OFFSET_Y), toOsmLon(p1lons[i], OFFSET_X), toOsmLat(p1lats[i], OFFSET_Y)));
     }
   }
 
@@ -143,5 +143,58 @@ public class OsmNogoPolygonTest {
     assertFalse(OsmNogoPolygon.isOnLine(15,19, 10,10, 20,30));
     assertFalse(OsmNogoPolygon.isOnLine(0,-10, 10,10, 20,30));
     assertFalse(OsmNogoPolygon.isOnLine(30,50, 10,10, 20,30));
+  }
+
+  @Test
+  public void testDistanceWithinPolygon() {
+      // Testing polygon
+      final double[] lons = { 2.333523, 2.333432, 2.333833, 2.333983, 2.334815, 2.334766, 2.333523 };
+      final double[] lats = { 48.823778, 48.824091, 48.82389, 48.824165, 48.824232, 48.82384, 48.823778 };
+      OsmNogoPolygon polygon = new OsmNogoPolygon(true);
+      for (int i = 0; i < lons.length; i++) {
+          polygon.addVertex(toOsmLon(lons[i], 0), toOsmLat(lats[i], 0));
+      }
+
+      // Check with a segment with a single intersection with the polygon
+      int lon1 = toOsmLon(2.33308732509613, 0);
+      int lat1 = toOsmLat(48.8238790443901, 0);
+      int lon2 = toOsmLon(2.33378201723099, 0);
+      int lat2 = toOsmLat(48.8239585098974, 0);
+      assertEquals(
+        "Should give the correct length for a segment with a single intersection",
+        17.5,
+        polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * 17.5
+      );
+
+      // Check with a segment crossing multiple times the polygon
+      lon2 = toOsmLon(2.33488172292709, 0);
+      lat2 = toOsmLat(48.8240891862353, 0);
+      assertEquals(
+        "Should give the correct length for a segment with multiple intersections",
+        85,
+        polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * 85
+      );
+
+      // Check that it works when a point is within the polygon
+      lon2 = toOsmLon(2.33433187007904, 0);
+      lat2 = toOsmLat(48.8240238480664, 0);
+      assertEquals(
+        "Should give the correct length when last point is within the polygon",
+        50,
+        polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * 50
+      );
+      lon1 = toOsmLon(2.33433187007904, 0);
+      lat1 = toOsmLat(48.8240238480664, 0);
+      lon2 = toOsmLon(2.33488172292709, 0);
+      lat2 = toOsmLat(48.8240891862353, 0);
+      assertEquals(
+        "Should give the correct length when first point is within the polygon",
+        35,
+        polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * 35
+      );
   }
 }

--- a/brouter-core/src/test/java/btools/router/RoutingContextTest.java
+++ b/brouter-core/src/test/java/btools/router/RoutingContextTest.java
@@ -1,0 +1,80 @@
+package btools.router;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import btools.util.CheapRulerSingleton;
+
+public class RoutingContextTest {
+  static int toOsmLon(double lon) {
+    return (int)( ( lon + 180. ) / CheapRulerSingleton.ILATLNG_TO_LATLNG + 0.5);
+  }
+
+  static int toOsmLat(double lat) {
+    return (int)( ( lat +  90. ) / CheapRulerSingleton.ILATLNG_TO_LATLNG + 0.5);
+  }
+
+  @Test
+  public void testCalcAngle() {
+    RoutingContext rc = new RoutingContext();
+    // Segment ends
+    int lon0, lat0, lon1, lat1, lon2, lat2;
+
+    lon0 = toOsmLon(2.317126);
+    lat0 = toOsmLat(48.817927);
+    lon1 = toOsmLon(2.317316);
+    lat1 = toOsmLat(48.817978);
+    lon2 = toOsmLon(2.317471);
+    lat2 = toOsmLat(48.818043);
+    assertEquals(
+      "Works for an angle between -pi/4 and pi/4",
+      10.,
+      rc.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+      0.05 * 10.
+    );
+
+    lon0 = toOsmLon(2.317020662874013);
+    lat0 = toOsmLat(48.81799440182911);
+    lon1 = toOsmLon(2.3169460585876327);
+    lat1 = toOsmLat(48.817812421536644);
+    lon2 = lon0;
+    lat2 = lat0;
+    assertEquals(
+      "Works for an angle between 3*pi/4 and 5*pi/4",
+      180.,
+      rc.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+      0.05 * 180.
+    );
+
+    lon0 = toOsmLon(2.317112);
+    lat0 = toOsmLat(48.817802);
+    lon1 = toOsmLon(2.317632);
+    lat1 = toOsmLat(48.817944);
+    lon2 = toOsmLon(2.317673);
+    lat2 = toOsmLat(48.817799);
+    assertEquals(
+      "Works for an angle between -3*pi/4 and -pi/4",
+      -100.,
+      rc.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+      0.1 * 100.
+    );
+
+    lon0 = toOsmLon(2.317128);
+    lat0 = toOsmLat(48.818072);
+    lon1 = toOsmLon(2.317532);
+    lat1 = toOsmLat(48.818108);
+    lon2 = toOsmLon(2.317497);
+    lat2 = toOsmLat(48.818264);
+    assertEquals(
+      "Works for an angle between pi/4 and 3*pi/4",
+      100.,
+      rc.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+      0.1 * 100.
+    );
+  }
+}

--- a/brouter-mem-router/src/main/java/btools/memrouter/ScheduledRouter.java
+++ b/brouter-mem-router/src/main/java/btools/memrouter/ScheduledRouter.java
@@ -45,7 +45,7 @@ final class ScheduledRouter
 
   private static List<Iternity> trips = new ArrayList<Iternity>();
   private static long oldChecksum = 0;
-  
+
   private String startEndText()
   {
     return (start == null ? "unmatched" : start.getName() ) + "->" + (end == null ? "unmatched" : end.getName() );
@@ -69,11 +69,11 @@ final class ScheduledRouter
 
     // check for identical params
     long[] nogocheck = rc.getNogoChecksums();
-    
+
     long checksum = nogocheck[0] + nogocheck[1] + nogocheck[2];
     checksum += startPos.getILat() + startPos.getILon() + endPos.getILat() + endPos.getILon();
     checksum += rc.localFunction.hashCode();
-    
+
     if ( checksum != oldChecksum )
     {
       trips = _findRoute( startPos, endPos, false );
@@ -86,7 +86,7 @@ final class ScheduledRouter
       if ( linksProcessed + linksReProcessed > 5000000 ) throw new RuntimeException( "5 million links limit reached" );
       else throw new RuntimeException( "no track found! (" + startEndText() + ")" );
     }
-    
+
     if ( alternativeIdx == 0 ) // = result overview
     {
       List<String> details = new ArrayList<String>();
@@ -101,15 +101,15 @@ final class ScheduledRouter
       t.iternity = details;
       return t;
     }
-    
+
     int idx = alternativeIdx > trips.size() ? trips.size()-1 : alternativeIdx-1;
     Iternity iternity = trips.get( idx );
     OsmTrack t = iternity.track;
     t.iternity = iternity.details;
     return t;
-  }    
-    
-    
+  }
+
+
   private List<Iternity> _findRoute( OsmPos startPos, OsmPos endPos, boolean fastStop ) throws Exception
   {
     List<Iternity> iternities = new ArrayList<Iternity>();
@@ -120,7 +120,7 @@ final class ScheduledRouter
     end = graph.matchNodeForPosition( endPos, rc.expctxWay, rc.transitonly );
     if ( end == null )
       throw new IllegalArgumentException( "unmatched end: " + endPos );
-      
+
     time0 = System.currentTimeMillis() + (long) ( rc.starttimeoffset * 60000L );
     long minutes0 = ( time0 + 59999L ) / 60000L;
     time0 = minutes0 * 60000L;
@@ -170,8 +170,8 @@ final class ScheduledRouter
       OffsetSet offsets = trip.offsets.ensureMaxOffset( maxOffset );
       if ( offsets == null )
         continue;
-     */ 
-      
+     */
+
       OffsetSet offsets = trip.offsets;
 
       // check global closure
@@ -240,7 +240,7 @@ System.out.println( "*** added track to result list !**** ");
           }
         }
 System.out.println( "*** finishedOffsets = " + finishedOffsets );
-          
+
       }
       for ( OsmLinkP link = currentNode.getFirstLink(); link != null; link = link.getNext( currentNode ) )
       {
@@ -305,9 +305,9 @@ System.out.println( "*** finishedOffsets = " + finishedOffsets );
     }
 
     // calc distance and check nogos
-    rc.nogomatch = false;
+    rc.nogomatch = null;
     int distance = rc.calcDistance( currentNode.ilon, currentNode.ilat, node.ilon, node.ilat );
-    if ( rc.nogomatch )
+    if ( rc.nogomatch != null )
     {
       return;
     }
@@ -483,7 +483,7 @@ System.out.println( "*** finishedOffsets = " + finishedOffsets );
 
     int distance = 0;
     long departure = 0;
-    
+
     ScheduledTrip itrip = null;
 
     String profile = extractProfile( rc.localFunction );
@@ -496,7 +496,7 @@ System.out.println( "*** finishedOffsets = " + finishedOffsets );
     while (current != null)
     {
       departure = current.departure;
-    
+
       // System.out.println( "trip=" + current );
       OsmNodeP node = current.getTargetNode();
       OsmPathElement pe = OsmPathElement.create( node.ilon, node.ilat, node.selev, null, false );
@@ -569,18 +569,18 @@ System.out.println( "*** finishedOffsets = " + finishedOffsets );
         iternity.details.add( "depart: " + df.format( d0 ) + " " + stationName );
         iternity.details.add( "                    --- " + lineName + " ---" );
         iternity.details.add( "arrive: " + df.format( d1 ) + " " + nextStationName );
-        
+
         if ( !iternity.lines.contains( lineName )  )
         {
           iternity.lines.add( lineName );
-        }    
+        }
       }
     }
 
     iternity.track = track;
     iternity.arrivaltime = time0 + 60000L * offset + trip.arrival;
     iternity.departtime = time0 + 60000L * offset + departure;
-    
+
     return iternity;
   }
 

--- a/brouter-mem-router/src/main/java/btools/memrouter/ScheduledRouter.java
+++ b/brouter-mem-router/src/main/java/btools/memrouter/ScheduledRouter.java
@@ -305,9 +305,9 @@ System.out.println( "*** finishedOffsets = " + finishedOffsets );
     }
 
     // calc distance and check nogos
-    rc.nogomatch = null;
+    rc.nogoCost = 0.;
     int distance = rc.calcDistance( currentNode.ilon, currentNode.ilat, node.ilon, node.ilat );
-    if ( rc.nogomatch != null )
+    if ( Math.abs(rc.nogoCost) > 0.)
     {
       return;
     }

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -222,24 +222,29 @@ public class ServerHandler extends RequestHandler {
     for (int i = 0; i < lonLatRadList.length; i++)
     {
       String[] lonLatRad = lonLatRadList[i].split(",");
-      nogoList.add(readNogo(lonLatRad[0], lonLatRad[1], lonLatRad[2]));
+      String nogoWeight = "100000";
+      if (lonLatRad.length > 3) {
+          nogoWeight = lonLatRad[3];
+      }
+      nogoList.add(readNogo(lonLatRad[0], lonLatRad[1], lonLatRad[2], nogoWeight));
     }
 
     return nogoList;
   }
 
-  private static OsmNodeNamed readNogo( String lon, String lat, String radius )
+  private static OsmNodeNamed readNogo( String lon, String lat, String radius, String nogoWeight )
   {
-    return readNogo(Double.parseDouble( lon ), Double.parseDouble( lat ), Integer.parseInt( radius ) );
+    return readNogo(Double.parseDouble( lon ), Double.parseDouble( lat ), Integer.parseInt( radius ), Double.parseDouble( nogoWeight ));
   }
 
-  private static OsmNodeNamed readNogo( double lon, double lat, int radius )
+  private static OsmNodeNamed readNogo( double lon, double lat, int radius, double nogoWeight )
   {
     OsmNodeNamed n = new OsmNodeNamed();
     n.name = "nogo" + radius;
     n.ilon = (int)( ( lon + 180. ) *1000000. + 0.5);
     n.ilat = (int)( ( lat +  90. ) *1000000. + 0.5);
     n.isNogo = true;
+    n.nogoWeight = nogoWeight;
     return n;
   }
 

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -222,7 +222,7 @@ public class ServerHandler extends RequestHandler {
     for (int i = 0; i < lonLatRadList.length; i++)
     {
       String[] lonLatRad = lonLatRadList[i].split(",");
-      String nogoWeight = "100000";
+      String nogoWeight = "NaN";
       if (lonLatRad.length > 3) {
           nogoWeight = lonLatRad[3];
       }

--- a/brouter-util/src/main/java/btools/util/CheapRulerSingleton.java
+++ b/brouter-util/src/main/java/btools/util/CheapRulerSingleton.java
@@ -33,7 +33,7 @@ public final class CheapRulerSingleton {
   }
 
   private static double[] calcKxKyFromILat(int ilat) {
-    double lat = DEG_TO_RAD*ilat*ILATLNG_TO_LATLNG - 90;
+    double lat = DEG_TO_RAD*(ilat*ILATLNG_TO_LATLNG - 90);
     double cos = Math.cos(lat);
     double cos2 = 2 * cos * cos - 1;
     double cos3 = 2 * cos * cos2 - cos;


### PR DESCRIPTION
Hi,

This PR should allow user to specify custom weights/penalty for each nogo circle. The motivation behind this is that so far the nogos are an all or nothing feature whereas they could potentially offer more control to the user by slightly biasing some areas.

Typically, in France, a lot of cities provide OpenData about road works (a full list of the files I found so far is available at https://framagit.org/phyks/cyclassist/blob/34e0fec0165d3633e1d254f360fcd8c2cdfac78c/scripts/opendata/works.py#L304-389). Some road works might be a complete road closure (nogo as currently implemented) while other might just mean having to deal with some extra pain (only some lanes closed, traffic jam expected etc). The latter ones should be avoided if possible, but not at all cost.

I tried to take care of making it retro-compatible. Please note however that this is my first contact with BRouter code (and Java!) so it might be far from being perfect. If you think this is worth a merge, I'll gladly take any review and fix it to make it mergeable!

The code was tested with a modified version of brouter-web, so it should be working fine.

Thanks!