### PR TITLE
fix/unify the file extensions used in map creator

### DIFF
--- a/brouter-map-creator/src/main/java/btools/mapcreator/NodeCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/NodeCutter.java
@@ -34,7 +34,7 @@ public class NodeCutter extends MapCreatorBase
   {
     init( nodeTilesOut );
 
-    new NodeIterator( this, true ).processDir( nodeTilesIn, ".tlf" );
+    new NodeIterator( this, true ).processDir( nodeTilesIn, ".ntl" );
   }
 
   @Override

--- a/brouter-map-creator/src/main/java/btools/mapcreator/NodeFilter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/NodeFilter.java
@@ -48,7 +48,7 @@ public class NodeFilter extends MapCreatorBase
     new WayIterator( this, false ).processFile( wayFileIn );
 
     // finally filter all node files
-    new NodeIterator( this, true ).processDir( nodeTilesIn, ".tls" );
+    new NodeIterator( this, true ).processDir( nodeTilesIn, ".ntl" );
   }
 
   @Override

--- a/brouter-map-creator/src/main/java/btools/mapcreator/WayCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/WayCutter.java
@@ -33,7 +33,7 @@ public class WayCutter extends MapCreatorBase
   {
     init( wayTilesOut );
 
-    new NodeIterator( this, false ).processDir( nodeTilesIn, ".tlf" );
+    new NodeIterator( this, false ).processDir( nodeTilesIn, ".ntl" );
 
     // *** finally process the way-file, cutting into pieces
     new WayIterator( this, true ).processFile( wayFileIn );


### PR DESCRIPTION
Creating routing data files (`*.rd5`) isn't possible at the moment:

The "node tiles" are created in `OsmCutter` with file extensions
`.ntl` ([source](https://github.com/abrensch/brouter/blob/master/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java#L341))

In later steps the node tiles are loaded. That fails in the current
version, because different file extensions are used:

- `NodeCutter` tries to load node tiles with `.tlf` extension ([source](https://github.com/abrensch/brouter/blob/master/brouter-map-creator/src/main/java/btools/mapcreator/NodeCutter.java#L37))
- `NodeFilter` tries to load node tiles with `.tls` extension ([source](https://github.com/abrensch/brouter/blob/master/brouter-map-creator/src/main/java/btools/mapcreator/NodeFilter.java#L51))
- `WayCutter` tries to load node tiles with `.tlf` extension ([source](https://github.com/abrensch/brouter/blob/master/brouter-map-creator/src/main/java/btools/mapcreator/WayCutter.java#L36))

This commit changes the file extensions used when loading the
node tiles to `.ntl` in the mentioned files.
