### PR TITLE
Manage cycleway left right opposite*

### DIFF
--- a/misc/profiles2/fastbike-verylowtraffic.brf
+++ b/misc/profiles2/fastbike-verylowtraffic.brf
@@ -2,7 +2,7 @@
 #  This profile, developed by Ess Bee, is based on the "fastbike-lowtraffic" profile
 #   it is intended for road cyclists who ride alone and / or in the middle of the week: thus trucks and high traffic are avoided
 #  (cyclists in group at the weekend will rather use "fastbike.brf" or "fastbike-lowprofile.brf" as groups are better respected by cars and trucks)
-# 
+#
 #     ==> where ever possible, choose:
 #     - an asphalted way (with good smoothness)
 #     - cycleways are prefered
@@ -11,21 +11,21 @@
 #          - avoid segments with high-traffic
 #
 #  The route is calculated using the taggs of the OSM map (such as highway, surface, smoothness, maxspeed, traffic_class...)
-#              
-  
+#
+
 ---context:global   # following code refers to global config
 
-# to generate turn instructions, adapt the mode by need 
+# to generate turn instructions, adapt the mode by need
 assign   turnInstructionMode  1   # 0=none, 1=auto-choose, 2=locus-style, 3=osmand-style
 
 # Use the following switches to change behaviour
 # (1=yes, 0=no):
 
 assign   consider_elevation   0   # set to 1 to calculate an elevation_penalty in routing
-assign   avoid_path           0   # set to 1 to avoid path (a.e. to avoid conflicts with pedestrians!) 
+assign   avoid_path           0   # set to 1 to avoid path (a.e. to avoid conflicts with pedestrians!)
 assign turnInstructionCatchingRange 8 # 2 turn instructions are generated only when distance > 8 m
-assign turnInstructionRoundabouts = 1 # roundabout, "take exit N" 
-assign considerTurnRestrictions true   # turn restrictions are considered  
+assign turnInstructionRoundabouts = 1 # roundabout, "take exit N"
+assign considerTurnRestrictions true   # turn restrictions are considered
 
 assign   validForBikes        1
 
@@ -43,19 +43,19 @@ assign cycleway_right if reversedirection=yes
 			      then if cycleway:left=track|lane|shared_lane then 1 else 0
                       else if cycleway:right=track|lane|shared_lane then 1 else 0
 
-assign any_cycleway  or cycleway=track|lane|shared_lane|shared cycleway_right 
-# as soon it is supported in lookup, add ==> bicycle_road=yes in any_cycleway 
+assign any_cycleway  or cycleway=track|lane|shared_lane|shared cycleway_right
+# as soon it is supported in lookup, add ==> bicycle_road=yes in any_cycleway
 
-# in relation with "route=bicycle" ? 
+# in relation with "route=bicycle" ?
 assign any_cycleroute or route_bicycle_icn=yes or route_bicycle_ncn=yes or route_bicycle_rcn=yes route_bicycle_lcn=yes
 
 assign nodeaccessgranted or any_cycleroute lcn=yes
 
 assign ispaved or surface=paved surface=asphalt
-assign isunpaved   surface=unpaved|gravel|dirt|earth|ground|sand  
+assign isunpaved   surface=unpaved|gravel|dirt|earth|ground|sand
 
-assign isfine_gravel  surface=fine_gravel|cobblestone|compacted|paving_stones     
-assign isconcrete surface=concrete     
+assign isfine_gravel  surface=fine_gravel|cobblestone|compacted|paving_stones
+assign isconcrete surface=concrete
 
 assign turncost = if junction=roundabout then 0
                   else 10
@@ -141,18 +141,18 @@ assign surfacepenalty
         switch surface=concrete|paving_stones|wood|metal             0.7      # Beton, Pflastersteine, Holz, Metall
         switch surface=cobblestone                                   2        # Kopfsteinpflaster
         switch concrete=lanes                                        3        # Betonspurplatten
-        switch surface=fine_gravel|compacted                         4        # Splitt,verdichtete Oberfläsche  
-        switch surface=sett|grass_paver                              5        # behauene Pflastersteine, Rasengittersteine 
+        switch surface=fine_gravel|compacted                         4        # Splitt,verdichtete Oberfläsche
+        switch surface=sett|grass_paver                              5        # behauene Pflastersteine, Rasengittersteine
         switch surface=gravel|sand|pebblestone|unpaved               10       # Schotter, Sand, Kies, unbefestigt
         switch surface=ground|grass|dirt|earth|mud|clay              25       # naturbelassene Oberfläsche, Gras, Schutz Schlamm...
 # if "surface" is not defined, for service and road asphalt is probable
