### PR TITLE
Add support for nogo polygons / polylines weight in brouter server

### DIFF
--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -271,13 +271,17 @@ public class ServerHandler extends RequestHandler {
         if ( lonLatList.length > 1 )
         {
           OsmNogoPolygon polygon = new OsmNogoPolygon(closed);
-          for (int j = 0; j < lonLatList.length-1;)
+          int j;
+          for (j = 0; j < 2 * (lonLatList.length / 2) - 1;)
           {
             String slon = lonLatList[j++];
             String slat = lonLatList[j++];
             int lon = (int)( ( Double.parseDouble(slon) + 180. ) *1000000. + 0.5);
             int lat = (int)( ( Double.parseDouble(slat) +  90. ) *1000000. + 0.5);
             polygon.addVertex(lon, lat);
+          }
+          if (j < lonLatList.length) {
+            polygon.nogoWeight = Double.parseDouble( lonLatList[j] );
           }
           if ( polygon.points.size() > 0 )
           {


### PR DESCRIPTION
Hi,

After #117, nogo polygons / polylines can have a custom weight. The BRouter-server part of the code was not updated to be able to consume polygons / polylines with a custom weight. This is done in this PR.

The polylines/polygons parameter is now read two by two (for latitude and longitude pairs). If a trailing single value is available, it is considered to be the weight.


This PR also includes a fix for a bug with GeoJSON generation. When no voice hints were emitted, the comma at the end of the `cost:` line was deleted, resulting in an invalid GeoJSON file.

Best,