### PR TITLE
Update river profile

### DIFF
--- a/misc/profiles2/river.brf
+++ b/misc/profiles2/river.brf
@@ -13,7 +13,7 @@ assign turncost 0
 assign initialcost 0
 
 assign costfactor
-  switch or waterway=canal or waterway=river waterway=lock_gate  1
+  switch or waterway=canal or waterway=river or waterway=fairway waterway=lock_gate  1
   100000
 
 ---context:node  # following code refers to node tags


### PR DESCRIPTION
Add support for routing over fairways which are used for navigable routes in a body of water
(where waterway=river or waterway=canal are not appropriate).

---

The current river profile works fine for (water)ways which are tagged with waterway=river or waterway=canal, but not for  waterway=fairway ([OSM  wiki](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dfairway)).

Example where routing does not work with the current profile, but where this change gives the desired result: 
http://brouter.de/brouter-web/#map=13/52.9304/5.6102/standard&lonlats=5.630567,52.936295;5.641656,52.899167&profile=river

This supports boat and canoe routing just as  #202, but concerns navigating over linear features in OSM instead of navigating over  bodies of water which do not have linear waterway features in OSM.