### PR TITLE
Added time and energy to response messages.

### DIFF
--- a/brouter-core/src/main/java/btools/router/MessageData.java
+++ b/brouter-core/src/main/java/btools/router/MessageData.java
@@ -55,7 +55,9 @@ final class MessageData implements Cloneable
          + "\t" + linknodecost
          + "\t" + linkinitcost
          + "\t" + wayKeyValues
-         + "\t" + ( nodeKeyValues == null ? "" : nodeKeyValues );
+         + "\t" + ( nodeKeyValues == null ? "" : nodeKeyValues )
+            + "\t" + time
+            + "\t" + energy;
   }
 
   void add( MessageData d )

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -34,7 +34,7 @@ import btools.util.StringUtils;
 public final class OsmTrack
 {
   // csv-header-line
-  private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags";
+  private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags\tTime\tEnergy";
 
   public MatchedWaypoint endPoint;
   public long[] nogoChecksums;


### PR DESCRIPTION
The purpose of this little change is to include time and energy in messages used for voice hints generation. This is meant to allow clients: 1) indicate time to the next voice hint (manoeuvre), 2) (Our interest) Greatly improve the way Locus handles ETA of planned tracks.