### PR TITLE
add `highway=razed` to lookup table

### DIFF
--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -36,6 +36,7 @@ highway;0000002133 corridor
 highway;0000002093 crossing
 highway;0000001440 bus_stop
 highway;0000001274 yes
+highway;0000000679 razed
 highway;0000000679 unsurfaced
 highway;0000000108 byway
 highway;0000000037 driveway


### PR DESCRIPTION
#293 revealed that `highway=razed` is missing in `lookups.dat`.

This pull-request adds the missing entry. Taginfo counts [679 occurrences](https://taginfo.openstreetmap.org/search?q=highway%3Drazed) of `highway=razed` in OSM as of today.