### PR TITLE
Content-Disposition filename must be quoted

### DIFF
--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -392,7 +392,7 @@ public class RouteServer extends Thread
     bw.write( "Content-Type: " + mimeType + "; charset=utf-8\n" );
     if ( fileName != null )
     {
-      bw.write( "Content-Disposition: attachment; filename=" + fileName + "\n" );
+      bw.write( "Content-Disposition: attachment; filename=\"" + fileName + "\"\n" );
     }
     bw.write( "Access-Control-Allow-Origin: *\n" );
     if ( headers != null )

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -191,7 +191,7 @@ public class ServerHandler extends RequestHandler {
 
     if ( format != null )
     {
-      fileName = ( params.get( "trackname" ) == null ? "brouter" : params.get( "trackname" ) ) + "." + format;
+      fileName = ( params.get( "trackname" ) == null ? "brouter" : params.get( "trackname" ).replaceAll("[^a-zA-Z0-9 \\._\\-]+", "") ) + "." + format;
     }
 
     return fileName;


### PR DESCRIPTION
In case filename contains spaces or anything non ascii, we have to quote the content disposition header to have it work properly.

Similarly, avoid strange characters in filename.