### PR TITLE
Use track name param if set

### DIFF
--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -191,7 +191,7 @@ public class ServerHandler extends RequestHandler {
 
     if ( format != null )
     {
-      fileName = "brouter." + format;
+      fileName = (params.get( "trackname" ) || "brouter") + "." + format;
     }
 
     return fileName;


### PR DESCRIPTION
This is a follow up of https://github.com/abrensch/brouter/pull/132, eg. when you set add a track name via query param, instead of generating `brouter-<profile>-<alternateidx>.<format>` filename, we should use the query name instead.

cc @Phyks 