### PR TITLE
Fix polygon/polyline nogos issues (#154)

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -359,7 +359,11 @@ public final class RoutingContext
             else if (((OsmNogoPolygon)nogo).intersects(lon1, lat1, lon2, lat2))
             {
               // nogo is a polygon, compute distance within the polygon
-              nogoCost = ((OsmNogoPolygon)nogo).distanceWithinPolygon(lon1, lat1, lon2, lat2) * nogo.nogoWeight;
+              if (((OsmNogoPolygon)nogo).isClosed) {
+                nogoCost = ((OsmNogoPolygon)nogo).distanceWithinPolygon(lon1, lat1, lon2, lat2) * nogo.nogoWeight;
+              } else {
+                nogoCost = nogo.nogoWeight;
+              }
             }
           }
           else

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -347,22 +347,30 @@ public final class RoutingContext
           }
           if ( nogo.isNogo )
           {
-            if (Double.isNaN(nogo.nogoWeight))
-            {
-                // Nogo is default nogo (ignore completely)
+            if (!(nogo instanceof OsmNogoPolygon)) {  // nogo is a circle
+              if (Double.isNaN(nogo.nogoWeight)) {
+                // default nogo behaviour (ignore completely)
                 nogoCost = -1;
-            }
-            else if (!(nogo instanceof OsmNogoPolygon)) {
-              // nogo is a circle, compute distance within the circle
-              nogoCost = nogo.distanceWithinRadius(lon1, lat1, lon2, lat2, d) * nogo.nogoWeight;
+              } else {
+                // nogo weight, compute distance within the circle
+                nogoCost = nogo.distanceWithinRadius(lon1, lat1, lon2, lat2, d) * nogo.nogoWeight;
+              }
             }
             else if (((OsmNogoPolygon)nogo).intersects(lon1, lat1, lon2, lat2))
             {
-              // nogo is a polygon, compute distance within the polygon
-              if (((OsmNogoPolygon)nogo).isClosed) {
-                nogoCost = ((OsmNogoPolygon)nogo).distanceWithinPolygon(lon1, lat1, lon2, lat2) * nogo.nogoWeight;
+              // nogo is a polyline/polygon, we have to check there is indeed
+              // an intersection in this case (radius check is not enough).
+              if (Double.isNaN(nogo.nogoWeight)) {
+                // default nogo behaviour (ignore completely)
+                nogoCost = -1;
               } else {
-                nogoCost = nogo.nogoWeight;
+                if (((OsmNogoPolygon)nogo).isClosed) {
+                  // compute distance within the polygon
+                  nogoCost = ((OsmNogoPolygon)nogo).distanceWithinPolygon(lon1, lat1, lon2, lat2) * nogo.nogoWeight;
+                } else {
+                  // for a polyline, just add a constant penalty
+                  nogoCost = nogo.nogoWeight;
+                }
               }
             }
           }


### PR DESCRIPTION
Hi,

Here are two commits to fix #154:

1. First commit changes the way the nogo polyline with a weight works. Past behavior was to have a cost given by `nogoCost * distance_travelled_along_the_line`. However, a polyline will almost never match with the routing linestring, so the resulting cost is actually `0` most of the time. It makes more sense in my opinion to have nogo polylines add a constant penalty whenever they are crossed, to "cut out" streets. I'm very much open to feedback and discussion on this change.

2. The second commit addresses #154. Basically, there was an incorrect handling of the `nogoCost` in the default case (no specific cost given, ignore the nogo area completely), which resulted in polylines and polygons being handled as circles (therefore without any precise check of the geometry and the intersection).

Best,