### PR TITLE
Fix default nogo weight for polygons

### DIFF
--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -280,9 +280,13 @@ public class ServerHandler extends RequestHandler {
             int lat = (int)( ( Double.parseDouble(slat) +  90. ) *1000000. + 0.5);
             polygon.addVertex(lon, lat);
           }
+
+          String nogoWeight = "NaN";
           if (j < lonLatList.length) {
-            polygon.nogoWeight = Double.parseDouble( lonLatList[j] );
+            nogoWeight = lonLatList[j];
           }
+          polygon.nogoWeight = Double.parseDouble( nogoWeight );
+
           if ( polygon.points.size() > 0 )
           {
             polygon.calcBoundingCircle();


### PR DESCRIPTION
Hi,

It seems there was an error with not passing a nogo weight for polygons/polylines nogos in the server. Default value should be `NaN`, to make them true nogos.

Instead, the default value was 0 which means this was simply ignored.

Best,