### PR TITLE
Docker image for creating routing data

### DIFF
--- a/misc/scripts/mapcreation/Dockerfile
+++ b/misc/scripts/mapcreation/Dockerfile
@@ -31,5 +31,10 @@ COPY --from=build /osmosis-src/lib/default/osmosis-osm-binary-0.48.3.jar /broute
 COPY --from=build /brouter-build/misc/pbfparser/pbfparser.jar /brouter/pbfparser/pbfparser.jar
 COPY misc/scripts/mapcreation/process_pbf_planet_docker.sh /brouter/process_pbf_planet_docker.sh
 
+VOLUME ["/brouter-tmp"]
+VOLUME ["/planet"]
+VOLUME ["/srtm"]
+VOLUME ["/segments"]
+
 WORKDIR /brouter
 ENTRYPOINT ["/bin/bash", "/brouter/process_pbf_planet_docker.sh"]

--- a/misc/scripts/mapcreation/Dockerfile
+++ b/misc/scripts/mapcreation/Dockerfile
@@ -8,11 +8,11 @@ RUN mvn package -pl brouter-server -am -Dmaven.javadoc.skip=true
 
 RUN apt-get update \
     && apt-get install -y ca-certificates curl \
-    && mkdir -p /osmosis-src && curl --location --output /osmosis-src/osmosis-0.48.0.tgz https://github.com/openstreetmap/osmosis/releases/download/0.48.0/osmosis-0.48.0.tgz \
-    && tar -xvzf /osmosis-src/osmosis-0.48.0.tgz -C /osmosis-src
+    && mkdir -p /osmosis-src && curl --location --output /osmosis-src/osmosis-0.48.3.tgz https://github.com/openstreetmap/osmosis/releases/download/0.48.3/osmosis-0.48.3.tgz \
+    && tar -xvzf /osmosis-src/osmosis-0.48.3.tgz -C /osmosis-src
 
 WORKDIR /brouter-build/misc/pbfparser
-RUN javac -d . -cp "/brouter-build/brouter-server/target/brouter-server-1.6.1-jar-with-dependencies.jar:/osmosis-src/lib/default/protobuf-java-3.11.4.jar:/osmosis-src/lib/default/osmosis-osm-binary-0.48.0.jar" *.java \
+RUN javac -d . -cp "/brouter-build/brouter-server/target/brouter-server-1.6.1-jar-with-dependencies.jar:/osmosis-src/lib/default/protobuf-java-3.12.2.jar:/osmosis-src/lib/default/osmosis-osm-binary-0.48.3.jar" *.java \
     && jar cf pbfparser.jar btools/**/*.class
 
 # Step 2: collect needed JARs + processing script and run script
