### PR TITLE
Fix shell in generate_profile_variants.sh

### DIFF
--- a/misc/scripts/generate_profile_variants.sh
+++ b/misc/scripts/generate_profile_variants.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 cd "$(dirname "$0")"
 cd ../profiles2
 


### PR DESCRIPTION
`/usr/bin/sh` is not found on Ubuntu 18.04, suggesting to use `/bin/sh` instead.