### PR TITLE
Add new lookups

### DIFF
--- a/misc/profiles2/car-eco-suspect_scan.brf
+++ b/misc/profiles2/car-eco-suspect_scan.brf
@@ -32,6 +32,8 @@ assign initialcost switch route=ferry 20000 0
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign caraccess
        switch motorcar=
               switch motor_vehicle=
@@ -44,7 +46,7 @@ assign caraccess
                                    switch highway=tertiary|tertiary_link    1
                                    switch highway=unclassified              1
                                    switch route=ferry                       1
-                                   switch highway=residential|living_street 1
+                                   switch isresidentialorliving              1
                                    switch highway=service                   1
                                    0
                                    access=yes|permissive|designated|destination
@@ -104,7 +106,7 @@ assign maxspeed_implicit =
   switch highway=unclassified               50
   switch route=ferry                        10
   switch highway=bridleway                  10
-  switch highway=residential|living_street  30
+  switch isresidentialorliving              30
   switch highway=service                    30
   switch highway=track|road|path switch tracktype=grade1 30 5
   0
@@ -148,7 +150,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=track                     ) then if tracktype=grade1 then 4 else 2
   else if ( highway=bridleway|road            ) then  2
@@ -165,7 +167,7 @@ assign costfactor = if equal maxspeed 0
 assign isgoodoneway = if reversedirection=yes then oneway=-1
                       else if oneway= then implicitoneway else oneway=yes|true|1
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if or isresidentialorliving highway=service then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -176,7 +178,7 @@ assign classifiermask add          isbadoneway
                       add multiply isroundabout   4
                       add multiply islinktype     8
                       add multiply isgoodforcars 16
-                          multiply highway=residential|living_street 32
+                          multiply isresidentialorliving 32
 
 
 ---context:node  # following code refers to node tags

--- a/misc/profiles2/car-eco.brf
+++ b/misc/profiles2/car-eco.brf
@@ -36,6 +36,8 @@ assign classifier_ferry       = 2
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign caraccess
        switch motorcar=
               switch motor_vehicle=
@@ -48,7 +50,7 @@ assign caraccess
                                    switch highway=tertiary|tertiary_link    1
                                    switch highway=unclassified              1
                                    switch route=ferry                       1
-                                   switch highway=residential|living_street 1
+                                   switch isresidentialorliving             1
                                    switch highway=service                   1
                                    0
                                    access=yes|permissive|designated|destination
@@ -111,7 +113,7 @@ assign maxspeed_implicit =
   switch highway=unclassified               50
   switch route=ferry                        10
   switch highway=bridleway                  10
-  switch highway=residential|living_street  30
+  switch isresidentialorliving              30
   switch highway=service                    30
   switch highway=track|road|path switch tracktype=grade1 30 5
   0
@@ -197,7 +199,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving          ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=track                     ) then if tracktype=grade1 then 4 else 2
   else if ( highway=bridleway|road            ) then  2
@@ -209,7 +211,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
                       else if oneway= then junction=roundabout else oneway=yes|true|1
 assign isroundabout = junction=roundabout
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if or isresidentialorliving highway=service then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -220,7 +222,7 @@ assign classifiermask add          isbadoneway
                       add multiply isroundabout   4
                       add multiply islinktype     8
                       add multiply isgoodforcars 16
-                      add multiply highway=residential|living_street 32
+                      add multiply isresidentialorliving 32
                           multiply caraccess_destination 64
 
 ---context:node  # following code refers to node tags

--- a/misc/profiles2/car-fast.brf
+++ b/misc/profiles2/car-fast.brf
@@ -36,6 +36,8 @@ assign classifier_ferry       = 2
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign caraccess
        switch motorcar=
               switch motor_vehicle=
@@ -48,7 +50,7 @@ assign caraccess
                                    switch highway=tertiary|tertiary_link    1
                                    switch highway=unclassified              1
                                    switch route=ferry                       1
-                                   switch highway=residential|living_street 1
+                                   switch isresidentialorliving             1
                                    switch highway=service                   1
                                    0
                                    access=yes|permissive|designated|destination
@@ -111,7 +113,7 @@ assign maxspeed_implicit =
   switch highway=unclassified               50
   switch route=ferry                        10
   switch highway=bridleway                  10
-  switch highway=residential|living_street  30
+  switch isresidentialorliving              30
   switch highway=service                    30
   switch highway=track|road|path switch tracktype=grade1 30 5
   0
@@ -197,7 +199,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=track                     ) then if tracktype=grade1 then 4 else 2
   else if ( highway=bridleway|road            ) then  2
@@ -209,7 +211,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
                       else if oneway= then junction=roundabout else oneway=yes|true|1
 assign isroundabout = junction=roundabout
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if or isresidentialorliving highway=service then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -220,7 +222,7 @@ assign classifiermask add          isbadoneway
                       add multiply isroundabout   4
                       add multiply islinktype     8
                       add multiply isgoodforcars 16
-                      add multiply highway=residential|living_street 32
+                      add multiply isresidentialorliving 32
                           multiply caraccess_destination 64
 
 ---context:node  # following code refers to node tags

--- a/misc/profiles2/car-traffic_analysis.brf
+++ b/misc/profiles2/car-traffic_analysis.brf
@@ -30,6 +30,8 @@ assign initialcost switch route=ferry 20000 0
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign caraccess
        switch motorcar=
               switch motor_vehicle=
@@ -42,7 +44,7 @@ assign caraccess
                                    switch or highway=tertiary highway=tertiary_link    1
                                    switch    highway=unclassified                      1
                                    switch    route=ferry                               1
-                                   switch or highway=residential highway=living_street 1
+                                   switch    isresidentialorliving                     1
                                    switch    highway=service                           1
                                    0
                                    or access=yes or access=permissive or access=designated access=destination
@@ -82,7 +84,7 @@ assign costfactor
  switch    highway=unclassified                      2.5
  switch    route=ferry                               5.67
  switch    highway=bridleway                         5
