### PR TITLE
Handle bicycle=use_sidepath the same as bicycle=no

### DIFF
--- a/misc/profiles2/fastbike-asia-pacific.brf
+++ b/misc/profiles2/fastbike-asia-pacific.brf
@@ -70,7 +70,7 @@ assign bikeaccess
                            switch or vehicle=private vehicle=no
                                   0
                                   1
-                 not or bicycle=private or bicycle=no bicycle=dismount
+                 not or bicycle=private|no|dismount|use_sidepath
 
 #
 # calculate logical foot access

--- a/misc/profiles2/fastbike-lowtraffic.brf
+++ b/misc/profiles2/fastbike-lowtraffic.brf
@@ -57,7 +57,7 @@ assign bikeaccess =
          )
          else not vehicle=private|no
        )
-       else not bicycle=private|no|dismount
+       else not bicycle=private|no|dismount|use_sidepath
 
 #
 # calculate logical foot access

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -65,7 +65,7 @@ assign bikeaccess
                            switch or vehicle=private vehicle=no
                                   0
                                   1
-                 not or bicycle=private or bicycle=no bicycle=dismount
+                 not or bicycle=private|no|dismount|use_sidepath
 
 #
 # calculate logical foot access

--- a/misc/profiles2/shortest.brf
+++ b/misc/profiles2/shortest.brf
@@ -43,7 +43,7 @@ assign bikeaccess
                             switch or vehicle=private vehicle=no
                                 0
                                 1
-                 not or bicycle=private or bicycle=no bicycle=dismount
+                 not or bicycle=private|no|dismount|use_sidepath
 
 #
 # calculate logical foot access

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -302,7 +302,7 @@ assign bikeaccess =
          if vehicle= then defaultaccess
          else not vehicle=private|no
        )
-       else not bicycle=private|no|dismount
+       else not bicycle=private|no|dismount|use_sidepath
 
 assign footaccess =
        if bicycle=dismount then true


### PR DESCRIPTION
See https://github.com/abrensch/brouter/issues/79, this patch has bicycle=use_sidepath threatened the same as bicycle=no.

In NL ways that have a seperate cycle path along it do not have access=no but access=use_sidepath as some special types of cycles (with more than two wheels and wider than 75 cm) still may still use the main road. Because of this, this patch does not change vm-forum-liegerad-schnell.brf and vm-forum-velomobil-schnell.brf