### PR TITLE
Fix nogo weights with polylines

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -330,9 +330,11 @@ public class OsmNogoPolygon extends OsmNodeNamed
       Point edgePoint1 = points.get(j);
       Point edgePoint2 = points.get(i);
       int intersectsEdge = intersect2D_2Segments(p1, p2, edgePoint1, edgePoint2);
-      if (intersectsEdge == 1)
+
+      if (isClosed && intersectsEdge == 1)
       {
-        // Intersects in a single point
+        // Intersects with a (closed) polygon edge on a single point
+        // Distance is zero when crossing a polyline.
         // Let's find this intersection point
         int xdiffSegment = lon1 - lon2;
         int xdiffEdge = edgePoint1.x - edgePoint2.x;
@@ -364,7 +366,19 @@ public class OsmNogoPolygon extends OsmNodeNamed
       }
       else if (intersectsEdge == 2) {
         // Segment and edge overlaps
-        distance += CheapRulerSingleton.distance(lon1, lat1, lon2, lat2);
+        // FIXME: Could probably be done in a smarter way
+        distance += Math.min(
+          CheapRulerSingleton.distance(p1.x, p1.y, p2.x, p2.y),
+          Math.min(
+            CheapRulerSingleton.distance(edgePoint1.x, edgePoint1.y, edgePoint2.x, edgePoint2.y),
+            Math.min(
+              CheapRulerSingleton.distance(p1.x, p1.y, edgePoint2.x, edgePoint2.y),
+              CheapRulerSingleton.distance(edgePoint1.x, edgePoint1.y, p2.x, p2.y)
+            )
+          )
+        );
+        // FIXME: We could store intersection.
+        previousIntersectionOnSegment = null;
       }
     }
 

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -148,11 +148,15 @@ public class OsmNogoPolygonTest {
   @Test
   public void testDistanceWithinPolygon() {
       // Testing polygon
-      final double[] lons = { 2.333523, 2.333432, 2.333833, 2.333983, 2.334815, 2.334766, 2.333523 };
-      final double[] lats = { 48.823778, 48.824091, 48.82389, 48.824165, 48.824232, 48.82384, 48.823778 };
+      final double[] lons = { 2.333523, 2.333432, 2.333833, 2.333983, 2.334815, 2.334766 };
+      final double[] lats = { 48.823778, 48.824091, 48.82389, 48.824165, 48.824232, 48.82384 };
       OsmNogoPolygon polygon = new OsmNogoPolygon(true);
       for (int i = 0; i < lons.length; i++) {
           polygon.addVertex(toOsmLon(lons[i], 0), toOsmLat(lats[i], 0));
+      }
+      OsmNogoPolygon polyline = new OsmNogoPolygon(false);
+      for (int i = 0; i < lons.length; i++) {
+          polyline.addVertex(toOsmLon(lons[i], 0), toOsmLat(lats[i], 0));
       }
 
       // Check with a segment with a single intersection with the polygon
@@ -195,6 +199,28 @@ public class OsmNogoPolygonTest {
         35,
         polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
         0.05 * 35
+      );
+
+      lon1 = toOsmLon(2.333523, 0);
+      lat1 = toOsmLat(48.823778, 0);
+      lon2 = toOsmLon(2.333432, 0);
+      lat2 = toOsmLat(48.824091, 0);
+      assertEquals(
+        "Should give the correct length if the segment overlaps with an edge of the polygon",
+        CheapRulerSingleton.distance(lon1, lat1, lon2, lat2),
+        polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * CheapRulerSingleton.distance(lon1, lat1, lon2, lat2)
+      );
+
+      lon1 = toOsmLon(2.333523, 0);
+      lat1 = toOsmLat(48.823778, 0);
+      lon2 = toOsmLon(2.3334775, 0);
+      lat2 = toOsmLat(48.8239345, 0);
+      assertEquals(
+        "Should give the correct length if the segment overlaps with a polyline",
+        CheapRulerSingleton.distance(lon1, lat1, lon2, lat2),
+        polyline.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+        0.05 * CheapRulerSingleton.distance(lon1, lat1, lon2, lat2)
       );
   }
 }


### PR DESCRIPTION
I think there was some potential errors for nogo polylines with a cost. This should partially fix it.

I can still think of some edge cases where the distance computation within/across a polygon/polyline could fail (typically when on the edge and then crossing a polygon). These are very particular edge cases though.

The main problem I can think of so far about these edge cases and the polylines is the fact that `intersect2D_2Segments` is making hard check against zero (lines exactly parallel) whereas in practice, there will always be some numerical residue.