- switch or highway=residential highway=living_street 3.5
+ switch    isresidentialorliving 3.5
  switch    highway=service                           3.5
  switch or highway=track or highway=road highway=path
   switch tracktype=grade1 5
@@ -91,12 +93,12 @@ assign costfactor
  10000
 
 assign trafficsourcedensity =
-   if highway=residential|living_street then 1
+   if isresidentialorliving then 1
    else if and maxspeed=30|50 highway=tertiary|secondary|primary then 1
    else 0
 
 assign istrafficbackbone
-  if greater costfactor 9999 then false 
+  if greater costfactor 9999 then false
   else if highway=motorway|motorway_link then true
   else false
 

--- a/misc/profiles2/car-vario.brf
+++ b/misc/profiles2/car-vario.brf
@@ -36,6 +36,8 @@ assign classifier_ferry       = 2
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign caraccess
        switch motorcar=
               switch motor_vehicle=
@@ -48,7 +50,7 @@ assign caraccess
                                    switch highway=tertiary|tertiary_link    1
                                    switch highway=unclassified              1
                                    switch route=ferry                       1
-                                   switch highway=residential|living_street 1
+                                   switch isresidentialorliving             1
                                    switch highway=service                   1
                                    0
                                    access=yes|permissive|designated|destination
@@ -111,7 +113,7 @@ assign maxspeed_implicit =
   switch highway=unclassified               50
   switch route=ferry                        10
   switch highway=bridleway                  10
-  switch highway=residential|living_street  30
+  switch isresidentialorliving              30
   switch highway=service                    30
   switch highway=track|road|path switch tracktype=grade1 30 5
   0
@@ -197,7 +199,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=track                     ) then if tracktype=grade1 then 4 else 2
   else if ( highway=bridleway|road            ) then  2
@@ -209,7 +211,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
                       else if oneway= then junction=roundabout else oneway=yes|true|1
 assign isroundabout = junction=roundabout
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -220,7 +222,7 @@ assign classifiermask add          isbadoneway
                       add multiply isroundabout   4
                       add multiply islinktype     8
                       add multiply isgoodforcars 16
-                      add multiply highway=residential|living_street 32
+                      add multiply isresidentialorliving 32
                           multiply caraccess_destination 64
 
 ---context:node  # following code refers to node tags

--- a/misc/profiles2/fastbike-asia-pacific.brf
+++ b/misc/profiles2/fastbike-asia-pacific.brf
@@ -63,11 +63,13 @@ assign defaultaccess =
 assign bikeaccess
        or any_cycleroute
           switch bicycle=
-                 switch vehicle=
-                        defaultaccess
-                        switch or vehicle=private vehicle=no
-                               0
-                               1
+                 switch bicycle_road=yes
+                    1
+                    switch vehicle=
+                           defaultaccess
+                           switch or vehicle=private vehicle=no
+                                  0
+                                  1
                  not or bicycle=private or bicycle=no bicycle=dismount
 
 #
@@ -145,7 +147,7 @@ assign costfactor
    switch tracktype=grade3 10.0
    switch tracktype=grade4 20.0
    switch tracktype=grade5 30.0
-   switch bicycle=designated 2.0
+   switch or bicycle=designated bicycle_road=yes 2.0
    switch ispaved 2.0 100.0
    10.0
 
@@ -153,25 +155,25 @@ assign costfactor
 
 assign priorityclassifier =
 
-  if      ( highway=motorway                  ) then  30
-  else if ( highway=motorway_link             ) then  29
-  else if ( highway=trunk                     ) then  28
-  else if ( highway=trunk_link                ) then  27
-  else if ( highway=primary                   ) then  26
-  else if ( highway=primary_link              ) then  25
-  else if ( highway=secondary                 ) then  24
-  else if ( highway=secondary_link            ) then  23
-  else if ( highway=tertiary                  ) then  22
-  else if ( highway=tertiary_link             ) then  21
-  else if ( highway=unclassified              ) then  20
-  else if ( isresidentialorliving ) then  6
-  else if ( highway=service                   ) then  6
-  else if ( highway=cycleway                  ) then  6
-  else if ( bicycle=designated                ) then  6
-  else if ( highway=track                     ) then if tracktype=grade1 then 6 else 4
-  else if ( highway=bridleway|road|path|footway ) then  4
-  else if ( highway=steps                     ) then  2
-  else if ( highway=pedestrian                ) then  2
+  if      ( highway=motorway                       ) then  30
+  else if ( highway=motorway_link                  ) then  29
+  else if ( highway=trunk                          ) then  28
+  else if ( highway=trunk_link                     ) then  27
+  else if ( highway=primary                        ) then  26
+  else if ( highway=primary_link                   ) then  25
+  else if ( highway=secondary                      ) then  24
+  else if ( highway=secondary_link                 ) then  23
+  else if ( highway=tertiary                       ) then  22
+  else if ( highway=tertiary_link                  ) then  21
+  else if ( highway=unclassified                   ) then  20
+  else if ( isresidentialorliving                  ) then  6
+  else if ( highway=service                        ) then  6
+  else if ( highway=cycleway                       ) then  6
+  else if ( or bicycle=designated bicycle_road=yes ) then  6
+  else if ( highway=track                          ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway    ) then  4
+  else if ( highway=steps                          ) then  2
+  else if ( highway=pedestrian                     ) then  2
   else 0
 
 

--- a/misc/profiles2/fastbike-asia-pacific.brf
+++ b/misc/profiles2/fastbike-asia-pacific.brf
@@ -116,6 +116,8 @@ assign onewaypenalty =
        )
        else 0.0
 
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign costfactor
 
   switch and highway= not route=ferry  10000
@@ -135,7 +137,7 @@ assign costfactor
   switch    route=ferry                               5.67
   switch    highway=bridleway                         5
   switch    highway=cycleway                          1.3
-  switch or highway=residential highway=living_street switch isunpaved 10 1.2
+  switch    isresidentialorliving switch isunpaved 10 1.2
   switch    highway=service                           switch isunpaved 10 1.2
   switch or highway=track or highway=road or highway=path highway=footway
    switch tracktype=grade1 switch isunpaved 3 1.2
