### PR TITLE
Complete voice hints and add times to GeoJSON

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -19,8 +19,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import btools.mapaccess.MatchedWaypoint;
 import btools.mapaccess.OsmPos;
@@ -710,6 +713,8 @@ public final class OsmTrack
 
   public String formatAsGeoJson()
   {
+    int turnInstructionMode = voiceHints != null ? voiceHints.turnInstructionMode : 0;
+
     StringBuilder sb = new StringBuilder( 8192 );
 
     sb.append( "{\n" );
@@ -731,7 +736,20 @@ public final class OsmTrack
       sb.append( "        \"voicehints\": [\n" );
       for( VoiceHint hint: voiceHints.list )
       {
-        sb.append( "          [" ).append( hint.indexInTrack ).append( ',' ).append( hint.getCommand() ).append( ',' ).append( hint.getExitNumber() ).append( "],\n" );
+        sb.append( "          [" );
+        sb.append( hint.indexInTrack );
+        sb.append( ',' ).append( hint.getCommand() );
+        sb.append( ',' ).append( hint.getExitNumber() );
+        sb.append( ',' ).append( hint.distanceToNext );
+        sb.append( ',' ).append( (int) hint.angle );
+
+        // not always include geometry because longer and only needed for comment style
+        if ( turnInstructionMode == 4 ) // comment style
+        {
+          sb.append( ",\"" ).append( hint.formatGeometry() ).append( "\"" );
+        }
+
+        sb.append( "],\n" );
       }
       sb.deleteCharAt( sb.lastIndexOf( "," ) );
       sb.append( "        ],\n" );
@@ -746,7 +764,7 @@ public final class OsmTrack
         {
           sb.append( "          [" ).append( sp.get(i) ).append( i> 0 ? "],\n" : "]\n" );
         }
-        sb.append( "        ]\n" );
+        sb.append( "        ],\n" );
       }
     }
     else // ... otherwise traditional message list
@@ -758,9 +776,24 @@ public final class OsmTrack
         sb.append( "          [\"" ).append( m.replaceAll( "\t", "\", \"" ) ).append( "\"],\n" );
       }
       sb.deleteCharAt( sb.lastIndexOf( "," ) );
-      sb.append( "        ]\n" );
+      sb.append( "        ],\n" );
     }
+
+    if ( getTotalSeconds() > 0 ) {
+      sb.append( "        \"times\": [" );
+      DecimalFormat decimalFormat = (DecimalFormat) NumberFormat.getInstance( Locale.ENGLISH );
+      decimalFormat.applyPattern( "0.###" );
+      for ( OsmPathElement n : nodes ) {
+        sb.append( decimalFormat.format( n.getTime() ) ).append( "," );
+      }
+      sb.deleteCharAt( sb.lastIndexOf( "," ) );
+      sb.append( "]\n" );
+    } else {
+      sb.deleteCharAt( sb.lastIndexOf( "," ) );
+    }
+
     sb.append( "      },\n" );
+
     if ( iternity != null )
     {
       sb.append( "      \"iternity\": [\n" );


### PR DESCRIPTION
Extends the already existing `voicehints` property in the GeoJSON format with the remaining values to pass full voice hint information to the client.

Also adds a new `times` property with all node time values. The GeoJSON spec explicitly does not allow additional values in the coordinates array anymore, so the times are passed as a separate array in properties that corresponds with the coordinates array. This will allow to e.g. [plot elevation over time rather than distance](https://groups.google.com/g/osm-android-bikerouting/c/u4K6RTmhzhI/m/oDAXHE_vBQAJ) and adding [time tags to GPX](https://github.com/abrensch/brouter/issues/221) (also [brouter-web#196](https://github.com/nrenner/brouter-web/issues/196)), voice hint times are looked up by `indexInTrack`.

The background is to enable track formatting in the client, accepting some code duplication, see discussion in [brouter-web#68](https://github.com/nrenner/brouter-web/issues/68) and previous discussions in #91, #196, [brouter-web#226](https://github.com/nrenner/brouter-web/pull/226), #188. 