-        switch surface= 
-               switch highway=service|road                           0.1 
+        switch surface=
+               switch highway=service|road                           0.1
 # in some cases only smoothness is tagged but surface not!
                switch smoothness=intermediate|good|excellent         0
-# else, check if tracktype=grade1, then is probably paved, so middle penalty 
+# else, check if tracktype=grade1, then is probably paved, so middle penalty
                switch tracktype=grade1                               1.3
-# if a cycleroute is defined, surface can not be horrible...               
+# if a cycleroute is defined, surface can not be horrible...
                switch any_cycleroute                                 3.5 5
 # surface not known yet?
                                                                      5
@@ -167,13 +167,13 @@ assign tracktypepenalty
 
 
 assign trafficpenalty =
-	if any_cycleway then   0 
+	if any_cycleway then   0
 	else
 if highway=primary|primary_link then
     (
       if      estimated_traffic_class=4 then 0.8
       else if estimated_traffic_class=5 then 1
-      else if estimated_traffic_class=6|7 then 2 
+      else if estimated_traffic_class=6|7 then 2
       else 0.6
     )
     else if highway=secondary|secondary_link then
@@ -213,7 +213,7 @@ assign maxspeedpenalty =
          switch maxspeed=100 3.0
          switch maxspeed=110 11
          switch maxspeed=120 12
-         switch maxspeed=130 13 
+         switch maxspeed=130 13
          switch maxspeed= 2.2  0
      switch or highway=secondary highway=secondary_link
 # as soon "name" is supported in lookup, replace with "switch maxspeed= switch name= 0.9 0.2
@@ -250,19 +250,19 @@ assign usesidepathpenalty =
 # give a light advantage to highways with a relation cycleroute
 assign nocycleway_penalty switch any_cycleroute  0 0.1
 
-assign not_bicycle_designatedpenalty switch bicycle=designated 0 0.1              
+assign not_bicycle_designatedpenalty switch bicycle=designated 0 0.1
 
 assign path_penalty if avoid_path then 1 else 0
- 
+
 assign costfactor
   add surfacepenalty
   add tracktypepenalty
   add trafficpenalty
-  add smoothnesspenalty 
+  add smoothnesspenalty
   add maxspeedpenalty
   add usesidepathpenalty
   add nocycleway_penalty
-  add not_bicycle_designatedpenalty 
+  add not_bicycle_designatedpenalty
   add path_penalty
   switch or highway=proposed highway=abandoned 10000
   min 9999
@@ -281,7 +281,7 @@ assign costfactor
   switch    highway=living_street                     1.2
   switch    highway=residential                       1.4
   switch    highway=service                           1.1
-  switch    highway=track|road|path                   1 
+  switch    highway=track|road|path                   1
   switch    highway=footway                           1.7
                                                       19.9
 
@@ -304,7 +304,7 @@ assign priorityclassifier =
   else if ( highway=service                   ) then  6
   else if ( highway=cycleway                  ) then  6
   else if ( bicycle=designated                ) then  6
-  else if ( highway=track|road|path ) 
+  else if ( highway=track|road|path )
        then if or surface=asphalt|paved|concrete|wood|metal tracktype=grade1 then 6 else 4
   else if ( highway=steps                     ) then  2
   else if ( highway=pedestrian                ) then  2
@@ -324,7 +324,7 @@ assign isgoodforcars = if greater priorityclassifier 6 then true
 
 # ... encoded into a bitmask
 
-assign classifiermask 
+assign classifiermask
 #      add          isbadoneway	# no voice hint if 1 of the 2 possibilities is badoneway
                       add multiply isgoodoneway   2
                       add multiply isroundabout   4

--- a/misc/profiles2/fastbike-verylowtraffic.brf
+++ b/misc/profiles2/fastbike-verylowtraffic.brf
@@ -115,17 +115,30 @@ assign accesspenalty
 # to push your bike)
 #
 assign badoneway =