@@ -26,8 +26,8 @@ WORKDIR /brouter
 COPY misc/profiles2/* /brouter/
 COPY misc/pbfparser /brouter/pbfparser
 COPY --from=build /brouter-build/brouter-server/target/brouter-server-1.6.1-jar-with-dependencies.jar brouter.jar
-COPY --from=build /osmosis-src/lib/default/protobuf-java-3.11.4.jar /brouter/pbfparser/protobuf.jar
-COPY --from=build /osmosis-src/lib/default/osmosis-osm-binary-0.48.0.jar /brouter/pbfparser/osmosis.jar
+COPY --from=build /osmosis-src/lib/default/protobuf-java-3.12.2.jar /brouter/pbfparser/protobuf.jar
+COPY --from=build /osmosis-src/lib/default/osmosis-osm-binary-0.48.3.jar /brouter/pbfparser/osmosis.jar
 COPY --from=build /brouter-build/misc/pbfparser/pbfparser.jar /brouter/pbfparser/pbfparser.jar
 COPY misc/scripts/mapcreation/process_pbf_planet_docker.sh /brouter/process_pbf_planet_docker.sh
 

--- a/misc/scripts/mapcreation/Dockerfile
+++ b/misc/scripts/mapcreation/Dockerfile
@@ -1,0 +1,35 @@
+# Step 1: Build BRouter and dependencies (Osmosis, PbfParser)
+
+FROM maven:3-jdk-8 as build
+RUN mkdir -p /brouter-build
+WORKDIR /brouter-build
+COPY . .
+RUN mvn package -pl brouter-server -am -Dmaven.javadoc.skip=true
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl \
+    && mkdir -p /osmosis-src && curl --location --output /osmosis-src/osmosis-0.48.0.tgz https://github.com/openstreetmap/osmosis/releases/download/0.48.0/osmosis-0.48.0.tgz \
+    && tar -xvzf /osmosis-src/osmosis-0.48.0.tgz -C /osmosis-src
+
+WORKDIR /brouter-build/misc/pbfparser
+RUN javac -d . -cp "/brouter-build/brouter-server/target/brouter-server-1.6.1-jar-with-dependencies.jar:/osmosis-src/lib/default/protobuf-java-3.11.4.jar:/osmosis-src/lib/default/osmosis-osm-binary-0.48.0.jar" *.java \
+    && jar cf pbfparser.jar btools/**/*.class
+
+# Step 2: collect needed JARs + processing script and run script
+
+FROM openjdk:8-jdk-buster
+
+RUN apt-get update \
+    && apt-get install -y osmctools
+
+WORKDIR /brouter
+COPY misc/profiles2/* /brouter/
+COPY misc/pbfparser /brouter/pbfparser
+COPY --from=build /brouter-build/brouter-server/target/brouter-server-1.6.1-jar-with-dependencies.jar brouter.jar
+COPY --from=build /osmosis-src/lib/default/protobuf-java-3.11.4.jar /brouter/pbfparser/protobuf.jar
+COPY --from=build /osmosis-src/lib/default/osmosis-osm-binary-0.48.0.jar /brouter/pbfparser/osmosis.jar
+COPY --from=build /brouter-build/misc/pbfparser/pbfparser.jar /brouter/pbfparser/pbfparser.jar
+COPY misc/scripts/mapcreation/process_pbf_planet_docker.sh /brouter/process_pbf_planet_docker.sh
+
+WORKDIR /brouter
+ENTRYPOINT ["/bin/bash", "/brouter/process_pbf_planet_docker.sh"]

--- a/misc/scripts/mapcreation/process_pbf_planet_docker.sh
+++ b/misc/scripts/mapcreation/process_pbf_planet_docker.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Set to 0 to skip updating the planet file
+PLANET_UPDATE=${PLANET_UPDATE:-1}
+JAVA_OPTS="${JAVA_OPTS:--Xmx6144M -Xms6144M -Xmn256M}"
+PLANET_SOURCE="/planet/$PLANET"
+# add an additional sub-directory to prevent accidentally deleting stuff
+# for the case that a non-empty directory was mounted into the container
+TEMP_BASE="/brouter-tmp/tmp"
+
+echo "$(date) Updating Planet file ..."
+
+if [[ "$PLANET_UPDATE" = "1" ]]; then
+    rm -vf "/planet/$PLANET.old.osm.pbf"
+    rm -vf "/planet/$PLANET.new.osm.pbf"
+    touch /planet/mapsnapshottime.txt
+    [[ -d /brouter-tmp/osmupdate ]] || mkdir -p /brouter-tmp/osmupdate
+    /usr/bin/osmupdate \
+        --verbose \
+        --drop-author \
+        --compression-level=1 \
+        --tempfiles="/brouter-tmp/osmupdate/" \
+        --keep-tempfiles \
+        "/planet/$PLANET" \
+        "/planet/$PLANET.new.osm.pbf" \
+        || { echo "Updating Planet failed" ; exit 2 ; }
+    PLANET_SOURCE="/planet/$PLANET.new.osm.pbf"
+fi
+
+[[ -d "$TEMP_BASE" ]] && rm -rf "$TEMP_BASE"
+
+mkdir -v "$TEMP_BASE"
+cd "$TEMP_BASE"
+mkdir -v nodetiles
+mkdir -v waytiles
+mkdir -v waytiles55
+mkdir -v nodes55
+
+echo "$(date) Running OsmFastCutter ..."
+
+java $JAVA_OPTS \
+    -cp /brouter/pbfparser/pbfparser.jar:/brouter/brouter.jar:/brouter/pbfparser/osmosis.jar:/brouter/pbfparser/protobuf.jar \
+    -Ddeletetmpfiles=false \
+    -DuseDenseMaps=true \
+    btools.mapcreator.OsmFastCutter \
+    /brouter/lookups.dat \
+    nodetiles \
+    waytiles \
+    nodes55 \
+    waytiles55 \
+    bordernids.dat \
+    relations.dat \
+    restrictions.dat \
+    /brouter/all.brf \
+    /brouter/trekking.brf \
+    /brouter/softaccess.brf \
+    "$PLANET_SOURCE"
+
+if [[ "$PLANET_UPDATE" = "1" ]]; then
+    mv "/planet/$PLANET" "/planet/$PLANET.old.osm.pbf"
+    mv "/planet/$PLANET.new.osm.pbf" "/planet/$PLANET"
+fi
+
+echo "$(date) Running PosUnifier ..."
+
+mkdir unodes55
+java $JAVA_OPTS \
+    -cp /brouter/brouter.jar \
+    -Ddeletetmpfiles=true \
+    -DuseDenseMaps=true \
+    btools.mapcreator.PosUnifier \
+    nodes55 \
+    unodes55 \
+    bordernids.dat \
+    bordernodes.dat \
+    /srtm
+
+echo "$(date) Running WayLinker ..."
+
+java $JAVA_OPTS \
+    -cp /brouter/brouter.jar \
+    -DuseDenseMaps=true \
+    -DskipEncodingCheck=true \
+    btools.mapcreator.WayLinker \
+    unodes55 \
+    waytiles55 \
+    bordernodes.dat \
+    restrictions.dat \
+    /brouter/lookups.dat \
+    /brouter/all.brf \
+    /segments \
+    rd5
+
+if [[ -f /planet/mapsnapshottime.txt ]]; then
+    touch -r /planet/mapsnapshottime.txt /segments/*.rd5
+fi
+
+echo "$(date) Finished."


### PR DESCRIPTION
This changeset adds a Dockerfile which allows building an image from scratch that contains everything needed to create the routing data files (*.rd5).

The documentation in `mapcreation.md` is updated as well and provides detailed instructions on how to use the Docker image.

(This Docker image is used by me to create world-wide routing data for my BRouter-Web instance for 8 weeks now at a rate of 4 builds per day)