### PR TITLE
add `dummyUsage` to certain profiles

### DIFF
--- a/misc/profiles2/fastbike-verylowtraffic.brf
+++ b/misc/profiles2/fastbike-verylowtraffic.brf
@@ -331,6 +331,8 @@ assign classifiermask
                       add multiply islinktype     8
                           multiply isgoodforcars 16
 
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node  # following code refers to node tags
 

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -260,6 +260,8 @@ assign classifiermask add          isbadoneway
                       add multiply islinktype     8
                           multiply isgoodforcars 16
 
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node  # following code refers to node tags
 

--- a/misc/profiles2/hiking-beta.brf
+++ b/misc/profiles2/hiking-beta.brf
@@ -237,7 +237,10 @@ assign costfactor
   switch highway=tertiary|tertiary_link|unclassified      switch ismuddy 2.0  switch iswet  switch issidewalk 1.4 1.7
 												                                            switch issidewalk 1.7 2.0
 
-  add cost_of_unknown ( switch ismuddy 0.5 0.0 ) 
+  add cost_of_unknown ( switch ismuddy 0.5 0.0 )
+
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node  # following code refers to node tags
 

--- a/misc/profiles2/moped.brf
+++ b/misc/profiles2/moped.brf
@@ -144,6 +144,8 @@ assign classifiermask add          isbadoneway
                       add multiply islinktype     8
                           multiply isgoodforcars 16
 
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node  # following code refers to node tags
 

--- a/misc/profiles2/shortest.brf
+++ b/misc/profiles2/shortest.brf
@@ -114,6 +114,9 @@ assign classifiermask add multiply isroundabout   4
                       add multiply islinktype     8
                           multiply isgoodforcars 16
 
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
+
 ---context:node  # following code refers to node tags
 
 assign defaultaccess

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -301,6 +301,8 @@ assign classifiermask add          isbadoneway
                       add multiply islinktype     8
                           multiply isgoodforcars 16
 
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node  # following code refers to node tags
 

--- a/misc/profiles2/vm-forum-liegerad-schnell.brf
+++ b/misc/profiles2/vm-forum-liegerad-schnell.brf
@@ -396,7 +396,8 @@ assign classifiermask add     isbadoneway
            add multiply islinktype   8
              multiply isgoodforcars 16
 
-
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node # following code refers to node tags
 

--- a/misc/profiles2/vm-forum-liegerad-schnell.brf
+++ b/misc/profiles2/vm-forum-liegerad-schnell.brf
@@ -396,9 +396,6 @@ assign classifiermask add     isbadoneway
            add multiply islinktype   8
              multiply isgoodforcars 16
 
-# include `smoothness=` tags in the response's WayTags for track analysis
-assign dummyUsage = smoothness=
-
 ---context:node # following code refers to node tags
 
 # Parameter für Knotenpunkte

--- a/misc/profiles2/vm-forum-velomobil-schnell.brf
+++ b/misc/profiles2/vm-forum-velomobil-schnell.brf
@@ -396,7 +396,8 @@ assign classifiermask add     isbadoneway
            add multiply islinktype   8
              multiply isgoodforcars 16
 
-
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
 
 ---context:node # following code refers to node tags
 

--- a/misc/profiles2/vm-forum-velomobil-schnell.brf
+++ b/misc/profiles2/vm-forum-velomobil-schnell.brf
@@ -396,9 +396,6 @@ assign classifiermask add     isbadoneway
            add multiply islinktype   8
              multiply isgoodforcars 16
 
-# include `smoothness=` tags in the response's WayTags for track analysis
-assign dummyUsage = smoothness=
-
 ---context:node # following code refers to node tags
 
 # Parameter für Knotenpunkte


### PR DESCRIPTION
If BRouter calculates a route with a cycling or hiking profile,
the `smoothness` tag is included in the response. That enables
a statistical analysis for the calculated route (distribution of
smoothness tags by distance).

See the analysis sidebar at https://brouter.m11n.de/ for an example.

References: 

- #249 
- nrenner/brouter-web#45