### PR TITLE
Cleanup file / base directory access

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -41,7 +41,7 @@ public class RoutingEngine extends Thread
 
   private volatile boolean terminated;
 
-  protected String segmentDir;
+  protected File segmentDir;
   private String outfileBase;
   private String logfileBase;
   private boolean infoLogEnabled;
@@ -64,7 +64,7 @@ public class RoutingEngine extends Thread
 
   private boolean directWeaving = !Boolean.getBoolean( "disableDirectWeaving" );
 
-  public RoutingEngine( String outfileBase, String logfileBase, String segmentDir,
+  public RoutingEngine( String outfileBase, String logfileBase, File segmentDir,
           List<OsmNodeNamed> waypoints, RoutingContext rc )
   {
     this.segmentDir = segmentDir;

--- a/brouter-core/src/main/java/btools/router/RoutingHelper.java
+++ b/brouter-core/src/main/java/btools/router/RoutingHelper.java
@@ -11,20 +11,20 @@ import btools.mapaccess.StorageConfigHelper;
 
 public final class RoutingHelper
 {
-    public static File getAdditionalMaptoolDir( String segmentDir )
+    public static File getAdditionalMaptoolDir( File segmentDir )
     {
     	return StorageConfigHelper.getAdditionalMaptoolDir(segmentDir);
     }
 
-    public static File getSecondarySegmentDir( String segmentDir )
+    public static File getSecondarySegmentDir( File segmentDir )
     {
     	return StorageConfigHelper.getSecondarySegmentDir(segmentDir);
     }
     
     
-    public static boolean hasDirectoryAnyDatafiles( String segmentDir )
+    public static boolean hasDirectoryAnyDatafiles( File segmentDir )
     {
-        if ( hasAnyDatafiles( new File( segmentDir ) ) )
+        if ( hasAnyDatafiles( segmentDir ) )
         {
         	return true;
         }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
@@ -56,10 +56,10 @@ public final class NodesCache
     return "collecting=" + garbageCollectionEnabled + " noGhosts=" + ghostCleaningDone + " cacheSum=" + cacheSum + " cacheSumClean=" + cacheSumClean + " ghostSum=" + ghostSum + " ghostWakeup=" + ghostWakeup ;
   }
 
-  public NodesCache( String segmentDir, BExpressionContextWay ctxWay, boolean forceSecondaryData, long maxmem, NodesCache oldCache, boolean detailed )
+  public NodesCache( File segmentDir, BExpressionContextWay ctxWay, boolean forceSecondaryData, long maxmem, NodesCache oldCache, boolean detailed )
   {
     this.maxmemtiles = maxmem / 8;
-    this.segmentDir = new File( segmentDir );
+    this.segmentDir = segmentDir;
     this.nodesMap = new OsmNodesMap();
     this.nodesMap.maxmem = (2L*maxmem) / 3L;
     this.expCtxWay = ctxWay;
@@ -77,7 +77,7 @@ public final class NodesCache
     first_file_access_name = null;
 
     if ( !this.segmentDir.isDirectory() )
-      throw new RuntimeException( "segment directory " + segmentDir + " does not exist" );
+      throw new RuntimeException( "segment directory " + segmentDir.getAbsolutePath () + " does not exist" );
 
     if ( oldCache != null )
     {

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/StorageConfigHelper.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/StorageConfigHelper.java
@@ -11,21 +11,21 @@ import java.io.FileReader;
 
 public class StorageConfigHelper
 {
-  public static File getSecondarySegmentDir( String segmentDir )
+  public static File getSecondarySegmentDir( File segmentDir )
   {
     return getStorageLocation( segmentDir, "secondary_segment_dir=" );
   }
 
-  public static File getAdditionalMaptoolDir( String segmentDir )
+  public static File getAdditionalMaptoolDir( File segmentDir )
   {
     return getStorageLocation( segmentDir, "additional_maptool_dir=" );
   }
 
-  private static File getStorageLocation( String segmentDir, String tag )
+  private static File getStorageLocation( File segmentDir, String tag )
   {
     File res = null;
     BufferedReader br = null;
-    String configFile = segmentDir + "/storageconfig.txt";
+    File configFile = new File (segmentDir, "storageconfig.txt");
     try
     {
       br = new BufferedReader( new FileReader( configFile ) );
@@ -38,7 +38,7 @@ public class StorageConfigHelper
         if ( line.startsWith( tag ) )
         {
           String path = line.substring( tag.length() ).trim();
-          res = path.startsWith( "/" ) ? new File( path ) : new File( new File( segmentDir ), path );
+          res = path.startsWith( "/" ) ? new File( path ) : new File( segmentDir, path );
           if ( !res.exists() ) res = null;
           break;
         }

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "btools.routingapp"
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 41
         versionName "1.6.1"

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "btools.routingapp"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 29
         versionCode 41
         versionName "1.6.1"
@@ -27,6 +27,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':brouter-mapaccess')
     implementation project(':brouter-core')
     implementation project(':brouter-expressions')

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -58,7 +58,7 @@ public class BInstallerView extends View
     private boolean tilesVisible = false;
     
     private long availableSize;
-    private String baseDir;
+    private File baseDir;
     
     private boolean isDownloading = false;
     private volatile boolean downloadCanceled = false;
@@ -207,7 +207,7 @@ public class BInstallerView extends View
     
     private void deleteRawTracks()
     {
-      File modeDir = new File( baseDir + "/brouter/modes" );
+      File modeDir = new File( baseDir, "brouter/modes" );
       String[] fileNames = modeDir.list();
       if ( fileNames == null ) return;
       for( String fileName : fileNames )
@@ -224,9 +224,9 @@ public class BInstallerView extends View
     {
       clearTileSelection( MASK_INSTALLED_RD5 | MASK_CURRENT_RD5 );
 
-      scanExistingFiles( new File( baseDir + "/brouter/segments4" ) );
+      scanExistingFiles( new File( baseDir, "brouter/segments4" ) );
       
-      File secondary = RoutingHelper.getSecondarySegmentDir( baseDir + "/brouter/segments4" );
+      File secondary = RoutingHelper.getSecondarySegmentDir( new File ( baseDir, "brouter/segments4" ) );
       if ( secondary != null )
       {
           scanExistingFiles( secondary );
@@ -235,7 +235,7 @@ public class BInstallerView extends View
       availableSize = -1;
       try
       {
-        StatFs stat = new StatFs(baseDir);
+        StatFs stat = new StatFs(baseDir.getAbsolutePath ());
         availableSize = (long)stat.getAvailableBlocks()*stat.getBlockSize();
       }
       catch (Exception e) { /* ignore */ }
@@ -472,7 +472,7 @@ float tx, ty;
         int tidx = gridPos2Tileindex( ix, iy );
         if ( ( tileStatus[tidx] & MASK_DELETED_RD5 ) != 0 )
         {
-          new File( baseDir + "/brouter/segments4/" + baseNameForTile( tidx ) + ".rd5").delete();
+          new File( baseDir, "brouter/segments4/" + baseNameForTile( tidx ) + ".rd5").delete();
         }
       }
     }
@@ -667,7 +667,7 @@ float tx, ty;
               OutputStream output = null;
               HttpURLConnection connection = null;
               String surl = sUrls[0];
-              String fname = null;
+              File fname = null;
               File tmp_file = null;
               try
               {
@@ -676,17 +676,16 @@ float tx, ty;
                     int slidx = surl.lastIndexOf( "segments4/" );
                     String name = surl.substring( slidx+10 );
                     String surlBase = surl.substring( 0, slidx+10 );
-                    fname = baseDir + "/brouter/segments4/" + name;
+                    fname = new File (baseDir, "brouter/segments4/" + name);
 
                     boolean delta = true;
 
-                    File targetFile = new File( fname );
-                    if ( targetFile.exists() )
+                    if ( fname.exists() )
                     {
                       updateProgress( "Calculating local checksum.." );
                     
                       // first check for a delta file
-                      String md5 = Rd5DiffManager.getMD5( targetFile );
+                      String md5 = Rd5DiffManager.getMD5( fname );
                       String surlDelta = surlBase + "diff/" + name.replace( ".rd5", "/" + md5 + ".rd5diff" );
                       
                       URL urlDelta = new URL(surlDelta);
@@ -728,7 +727,7 @@ float tx, ty;
                     // download the file
                     input = connection.getInputStream();
                     
-                    tmp_file = new File( fname + ( delta ? "_diff" : "_tmp" ) );
+                    tmp_file = new File( fname.getAbsolutePath() + ( delta ? "_diff" : "_tmp" ) );
                     output = new FileOutputStream( tmp_file );
 
                     byte data[] = new byte[4096];
@@ -768,7 +767,7 @@ float tx, ty;
                       updateProgress( "Applying delta.." );
                       File diffFile = tmp_file;
                       tmp_file = new File( fname + "_tmp" );
-                      Rd5DiffTool.recoverFromDelta( targetFile, diffFile, tmp_file, this );
+                      Rd5DiffTool.recoverFromDelta( fname, diffFile, tmp_file, this );
                       diffFile.delete();
                     }
                     if (isDownloadCanceled())
@@ -781,9 +780,9 @@ float tx, ty;
                       String check_result = PhysicalFile.checkFileIntegrity( tmp_file );
                       if ( check_result != null ) return check_result;
 
-                      if ( !tmp_file.renameTo( targetFile ) )
+                      if ( !tmp_file.renameTo( fname ) )
                       {
-                        return "Could not rename to " + targetFile;
+                        return "Could not rename to " + fname.getAbsolutePath();
                       }
                       deleteRawTracks(); // invalidate raw-tracks after data update
                     }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 import java.util.ArrayList;
 
@@ -58,7 +59,7 @@ public class BRouterService extends Service
         if ( configInput != null ) try { configInput.close(); } catch (Exception ee) {}
       }
       worker.baseDir = baseDir;
-      worker.segmentDir = baseDir + "/brouter/segments4";
+      worker.segmentDir = new File (baseDir, "brouter/segments4" );
 
       String remoteProfile = params.getString( "remoteProfile" );
 
@@ -85,9 +86,9 @@ public class BRouterService extends Service
           try
           {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            baos.write( "z64".getBytes("UTF-8") ); // marker prefix
+            baos.write( "z64".getBytes(StandardCharsets.UTF_8) ); // marker prefix
             OutputStream os = new GZIPOutputStream( baos );
-            byte[] ab = gpxMessage.getBytes("UTF-8");
+            byte[] ab = gpxMessage.getBytes(StandardCharsets.UTF_8);
             gpxMessage = null;
             os.write( ab );
             ab = null;

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -17,7 +17,7 @@ import btools.router.RoutingEngine;
 public class BRouterWorker
 {
   public String baseDir;
-  public String segmentDir;
+  public File segmentDir;
   public String profileName;
   public String profilePath;
   public String rawTrackPath;

--- a/brouter-routing-app/src/main/java/btools/routingapp/ConfigHelper.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/ConfigHelper.java
@@ -6,59 +6,35 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.File;
 
 import android.content.Context;
 
 public class ConfigHelper
 {
-  public static String getBaseDir( Context ctx )
+  public static File getBaseDir( Context ctx )
   {
     // get base dir from private file
-    InputStream configInput = null;
-    try
-    {
-      configInput = ctx.openFileInput( "config15.dat" );
-      BufferedReader br = new BufferedReader( new InputStreamReader( configInput ) );
-      return br.readLine();
+
+    try (InputStream configInput = ctx.openFileInput( "config15.dat" );
+         InputStreamReader isr = new InputStreamReader( configInput );
+         BufferedReader br = new BufferedReader(isr)) {
+      return new File ( br.readLine() );
     }
     catch (Exception e)
     {
       return null;
     }
-    finally
-    {
-      if ( configInput != null )
-      {
-        try
-        {
-          configInput.close();
-        }
-        catch (Exception ee)
-        {
-        }
-      }
-    }
   }
 
-  public static void writeBaseDir( Context ctx, String baseDir )
+  public static void writeBaseDir( Context ctx, File baseDir )
   {
-    BufferedWriter bw = null;
-    try
-    {
-      OutputStream configOutput = ctx.openFileOutput( "config15.dat", Context.MODE_PRIVATE );
-      bw = new BufferedWriter( new OutputStreamWriter( configOutput ) );
-      bw.write( baseDir );
+    try (OutputStream configOutput = ctx.openFileOutput( "config15.dat", Context.MODE_PRIVATE );
+         OutputStreamWriter osw = new OutputStreamWriter( configOutput );
+         BufferedWriter bw = new BufferedWriter( osw)) {
+      bw.write( baseDir.getAbsolutePath () );
       bw.write( '\n' );
     }
     catch (Exception e){ /* ignore */ }
-    finally
-    {
-      if ( bw != null )
-        try
-        {
-          bw.close();
-        }
-        catch (Exception ee) { /* ignore */ }
-    }
   }
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/ConfigMigration.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/ConfigMigration.java
@@ -87,17 +87,17 @@ public class ConfigMigration
     }
   }
 
-  public static File saveAdditionalMaptoolDir( String segmentDir, String value )
+  public static File saveAdditionalMaptoolDir( File segmentDir, String value )
   {
     return saveStorageLocation( segmentDir, "additional_maptool_dir=", value );
   }
 
-  private static File saveStorageLocation( String segmentDir, String tag, String value )
+  private static File saveStorageLocation( File segmentDir, String tag, String value )
   {
     File res = null;
     BufferedReader br = null;
     BufferedWriter bw = null;
-    String configFile = segmentDir + "/storageconfig.txt";
+    File configFile = new File (segmentDir, "storageconfig.txt");
     List<String> lines = new ArrayList<String>();
     try
     {

--- a/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReader.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/CoordinateReader.java
@@ -149,12 +149,12 @@ public abstract class CoordinateReader
   protected abstract void readPointmap() throws Exception;
   
 
-  public static CoordinateReader obtainValidReader( String basedir, String segmentDir ) throws Exception
+  public static CoordinateReader obtainValidReader( String basedir, File segmentDir ) throws Exception
   {
     return obtainValidReader( basedir, segmentDir, false );
   }
 
-  public static CoordinateReader obtainValidReader( String basedir, String segmentDir, boolean nogosOnly ) throws Exception
+  public static CoordinateReader obtainValidReader( String basedir, File segmentDir, boolean nogosOnly ) throws Exception
   {
     CoordinateReader cor = null;
     ArrayList<CoordinateReader> rl = new ArrayList<CoordinateReader>();

--- a/brouter-server/src/main/java/btools/server/BRouter.java
+++ b/brouter-server/src/main/java/btools/server/BRouter.java
@@ -6,6 +6,7 @@ import java.io.FileOutputStream;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.io.File;
 
 import btools.router.OsmNodeNamed;
 import btools.router.RoutingContext;
@@ -75,7 +76,7 @@ public class BRouter
         wplist.add( from );
         wplist.add( to );
 
-        RoutingEngine re = new RoutingEngine( null, null, args[0], wplist, readRoutingContext(a2) );
+        RoutingEngine re = new RoutingEngine( null, null, new File (args[0]), wplist, readRoutingContext(a2) );
         re.doRun( maxRunningTime );
         if ( re.getErrorMessage() != null )
         {
@@ -111,7 +112,7 @@ public class BRouter
         SearchBoundary boundary = new SearchBoundary( wplist.get(0), searchRadius, direction/2 );
         rc.trafficOutputStream = dos;
         rc.inverseDirection = (direction & 1 ) != 0;
-        re = new RoutingEngine( "mytrack", "mylog", args[0], wplist, rc );
+        re = new RoutingEngine( "mytrack", "mylog", new File ( args[0] ), wplist, rc );
         re.boundary = boundary;
         re.airDistanceCostFactor = rc.trafficDirectionFactor;
         rc.countTraffic = true;
@@ -127,7 +128,7 @@ public class BRouter
     {
       wplist.add( readPosition( args, 3, "to" ) );
       RoutingContext rc = readRoutingContext(args);
-      re = new RoutingEngine( "mytrack", "mylog", args[0], wplist, rc );
+      re = new RoutingEngine( "mytrack", "mylog", new File ( args[0] ), wplist, rc );
       re.doRun( 0 );
       
     }

--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -294,7 +294,7 @@ public class RouteServer extends Thread implements Comparable<RouteServer>
         }
 
         ServiceContext serviceContext = new ServiceContext();
-        serviceContext.segmentDir = args[0];
+        serviceContext.segmentDir = new File ( args[0] );
         serviceContext.profileDir = args[1];
         System.setProperty( "profileBaseDir", serviceContext.profileDir );
         String dirs = args[2];

--- a/brouter-server/src/main/java/btools/server/ServiceContext.java
+++ b/brouter-server/src/main/java/btools/server/ServiceContext.java
@@ -2,6 +2,7 @@ package btools.server;
 
 import java.util.List;
 import java.util.Map;
+import java.io.File;
 
 import btools.router.OsmNodeNamed;
 
@@ -10,7 +11,7 @@ import btools.router.OsmNodeNamed;
  */
 public class ServiceContext
 {
-  public String segmentDir;
+  public File segmentDir;
   public String profileDir;
   public String customProfileDir;
   public String sharedProfileDir;

--- a/brouter-server/src/test/java/btools/server/RouterTest.java
+++ b/brouter-server/src/test/java/btools/server/RouterTest.java
@@ -67,7 +67,7 @@ public class RouterTest
     RoutingEngine re = new RoutingEngine(
         wd + "/" + trackname,
         wd + "/" + trackname,
-        wd + "/../../../brouter-map-creator/target/test-classes/tmp/segments", wplist, rctx );
+        new File ( wd, "/../../../brouter-map-creator/target/test-classes/tmp/segments"), wplist, rctx );
     re.doRun( 0 );
     
     return re.getErrorMessage();


### PR DESCRIPTION
I wanted to clean up the definition / access of the brouter base directory to be more aligned with Android's storage model - particularly, directly using `Context.getExternalFilesDirs` to find writable directories without manually constructing any paths. Effectively, the paths presented in the path selection dialog should always work. For the manual path entry, I added the capability to request the `WRITE_EXTERNAL_STORAGE` permission, so that more paths can be selected. Unfortunately, this still doesn't allow us to write to the actual SD card outside of the app-specific `Android` directory, but _does_ allow directly writing to `/storage/emulated/0` if the user wishes to. I also did some general clean-up, using `java.io.File` instead of just `String` in some places, and also try-with-resources. This breaks pre-KitKat compatibility, but I suspect apps like Locus won't run on devices this old anyways :)

With Android 11 "scoped storage", apps won't be able to access arbitrary shared locations at all any more. Therefore, it is probably necessary to refactor the various file-based data accesses in brouter and e.g. store everything in app-private directories and exchange all data via the Service interface. E.g. to avoid having to manually deal with profile files, brouter could offer a GUI to install/manage profiles, and client apps like Locus could query the installed profiles via the service API to present a selection dialog to choose one for routing. This would obviate the need for the user to manually deal with profile files. The file-based router interface probably can't be made to work on Android 11, so this probably needs to be completely converted to a Service-based one. A prettier, more user-friendly and localized GUI would probably also be nice. To avoid a lot of complexity, it would probably be a good idea to drop some backward-compatibility, perhaps doing this as a 2.0 version, which then would only work with accordingly-updated client apps.

Would there be any interest to refactor brouter like that?

This is based on the switch to gradle in #243.