### PR TITLE
Consider sett as paved in trekking.brf & fastbike.brf

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -57,7 +57,7 @@ assign turnInstructionRoundabouts   = true  # %turnInstructionRoundabouts% | Set
 assign any_cycleroute or route_bicycle_icn=yes or route_bicycle_ncn=yes or route_bicycle_rcn=yes route_bicycle_lcn=yes
 assign nodeaccessgranted or any_cycleroute lcn=yes
 
-assign ispaved or surface=paved or surface=asphalt or surface=concrete surface=paving_stones
+assign ispaved or surface=paved or surface=asphalt or surface=concrete or surface=paving_stones surface=sett
 assign isunpaved not or surface= or ispaved or surface=fine_gravel surface=cobblestone
 
 assign turncost = if junction=roundabout then 0

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -66,7 +66,7 @@ assign is_ldcr =
      else any_cycleroute
 
 assign isbike = or bicycle_road=yes or bicycle=yes or or bicycle=permissive bicycle=designated lcn=yes
-assign ispaved = surface=paved|asphalt|concrete|paving_stones
+assign ispaved = surface=paved|asphalt|concrete|paving_stones|sett
 assign isunpaved = not or surface= or ispaved surface=fine_gravel|cobblestone
 assign probablyGood = or ispaved and ( or isbike highway=footway ) not isunpaved
 


### PR DESCRIPTION
add "sett" as a paved surface (often nicer for bikes than paving_stones)
otherwise, sett surfaces tend to be avoided in routing, while it is usually smooth
even for thin wheels