@@ -162,7 +164,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
@@ -181,7 +183,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -216,7 +218,7 @@ assign footaccess
 
 assign initialcost
        switch bikeaccess
-              0 
+              0
               switch footaccess
                      300
                      1000000

--- a/misc/profiles2/fastbike-lowtraffic.brf
+++ b/misc/profiles2/fastbike-lowtraffic.brf
@@ -48,7 +48,8 @@ assign bikeaccess =
        if any_cycleroute then true
        else if bicycle= then
        (
-         if vehicle= then
+         if bicycle_road=yes then true
+         else if vehicle= then
          (
            if access= then not or motorroad=yes highway=footway
            else if access=private|no then false
@@ -169,7 +170,7 @@ assign costfactor
    switch tracktype=grade3 10.0
    switch tracktype=grade4 20.0
    switch tracktype=grade5 30.0
-   switch bicycle=designated 1.3
+   switch or bicycle=designated bicycle_road=yes 1.3
    switch ispaved 2.0 100.0
    10.0
 
@@ -177,25 +178,25 @@ assign costfactor
 
 assign priorityclassifier =
 
-  if      ( highway=motorway                  ) then  30
-  else if ( highway=motorway_link             ) then  29
-  else if ( highway=trunk                     ) then  28
-  else if ( highway=trunk_link                ) then  27
-  else if ( highway=primary                   ) then  26
-  else if ( highway=primary_link              ) then  25
-  else if ( highway=secondary                 ) then  24
-  else if ( highway=secondary_link            ) then  23
-  else if ( highway=tertiary                  ) then  22
-  else if ( highway=tertiary_link             ) then  21
-  else if ( highway=unclassified              ) then  20
-  else if ( isresidentialorliving ) then  6
-  else if ( highway=service                   ) then  6
-  else if ( highway=cycleway                  ) then  6
-  else if ( bicycle=designated                ) then  6
-  else if ( highway=track                     ) then if tracktype=grade1 then 6 else 4
-  else if ( highway=bridleway|road|path|footway ) then  4
-  else if ( highway=steps                     ) then  2
-  else if ( highway=pedestrian                ) then  2
+  if      ( highway=motorway                       ) then  30
+  else if ( highway=motorway_link                  ) then  29
+  else if ( highway=trunk                          ) then  28
+  else if ( highway=trunk_link                     ) then  27
+  else if ( highway=primary                        ) then  26
+  else if ( highway=primary_link                   ) then  25
+  else if ( highway=secondary                      ) then  24
+  else if ( highway=secondary_link                 ) then  23
+  else if ( highway=tertiary                       ) then  22
+  else if ( highway=tertiary_link                  ) then  21
+  else if ( highway=unclassified                   ) then  20
+  else if ( isresidentialorliving                  ) then  6
+  else if ( highway=service                        ) then  6
+  else if ( highway=cycleway                       ) then  6
+  else if ( or bicycle=designated bicycle_road=yes ) then  6
+  else if ( highway=track                          ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway    ) then  4
+  else if ( highway=steps                          ) then  2
+  else if ( highway=pedestrian                     ) then  2
   else 0
 
 

--- a/misc/profiles2/fastbike-lowtraffic.brf
+++ b/misc/profiles2/fastbike-lowtraffic.brf
@@ -4,7 +4,7 @@
 # to fallback to this one.
 #
 # Structure is similar to trekking.brf, see this for documenation.
-# 
+#
 
 ---context:global   # following code refers to global config
 
@@ -114,7 +114,7 @@ assign trafficpenalty0 =
     (
       if      estimated_traffic_class=4 then 0.2
       else if estimated_traffic_class=5 then 0.4
-      else if estimated_traffic_class=6|7 then 0.6 
+      else if estimated_traffic_class=6|7 then 0.6
       else 0
     )
     else if highway=secondary|secondary_link then
@@ -139,6 +139,8 @@ assign trafficpenalty =
   if hascycleway then min 0.3 trafficpenalty0
   else trafficpenalty0
 
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign costfactor
 
   switch and highway= not route=ferry  10000
@@ -159,7 +161,7 @@ assign costfactor
   switch    route=ferry                               5.67
   switch    highway=bridleway                         5
   switch    highway=cycleway|footway                  1.3
-  switch or highway=residential highway=living_street switch isunpaved 10 1.2
+  switch    isresidentialorliving switch isunpaved 10 1.2
   switch    highway=service                           switch isunpaved 10 1.2
   switch or highway=track or highway=road or highway=path highway=footway
    switch tracktype=grade1 switch isunpaved 3 1.2
@@ -186,7 +188,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
@@ -205,7 +207,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -240,7 +242,7 @@ assign footaccess
 
 assign initialcost
        switch bikeaccess
-              0 
+              0
               switch footaccess
                      300
                      1000000

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -4,7 +4,7 @@
 # to fallback to this one.
 #
 # Structure is similar to trekking.brf, see this for documenation.
-# 
+#
 
 ---context:global   # following code refers to global config
 
@@ -111,6 +111,8 @@ assign onewaypenalty =
        )
        else 0.0
 
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign costfactor
 
   switch and highway= not route=ferry  10000
@@ -130,7 +132,7 @@ assign costfactor
   switch    route=ferry                               5.67
   switch    highway=bridleway                         5
   switch    highway=cycleway                          1.3
-  switch or highway=residential highway=living_street switch isunpaved 10 1.2
+  switch    isresidentialorliving                     switch isunpaved 10 1.2
   switch    highway=service                           switch isunpaved 10 1.2
   switch or highway=track or highway=road or highway=path highway=footway
    switch tracktype=grade1 switch isunpaved 3 1.2
@@ -157,7 +159,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
@@ -176,7 +178,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 
@@ -220,7 +222,7 @@ assign footaccess
 
 assign initialcost
        switch bikeaccess
-              0 
+              0
               switch footaccess
                      300
                      1000000

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -58,11 +58,13 @@ assign defaultaccess
 assign bikeaccess
        or any_cycleroute
           switch bicycle=
-                 switch vehicle=
-                        defaultaccess
-                        switch or vehicle=private vehicle=no
-                               0
-                               1
+                 switch bicycle_road=yes
+                    1
+                    switch vehicle=
+                           defaultaccess
+                           switch or vehicle=private vehicle=no
+                                  0
+                                  1
                  not or bicycle=private or bicycle=no bicycle=dismount
 
 #
@@ -140,7 +142,7 @@ assign costfactor
    switch tracktype=grade3 10.0
    switch tracktype=grade4 20.0
    switch tracktype=grade5 30.0
-   switch bicycle=designated 2.0
+   switch or bicycle=designated bicycle_road=yes 2.0
    switch ispaved 2.0 100.0
    10.0
 
@@ -148,25 +150,25 @@ assign costfactor
 
 assign priorityclassifier =
 
-  if      ( highway=motorway                  ) then  30
-  else if ( highway=motorway_link             ) then  29
-  else if ( highway=trunk                     ) then  28
-  else if ( highway=trunk_link                ) then  27
-  else if ( highway=primary                   ) then  26
-  else if ( highway=primary_link              ) then  25
-  else if ( highway=secondary                 ) then  24
-  else if ( highway=secondary_link            ) then  23
-  else if ( highway=tertiary                  ) then  22
-  else if ( highway=tertiary_link             ) then  21
-  else if ( highway=unclassified              ) then  20
-  else if ( isresidentialorliving ) then  6
-  else if ( highway=service                   ) then  6
-  else if ( highway=cycleway                  ) then  6
-  else if ( bicycle=designated                ) then  6
-  else if ( highway=track                     ) then if tracktype=grade1 then 6 else 4
-  else if ( highway=bridleway|road|path|footway ) then  4
-  else if ( highway=steps                     ) then  2
-  else if ( highway=pedestrian                ) then  2
+  if      ( highway=motorway                         ) then  30
+  else if ( highway=motorway_link                    ) then  29
+  else if ( highway=trunk                            ) then  28
+  else if ( highway=trunk_link                       ) then  27
+  else if ( highway=primary                          ) then  26
+  else if ( highway=primary_link                     ) then  25
+  else if ( highway=secondary                        ) then  24
+  else if ( highway=secondary_link                   ) then  23
+  else if ( highway=tertiary                         ) then  22
+  else if ( highway=tertiary_link                    ) then  21
+  else if ( highway=unclassified                     ) then  20
+  else if ( isresidentialorliving                    ) then  6
+  else if ( highway=service                          ) then  6
+  else if ( highway=cycleway                         ) then  6
+  else if ( or bicycle=designated bicycle_road=yes   ) then  6
+  else if ( highway=track                            ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway      ) then  4
+  else if ( highway=steps                            ) then  2
+  else if ( highway=pedestrian                       ) then  2
   else 0
 
 

--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -887,3 +887,6 @@ traffic_calming;0000000186 dip
 
 ford;0000037927 yes
 ford;0000000310 stepping_stones
+
+direction;0000274642 forward
+direction;0000249637 backward

--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -1,5 +1,5 @@
 ---lookupversion:10
----minorversion:11
+---minorversion:12
 
 ---context:way
 
@@ -635,6 +635,10 @@ embedded_rails;0000000007 yes
 embedded_rails;0000000003 rail
 
 living_street;0000000404 yes
+
+sidewalk:bicycle;0000000439 yes designated
+sidewalk:left:bicycle;0000001722 yes designated
+sidewalk:right:bicycle;0000002667 yes designated
 
 ---context:node
 

--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -634,6 +634,8 @@ embedded_rails;0000000928 tram
 embedded_rails;0000000007 yes
 embedded_rails;0000000003 rail
 
+living_street;0000000404 yes
+
 ---context:node
 
 highway;0001314954 bus_stop

--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -640,6 +640,8 @@ sidewalk:bicycle;0000000439 yes designated
 sidewalk:left:bicycle;0000001722 yes designated
 sidewalk:right:bicycle;0000002667 yes designated
 
+bicycle_road;0000006521 yes designated
+
 ---context:node
 
 highway;0001314954 bus_stop

--- a/misc/profiles2/moped.brf
+++ b/misc/profiles2/moped.brf
@@ -29,6 +29,8 @@ assign initialcost switch route=ferry 20000 0
 #
 # calculate logical car access
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign motorverhicleaccess
               switch motor_vehicle=
                      switch vehicle=
@@ -39,7 +41,7 @@ assign motorverhicleaccess
                                    switch or highway=tertiary highway=tertiary_link    1
                                    switch    highway=unclassified                      1
                                    switch    route=ferry                               1
-                                   switch or highway=residential highway=living_street 1
+                                   switch    isresidentialorliving                     1
                                    switch    highway=service                           1
                                    0
                                    or access=yes or access=designated access=destination
@@ -90,7 +92,7 @@ assign costfactor
  switch    highway=unclassified                      1.2
  switch    route=ferry                               5.67
  switch    highway=bridleway                         5
- switch or highway=residential highway=living_street 2
+ switch    isresidentialorliving                     2
  switch    highway=service                           2
  switch or highway=track or highway=road highway=path
   switch tracktype=grade1 5
@@ -113,7 +115,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=track                     ) then if tracktype=grade1 then 4 else 2
   else if ( highway=bridleway|road            ) then  2
