### PR TITLE
Make it easier to directly run BRouter from source checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+misc/segments4
+misc/customprofiles
 target/
 *.BAK
 .classpath

--- a/README.md
+++ b/README.md
@@ -10,9 +10,22 @@ For more infos see http://brouter.de/brouter
 <a href="https://play.google.com/store/apps/details?id=btools.routingapp" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
 
+
+## Build and Install
+
 Compile with (Java 6!):
 
 > mvn clean install -Dandroid.sdk.path=<your-sdk-path>
+
+To skip building for Android, add ``-pl '!brouter-routing-app'``.
+
+Next, download one or more [data file(s)](http://brouter.de/brouter/segments4/) (rd5) into the ``misc/segments4`` directory.
+
+## Run
+
+On Linux:
+> ./misc/scripts/standalone/server.sh
+
 
 Related Projects
 ================

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Next, download one or more [data file(s)](http://brouter.de/brouter/segments4/) 
 On Linux:
 > ./misc/scripts/standalone/server.sh
 
+On Windows (using Bash):
+> ./misc/scripts/standalone/server.sh
+
+On Windows (using CMD):
+> misc\scripts\standalone\server.cmd
+
 
 Related Projects
 ================

--- a/misc/scripts/standalone/local.sh
+++ b/misc/scripts/standalone/local.sh
@@ -1,10 +1,3 @@
 #!/bin/sh
 
-# BRouter standalone server
-# java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads> [bindaddress]
-
-# maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
-JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300"
-CLASSPATH=../brouter.jar
-
-java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments4 ../profiles2 ../customprofiles 17777 1 localhost
+BINDADDRESS="localhost" "$(dirname "$0")/server.sh"

--- a/misc/scripts/standalone/server.cmd
+++ b/misc/scripts/standalone/server.cmd
@@ -3,8 +3,35 @@
 REM BRouter standalone server
 REM java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads>
 
+pushd %~dp0
+
 REM maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
 set JAVA_OPTS=-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300
-set CLASSPATH=../brouter.jar
 
-java %JAVA_OPTS% -cp %CLASSPATH% btools.server.RouteServer ..\segments4 ..\profiles2 ..\customprofiles 17777 1
+REM First search in locations matching the directory structure as found in the official BRouter zip archive
+set CLASSPATH=../brouter.jar
+set SEGMENTSPATH=..\segments4
+set PROFILESPATH=..\profiles2
+set CUSTOMPROFILESPATH=..\customprofiles
+
+REM Otherwise try to locate files inside the source checkout
+if not exist "%CLASSPATH%" (
+    for /f "tokens=*" %%w in (
+        'where /R ..\..\..\brouter-server\target brouter-server*-jar-with-dependencies.jar'
+    ) do (
+        set CLASSPATH=%%w
+    )
+)
+if not exist "%SEGMENTSPATH%" (
+    set SEGMENTSPATH=..\..\segments4
+)
+if not exist "%PROFILESPATH%" (
+    set PROFILESPATH=..\..\profiles2
+)
+if not exist "%CUSTOMPROFILESPATH%" (
+    set CUSTOMPROFILESPATH=..\..\customprofiles
+)
+
+java %JAVA_OPTS% -cp %CLASSPATH% btools.server.RouteServer "%SEGMENTSPATH%" "%PROFILESPATH%" "%CUSTOMPROFILESPATH%" 17777 1
+
+popd

--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -6,6 +6,26 @@ cd "$(dirname "$0")"
 
 # maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
 JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300"
-CLASSPATH=../brouter.jar
 
-java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments4 ../profiles2 ../customprofiles 17777 1 $BINDADDRESS
+# If paths are unset, first search in locations matching the directory structure
+# as found in the official BRouter zip archive
+CLASSPATH=${CLASSPATH:-"../brouter.jar"}
+SEGMENTSPATH=${SEGMENTSPATH:-"../segments4"}
+PROFILESPATH=${PROFILESPATH:-"../profiles2"}
+CUSTOMPROFILESPATH=${CUSTOMPROFILESPATH:-"../customprofiles"}
+
+# Otherwise try to locate files inside the source checkout
+if [ ! -e "$CLASSPATH" ]; then
+    CLASSPATH="$(ls ../../../brouter-server/target/brouter-server-*jar-with-dependencies.jar | sort --reverse --version-sort | head --lines 1)"
+fi
+if [ ! -e "$SEGMENTSPATH" ]; then
+    SEGMENTSPATH="../../segments4"
+fi
+if [ ! -e "$PROFILESPATH" ]; then
+    PROFILESPATH="../../profiles2"
+fi
+if [ ! -e "$CUSTOMPROFILESPATH" ]; then
+    CUSTOMPROFILESPATH="../../customprofiles"
+fi
+
+java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer "$SEGMENTSPATH" "$PROFILESPATH" "$CUSTOMPROFILESPATH" 17777 1 $BINDADDRESS

--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -2,10 +2,10 @@
 
 cd "$(dirname "$0")"
 # BRouter standalone server
-# java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads>
+# java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads> [bindaddress]
 
 # maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
 JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300"
 CLASSPATH=../brouter.jar
 
-java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments4 ../profiles2 ../customprofiles 17777 1
+java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer ../segments4 ../profiles2 ../customprofiles 17777 1 $BINDADDRESS


### PR DESCRIPTION
- Refactor/merge server.sh and local.sh
- Allow to run server.sh and server.cmd from source directory
- Update README

Test Plan:
- clone repo
- run maven
- drop rd5 into ``misc/segments4``
- launch ``./misc/scripts/standalone/server.sh``

(Note how no further configuration is necessary. In addition, compatibility with the directory structure as found in BRouter's zip archives is kept.)