### PR TITLE
Ignore generated profiles

### DIFF
--- a/misc/profiles2/.gitignore
+++ b/misc/profiles2/.gitignore
@@ -1,0 +1,9 @@
+/car-eco.brf
+/car-fast.brf
+/fastbike-asia-pacific.brf
+/fastbike-lowtraffic.brf
+/safety.brf
+/trekking-ignore-cr.brf
+/trekking-noferries.brf
+/trekking-nosteps.brf
+/trekking-steep.brf


### PR DESCRIPTION
Ignore profiles in Git that are generated by [misc/scripts/generate_profile_variants.sh](https://github.com/abrensch/brouter/blob/master/misc/scripts/generate_profile_variants.sh).