@@ -126,7 +128,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
                       else if oneway= then junction=roundabout else oneway=yes|true|1
 assign isroundabout = junction=roundabout
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 

--- a/misc/profiles2/shortest.brf
+++ b/misc/profiles2/shortest.brf
@@ -36,11 +36,13 @@ assign defaultaccess
 assign bikeaccess
        or any_cycleroute
           switch bicycle=
-                 switch vehicle=
-                        defaultaccess
-                        switch or vehicle=private vehicle=no
-                               0
-                               1
+                 switch bicycle_road=yes
+                    1
+                    switch vehicle=
+                            defaultaccess
+                            switch or vehicle=private vehicle=no
+                                0
+                                1
                  not or bicycle=private or bicycle=no bicycle=dismount
 
 #
@@ -71,25 +73,25 @@ assign isresidentialorliving = or highway=residential|living_street living_stree
 
 assign priorityclassifier =
 
-  if      ( highway=motorway                  ) then  30
-  else if ( highway=motorway_link             ) then  29
-  else if ( highway=trunk                     ) then  28
-  else if ( highway=trunk_link                ) then  27
-  else if ( highway=primary                   ) then  26
-  else if ( highway=primary_link              ) then  25
-  else if ( highway=secondary                 ) then  24
-  else if ( highway=secondary_link            ) then  23
-  else if ( highway=tertiary                  ) then  22
-  else if ( highway=tertiary_link             ) then  21
-  else if ( highway=unclassified              ) then  20
-  else if ( isresidentialorliving             ) then  6
-  else if ( highway=service                   ) then  6
-  else if ( highway=cycleway                  ) then  6
-  else if ( bicycle=designated                ) then  6
-  else if ( highway=track                     ) then if tracktype=grade1 then 6 else 4
-  else if ( highway=bridleway|road|path|footway ) then  4
-  else if ( highway=steps                     ) then  2
-  else if ( highway=pedestrian                ) then  2
+  if      ( highway=motorway                       ) then  30
+  else if ( highway=motorway_link                  ) then  29
+  else if ( highway=trunk                          ) then  28
+  else if ( highway=trunk_link                     ) then  27
+  else if ( highway=primary                        ) then  26
+  else if ( highway=primary_link                   ) then  25
+  else if ( highway=secondary                      ) then  24
+  else if ( highway=secondary_link                 ) then  23
+  else if ( highway=tertiary                       ) then  22
+  else if ( highway=tertiary_link                  ) then  21
+  else if ( highway=unclassified                   ) then  20
+  else if ( isresidentialorliving                  ) then  6
+  else if ( highway=service                        ) then  6
+  else if ( highway=cycleway                       ) then  6
+  else if ( or bicycle=designated bicycle_road=yes ) then  6
+  else if ( highway=track                          ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway    ) then  4
+  else if ( highway=steps                          ) then  2
+  else if ( highway=pedestrian                     ) then  2
   else 0
 
 # some more classifying bits used for voice hint generation...