-       if reversedirection=yes then
-         if oneway:bicycle=yes then true
-         else if oneway= then junction=roundabout
-         else oneway=yes|true|1
-       else oneway=-1
+      if reversedirection=yes then
+        if oneway:bicycle=yes then true
+        else if oneway= then junction=roundabout
+        else oneway=yes|true|1
+      else oneway=-1
 
 assign onewaypenalty =
        if ( badoneway ) then
        (
-         if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
-         else if ( oneway:bicycle=no                         ) then 0
+         # Not a oneway street for bikes
+         if ( oneway:bicycle=no ) then 0
+         # No penalty if there is any cycleway going against traffic
+         else if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
+         else if ( cycleway:right=opposite|opposite_lane|opposite_track ) then 0
+         else if ( cycleway:left=opposite|opposite_lane|opposite_track ) then 0
+         # Otherwise, check the value of oneway:bicycle
+         else if ( and ( not reversedirection=yes ) oneway:bicycle=yes|no ) then 0
+         # No penalty if there is any left cycleway in opposite direction
+         else if ( and reversedirection=yes cycleway:left:oneway=-1|no ) then 0
+         else if ( and ( not reversedirection=yes ) cycleway:left:oneway=yes|no ) then 0
+         # No penalty if there is any right cycleway in opposite direction
+         else if ( and reversedirection=yes cycleway:right:oneway=-1|no ) then 0
+         else if ( and ( not reversedirection=yes ) cycleway:right:oneway=yes|no ) then 0
+         # Other cases
          else if ( highway=primary|primary_link              ) then 50
          else if ( highway=secondary|secondary_link          ) then 30
          else if ( highway=tertiary|tertiary_link            ) then 20

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -128,16 +128,29 @@ assign badoneway =
        else oneway=-1
 
 assign onewaypenalty =
-       if ( badoneway ) then
-       (
-         if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
-         else if ( oneway:bicycle=no                         ) then 0
-         else if ( highway=primary|primary_link              ) then 50
-         else if ( highway=secondary|secondary_link          ) then 30
-         else if ( highway=tertiary|tertiary_link            ) then 20
-         else 6.0
-       )
-       else 0.0
+      if ( badoneway ) then
+      (
+        # Not a oneway street for bikes
+        if ( oneway:bicycle=no ) then 0
+        # No penalty if there is any cycleway going against traffic
+        else if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
+        else if ( cycleway:right=opposite|opposite_lane|opposite_track ) then 0
+        else if ( cycleway:left=opposite|opposite_lane|opposite_track ) then 0
+        # Otherwise, check the value of oneway:bicycle
+        else if ( and ( not reversedirection=yes ) oneway:bicycle=yes|no ) then 0
+        # No penalty if there is any left cycleway in opposite direction
+        else if ( and reversedirection=yes cycleway:left:oneway=-1|no ) then 0
+        else if ( and ( not reversedirection=yes ) cycleway:left:oneway=yes|no ) then 0
+        # No penalty if there is any right cycleway in opposite direction
+        else if ( and reversedirection=yes cycleway:right:oneway=-1|no ) then 0
+        else if ( and ( not reversedirection=yes ) cycleway:right:oneway=yes|no ) then 0
+        # Other cases
+        else if ( highway=primary|primary_link              ) then 50
+        else if ( highway=secondary|secondary_link          ) then 30
+        else if ( highway=tertiary|tertiary_link            ) then 20
+        else 6.0
+      )
+      else 0.0
 
 # Eventually compute traffic penalty
 assign hascycleway = not

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -152,11 +152,26 @@ assign badoneway =
          else oneway=yes|true|1
        else oneway=-1
 
+# Penalty associated with going against traffic in a one-way street
+# Note: Can be zero if opposite traffic is allowed for bikes
 assign onewaypenalty =
        if ( badoneway ) then
        (
-         if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
-         else if ( oneway:bicycle=no                         ) then 0
+         # Not a oneway street for bikes
+         if ( oneway:bicycle=no ) then 0
+         # No penalty if there is any cycleway going against traffic
+         else if ( cycleway=opposite|opposite_lane|opposite_track ) then 0
+         else if ( cycleway:right=opposite|opposite_lane|opposite_track ) then 0
+         else if ( cycleway:left=opposite|opposite_lane|opposite_track ) then 0
+         # Otherwise, check the value of oneway:bicycle
+         else if ( and ( not reversedirection=yes ) oneway:bicycle=yes|no ) then 0
+         # No penalty if there is any left cycleway in opposite direction
+         else if ( and reversedirection=yes cycleway:left:oneway=-1|no ) then 0
+         else if ( and ( not reversedirection=yes ) cycleway:left:oneway=yes|no ) then 0
+         # No penalty if there is any right cycleway in opposite direction
+         else if ( and reversedirection=yes cycleway:right:oneway=-1|no ) then 0
+         else if ( and ( not reversedirection=yes ) cycleway:right:oneway=yes|no ) then 0
+         # Other cases
          else if ( highway=primary|primary_link              ) then 50
          else if ( highway=secondary|secondary_link          ) then 30
          else if ( highway=tertiary|tertiary_link            ) then 20


### PR DESCRIPTION
Should fix #203 from #123.
I was not be able to manage cycleway=opposite_share_busway since it's not in the database.
I don't know how to add it.
https://wiki.openstreetmap.org/wiki/Tag:cycleway%3Dshare_busway