--- a/misc/profiles2/shortest.brf
+++ b/misc/profiles2/shortest.brf
@@ -67,6 +67,8 @@ assign costfactor
 
 # way priorities used for voice hint generation
 
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+
 assign priorityclassifier =
 
   if      ( highway=motorway                  ) then  30
@@ -80,7 +82,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
@@ -95,7 +97,7 @@ assign priorityclassifier =
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -157,6 +157,7 @@ assign onewaypenalty =
 # must be >=1 and it's supposed to be close to 1 for
 # the type of way the routing profile is searching for
 #
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
 assign costfactor
 
   #
@@ -185,7 +186,7 @@ assign costfactor
   #
   # steps and ferries are special. Note this is handled
   # before the cycleroute-switch, to be able
-  # to really exlude them be setting cost to infinity 
+  # to really exlude them be setting cost to infinity
   #
   if ( highway=steps ) then ( if allow_steps then 40 else 10000 )
   else if ( route=ferry   ) then ( if allow_ferries then 5.67 else 10000 )
@@ -203,7 +204,7 @@ assign costfactor
   if      ( highway=pedestrian                ) then 3
   else if ( highway=bridleway                 ) then 5
   else if ( highway=cycleway                  ) then 1
-  else if ( highway=residential|living_street ) then ( if isunpaved then 1.5 else 1.1 )
+  else if ( isresidentialorliving             ) then ( if isunpaved then 1.5 else 1.1 )
   else if ( highway=service                   ) then ( if isunpaved then 1.6 else 1.3 )
 
   #
@@ -256,7 +257,7 @@ assign priorityclassifier =
   else if ( highway=tertiary                  ) then  22
   else if ( highway=tertiary_link             ) then  21
   else if ( highway=unclassified              ) then  20
-  else if ( highway=residential|living_street ) then  6
+  else if ( isresidentialorliving             ) then  6
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
@@ -274,7 +275,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-                  else if highway=residential|living_street|service then true
+                  else if ( or isresidentialorliving highway=service ) then true
                   else if ( and highway=track tracktype=grade1 ) then true
                   else false
 

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -52,7 +52,7 @@ assign is_ldcr =
      if ignore_cycleroutes then false
      else any_cycleroute
 
-assign isbike = or bicycle=yes or or bicycle=permissive bicycle=designated lcn=yes
+assign isbike = or bicycle_road=yes or bicycle=yes or or bicycle=permissive bicycle=designated lcn=yes
 assign ispaved = surface=paved|asphalt|concrete|paving_stones
 assign isunpaved = not or surface= or ispaved surface=fine_gravel|cobblestone
 assign probablyGood = or ispaved and isbike not isunpaved
@@ -102,7 +102,8 @@ assign bikeaccess =
        if any_cycleroute then true
        else if bicycle= then
        (
-         if vehicle= then defaultaccess
+         if bicycle_road=yes then true
+         else if vehicle= then defaultaccess
          else not vehicle=private|no
        )
        else not bicycle=private|no|dismount
@@ -246,25 +247,25 @@ assign costfactor
 
 assign priorityclassifier =
 
-  if      ( highway=motorway                  ) then  30
-  else if ( highway=motorway_link             ) then  29
-  else if ( highway=trunk                     ) then  28
-  else if ( highway=trunk_link                ) then  27
-  else if ( highway=primary                   ) then  26
-  else if ( highway=primary_link              ) then  25
-  else if ( highway=secondary                 ) then  24
-  else if ( highway=secondary_link            ) then  23
-  else if ( highway=tertiary                  ) then  22
-  else if ( highway=tertiary_link             ) then  21
-  else if ( highway=unclassified              ) then  20
-  else if ( isresidentialorliving             ) then  6
-  else if ( highway=service                   ) then  6
-  else if ( highway=cycleway                  ) then  6
-  else if ( bicycle=designated                ) then  6
-  else if ( highway=track                     ) then if tracktype=grade1 then 6 else 4
-  else if ( highway=bridleway|road|path|footway ) then  4
-  else if ( highway=steps                     ) then  2
-  else if ( highway=pedestrian                ) then  2
+  if      ( highway=motorway                          ) then  30
+  else if ( highway=motorway_link                     ) then  29
+  else if ( highway=trunk                             ) then  28
+  else if ( highway=trunk_link                        ) then  27
+  else if ( highway=primary                           ) then  26
+  else if ( highway=primary_link                      ) then  25
+  else if ( highway=secondary                         ) then  24
+  else if ( highway=secondary_link                    ) then  23
+  else if ( highway=tertiary                          ) then  22
+  else if ( highway=tertiary_link                     ) then  21
+  else if ( highway=unclassified                      ) then  20
+  else if ( isresidentialorliving                     ) then  6
+  else if ( highway=service                           ) then  6
+  else if ( highway=cycleway                          ) then  6
+  else if ( or bicycle=designated bicycle_road=yes    ) then  6
+  else if ( highway=track                             ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway       ) then  4
+  else if ( highway=steps                             ) then  2
+  else if ( highway=pedestrian                        ) then  2
   else 0
 
 # some more classifying bits used for voice hint generation...

--- a/misc/profiles2/vm-forum-liegerad-schnell.brf
+++ b/misc/profiles2/vm-forum-liegerad-schnell.brf
@@ -15,7 +15,7 @@ assign low_memory_cutoff = false # mit true werden Wege mit hohen Kosten aus der
 
 assign turnInstructionMode 1 #Ausgabe von Abiegehinweise 0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style
 assign turnInstructionCatchingRange 20 # innerhalb dieser Strecke werden mehrere Abiegehinweise zu einem zusammengefasst und die Abiegewinkel werden besser an die generelle Richtung angenähert
-assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert 
+assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert
 
 assign downhillcost 80 # Kosten für die Höhenmeter bergab
 assign downhillcutoff 0.1 # Gefälle unter diesem Wert in Prozent werden nicht gewertet
@@ -55,7 +55,7 @@ assign cycleway
 assign footway
  or highway=footway and highway=path foot=designated|yes
 
-assign turncost 
+assign turncost
  switch junction=roundabout 0
  150 # Kosten die für eine 90 Grad Abbiegung berechnet werden. Für kleinere Winkel werden sie mit turncost*cos(Winkel) berechnet, bei Kreisverkehr keine weitere Kosten
 
@@ -157,7 +157,7 @@ assign maxspeed_backward
   switch maxspeed:backward=rural 100
   0
 
-assign maxspeed 
+assign maxspeed
   switch and reversedirection=yes maxspeed_backward maxspeed_backward
   switch and not reversedirection=yes maxspeed_forward maxspeed_forward
   switch maxspeed=50 50
@@ -203,7 +203,7 @@ assign upspeedpenalty
 
 assign surfacepenalty
  add switch embedded_rails=tram|yes|rail 10 # Zusatzkosten bei Schienen in der Fahrbahn
- 0 
+ 0
  switch surface=asphalt|paved 0 #Zusatzkosten für Teer oder versiegelte Flächen
  switch concrete=plates 1 # Zusatzkosten für Betonplattenwege
  switch concrete=lanes  2 # Zusatzkosten für Betonspurplatten
@@ -253,7 +253,7 @@ assign costfactor
   switch tracktype=grade5 add lmc 50 # Kosten für kaum erkennbare Feldwege
   add lmc 20 # Kosten für Feldwege ohne Oberflächenangabe
  switch cycleway 1.3 # Kosten für Fahrradwege
- switch highway=living_street 4 # Kosten für Spielstraßen
+ switch ( or highway=living_street living_street=yes ) 4 # Kosten für Spielstraßen
  switch highway=road 7 # Kosten für noch nicht genauer beschriebene Straße
  switch footway 15 # Kosten für Fußwege
  switch highway=pedestrian 20 # Kosten für Gehwege
@@ -296,13 +296,13 @@ assign uphillcostfactor
   switch tracktype=grade5 add lmc 50
   add lmc 20
  switch cycleway 1
- switch highway=living_street 2.5
+ switch ( or highway=living_street living_street=yes ) 2.5
  switch highway=road 5
  switch footway 15
  switch highway=pedestrian 20
  switch highway=steps 30
  switch highway=path
-  switch surface= add lmc 30 
+  switch surface= add lmc 30
   1
  switch highway=bridleway add lmc 80
  add lmc 20
@@ -339,13 +339,13 @@ assign downhillcostfactor
   switch tracktype=grade5 add lmc 50
   add lmc 20
  switch cycleway 2
- switch highway=living_street 8
+ switch ( or highway=living_street living_street=yes ) 8
  switch highway=road 10
  switch footway 20
  switch highway=pedestrian 30
  switch highway=steps 40
  switch highway=path
-  switch surface= add lmc 40 
+  switch surface= add lmc 40
   2
  switch highway=bridleway add lmc 80
  add lmc 20
@@ -366,7 +366,7 @@ assign priorityclassifier =
  else if ( highway=tertiary         ) then 22
  else if ( highway=tertiary_link       ) then 21
  else if ( highway=unclassified       ) then 20
- else if ( highway=residential|living_street ) then 6
+ else if ( or highway=residential|living_street living_street=yes ) then 6
  else if ( highway=service          ) then 6
  else if ( highway=cycleway         ) then 6
  else if ( bicycle=designated        ) then 6
@@ -384,7 +384,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-         else if highway=residential|living_street|service then true
+         else if ( or highway=residential|living_street|service living_street=yes ) then true
          else if ( and highway=track tracktype=grade1 ) then true
          else false
 
@@ -435,7 +435,7 @@ assign initialcost
   switch railway=crossing|level_crossing 200 # Kosten für Bahnübergang
   0
  switch bikeaccess
-  0 
+  0
  switch footaccess
   10000 # Kosten fürs Absteigen
  1000000 #Kosten für verbotene oder private Wege

--- a/misc/profiles2/vm-forum-liegerad-schnell.brf
+++ b/misc/profiles2/vm-forum-liegerad-schnell.brf
@@ -50,7 +50,7 @@ assign any_cycleroute or route_bicycle_icn=yes or route_bicycle_ncn=yes or route
 assign nodeaccessgranted or any_cycleroute lcn=yes
 
 assign cycleway
- or highway=cycleway and highway=path|footway bicycle=designated|yes
+ or bicycle_road=yes or highway=cycleway and highway=path|footway bicycle=designated|yes
 
 assign footway
  or highway=footway and highway=path foot=designated|yes
@@ -99,8 +99,10 @@ assign defaultaccess
 assign bikeaccess
  or any_cycleroute
  switch bicycle=
-  switch vehicle=
-   defaultaccess
+  switch bicycle_road=yes
+    1
+    switch vehicle=
+     defaultaccess
   switch or vehicle=private vehicle=no
    0
   1
@@ -355,25 +357,25 @@ assign downhillcostfactor
 
 assign priorityclassifier =
 
- if   ( highway=motorway         ) then 30
- else if ( highway=motorway_link       ) then 29
- else if ( highway=trunk           ) then 28
- else if ( highway=trunk_link        ) then 27
- else if ( highway=primary          ) then 26
- else if ( highway=primary_link       ) then 25
- else if ( highway=secondary         ) then 24
- else if ( highway=secondary_link      ) then 23
- else if ( highway=tertiary         ) then 22
- else if ( highway=tertiary_link       ) then 21
- else if ( highway=unclassified       ) then 20
+ if   ( highway=motorway                                          ) then 30
+ else if ( highway=motorway_link                                  ) then 29
+ else if ( highway=trunk                                          ) then 28
+ else if ( highway=trunk_link                                     ) then 27
+ else if ( highway=primary                                        ) then 26
+ else if ( highway=primary_link                                   ) then 25
+ else if ( highway=secondary                                      ) then 24
+ else if ( highway=secondary_link                                 ) then 23
+ else if ( highway=tertiary                                       ) then 22
+ else if ( highway=tertiary_link                                  ) then 21
+ else if ( highway=unclassified                                   ) then 20
  else if ( or highway=residential|living_street living_street=yes ) then 6
- else if ( highway=service          ) then 6
- else if ( highway=cycleway         ) then 6
- else if ( bicycle=designated        ) then 6
- else if ( highway=track           ) then if tracktype=grade1 then 6 else 4
- else if ( highway=bridleway|road|path|footway ) then 4
- else if ( highway=steps           ) then 2
- else if ( highway=pedestrian        ) then 2
+ else if ( highway=service                                        ) then 6
+ else if ( highway=cycleway                                       ) then 6
+ else if ( or bicycle=designated bicycle_road=yes                 ) then 6
+ else if ( highway=track                                          ) then if tracktype=grade1 then 6 else 4
+ else if ( highway=bridleway|road|path|footway                    ) then 4
+ else if ( highway=steps                                          ) then 2
+ else if ( highway=pedestrian                                     ) then 2
  else 0
 
 

--- a/misc/profiles2/vm-forum-velomobil-schnell.brf
+++ b/misc/profiles2/vm-forum-velomobil-schnell.brf
@@ -15,7 +15,7 @@ assign low_memory_cutoff = false # mit true werden Wege mit hohen Kosten aus der
 
 assign turnInstructionMode 1 #Ausgabe von Abiegehinweise 0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style
 assign turnInstructionCatchingRange 20 # innerhalb dieser Strecke werden mehrere Abiegehinweise zu einem zusammengefasst und die Abiegewinkel werden besser an die generelle Richtung angenähert
-assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert 
+assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert
 
 assign downhillcost 80 # Kosten für die Höhenmeter bergab
 assign downhillcutoff 0.1 # Gefälle unter diesem Wert in Prozent werden nicht gewertet
@@ -55,7 +55,7 @@ assign cycleway
 assign footway
  or highway=footway and highway=path foot=designated|yes
 
-assign turncost 
+assign turncost
  switch junction=roundabout 0
  150 # Kosten die für eine 90 Grad Abbiegung berechnet werden. Für kleinere Winkel werden sie mit turncost*cos(Winkel) berechnet, bei Kreisverkehr keine weitere Kosten
 
@@ -157,7 +157,7 @@ assign maxspeed_backward
   switch maxspeed:backward=rural 100
   0
 
-assign maxspeed 
+assign maxspeed
   switch and reversedirection=yes maxspeed_backward maxspeed_backward
   switch and not reversedirection=yes maxspeed_forward maxspeed_forward
   switch maxspeed=50 50
@@ -203,7 +203,7 @@ assign upspeedpenalty
 
 assign surfacepenalty
  add switch embedded_rails=tram|yes|rail 20 # Zusatzkosten bei Schienen in der Fahrbahn
- 0 
+ 0
  switch surface=asphalt|paved 0 #Zusatzkosten für Teer oder versiegelte Flächen
  switch concrete=plates 1 # Zusatzkosten für Betonplattenwege
  switch concrete=lanes  5 # Zusatzkosten für Betonspurplatten
@@ -253,7 +253,7 @@ assign costfactor
   switch tracktype=grade5 add lmc 50 # Kosten für kaum erkennbare Feldwege
   add lmc 20 # Kosten für Feldwege ohne Oberflächenangabe
  switch cycleway 2.5 # Kosten für Fahrradwege
- switch highway=living_street 5 # Kosten für Spielstraßen
+ switch ( or highway=living_street living_street=yes ) 5 # Kosten für Spielstraßen
  switch highway=road 10 # Kosten für noch nicht genauer beschriebene Straße
  switch footway 30 # Kosten für Fußwege
  switch highway=pedestrian 30 # Kosten für Gehwege
@@ -296,13 +296,13 @@ assign uphillcostfactor
   switch tracktype=grade5 add lmc 50
   add lmc 20
  switch cycleway 2
- switch highway=living_street 5
+ switch ( or highway=living_street living_street=yes ) 5
  switch highway=road 10
  switch footway 30
  switch highway=pedestrian 30
  switch highway=steps 40
  switch highway=path
-  switch surface= add lmc 40 
+  switch surface= add lmc 40
   10
  switch highway=bridleway add lmc 80
  add lmc 20
@@ -339,13 +339,13 @@ assign downhillcostfactor
   switch tracktype=grade5 add lmc 50
   add lmc 20
  switch cycleway 5
- switch highway=living_street 8
+ switch ( or highway=living_street living_street=yes ) 8
  switch highway=road 10
  switch footway 30
  switch highway=pedestrian 30
  switch highway=steps 40
  switch highway=path
-  switch surface= add lmc 40 
+  switch surface= add lmc 40
   10
  switch highway=bridleway add lmc 80
  add lmc 20
@@ -366,7 +366,7 @@ assign priorityclassifier =
  else if ( highway=tertiary         ) then 22
  else if ( highway=tertiary_link       ) then 21
  else if ( highway=unclassified       ) then 20
- else if ( highway=residential|living_street ) then 6
+ else if ( or highway=residential|living_street living_street=yes ) then 6
  else if ( highway=service          ) then 6
  else if ( highway=cycleway         ) then 6
  else if ( bicycle=designated        ) then 6
@@ -384,7 +384,7 @@ assign isgoodoneway = if reversedirection=yes then oneway=-1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true
-         else if highway=residential|living_street|service then true
+         else if ( or highway=residential|living_street|service living_street=yes ) then true
          else if ( and highway=track tracktype=grade1 ) then true
          else false
 
@@ -435,7 +435,7 @@ assign initialcost
   switch railway=crossing|level_crossing 350 # Kosten für Bahnübergang
   0
  switch bikeaccess
-  0 
+  0
  switch footaccess
   10000 # Kosten fürs Absteigen
  1000000 #Kosten für verbotene oder private Wege

--- a/misc/profiles2/vm-forum-velomobil-schnell.brf
+++ b/misc/profiles2/vm-forum-velomobil-schnell.brf
@@ -50,7 +50,7 @@ assign any_cycleroute or route_bicycle_icn=yes or route_bicycle_ncn=yes or route
 assign nodeaccessgranted or any_cycleroute lcn=yes
 
 assign cycleway
- or highway=cycleway and highway=path|footway bicycle=designated|yes
+ or bicycle_road=yes or highway=cycleway and highway=path|footway bicycle=designated|yes
 
 assign footway
  or highway=footway and highway=path foot=designated|yes
@@ -99,8 +99,10 @@ assign defaultaccess
 assign bikeaccess
  or any_cycleroute
  switch bicycle=
-  switch vehicle=
-   defaultaccess
+  switch bicycle_road=yes
+    1
+    switch vehicle=
+      defaultaccess
   switch or vehicle=private vehicle=no
    0
   1
@@ -355,25 +357,25 @@ assign downhillcostfactor
 
 assign priorityclassifier =
 
- if   ( highway=motorway         ) then 30
- else if ( highway=motorway_link       ) then 29
- else if ( highway=trunk           ) then 28
- else if ( highway=trunk_link        ) then 27
- else if ( highway=primary          ) then 26
- else if ( highway=primary_link       ) then 25
- else if ( highway=secondary         ) then 24
- else if ( highway=secondary_link      ) then 23
- else if ( highway=tertiary         ) then 22
- else if ( highway=tertiary_link       ) then 21
- else if ( highway=unclassified       ) then 20
+ if   ( highway=motorway                                          ) then 30
+ else if ( highway=motorway_link                                  ) then 29
+ else if ( highway=trunk                                          ) then 28
+ else if ( highway=trunk_link                                     ) then 27
+ else if ( highway=primary                                        ) then 26
+ else if ( highway=primary_link                                   ) then 25
+ else if ( highway=secondary                                      ) then 24
+ else if ( highway=secondary_link                                 ) then 23
+ else if ( highway=tertiary                                       ) then 22
+ else if ( highway=tertiary_link                                  ) then 21
+ else if ( highway=unclassified                                   ) then 20
  else if ( or highway=residential|living_street living_street=yes ) then 6
- else if ( highway=service          ) then 6
- else if ( highway=cycleway         ) then 6
- else if ( bicycle=designated        ) then 6
- else if ( highway=track           ) then if tracktype=grade1 then 6 else 4
- else if ( highway=bridleway|road|path|footway ) then 4
- else if ( highway=steps           ) then 2
- else if ( highway=pedestrian        ) then 2
+ else if ( highway=service                                        ) then 6
+ else if ( highway=cycleway                                       ) then 6
+ else if ( or bicycle=designated bicycle_road=yes                 ) then 6
+ else if ( highway=track                                          ) then if tracktype=grade1 then 6 else 4
+ else if ( highway=bridleway|road|path|footway                    ) then 4
+ else if ( highway=steps                                          ) then 2
+ else if ( highway=pedestrian                                     ) then 2
  else 0
 
 


### PR DESCRIPTION
Hi,

This should address #166 and #174 (one commit for each):

1. I updated the profiles so that `living_street=yes` is equivalent to `highway=living_street`.
One might argue that `living_street=yes` should have a slight penalty with respect to `highway=living_street` to reflect that this might not be fully a living street (`highway=secondary` + `living_street=yes` probably means there is much traffic and one can expect this to be a poor quality living street). I, however, don't have enough feedback so far on the use of `living_street` across the world (seems to be mostly used in Russia so far), so I think considering it as an alias is fine for a first version.

2. I added support for `sidewalk:bicycle` tag (and its `left`/`right` variants). This one is mainly used in Germany to describe an implicit sidewalk which can be cycled on (https://wiki.openstreetmap.org/wiki/DE:Key:sidewalk). I did not edit the `trekking` profile accordingly, it might be worth extending `isbike` to account for `sidewalk:bicycle=yes`, but I did not find any documentation (or missed it, I don't speak german :/) about whether this should be considered oneway or not by default.

3. @abrensch you mentionned
> in the google group there's something about stop signs

Do you have more infos on this? I can't find it back :/

Thanks!
Best