### PR TITLE
Migrate to gradle part 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ A full documentation on how to set this up is available at
 
 ### Build and Install
 
-To compile BRouter (including the BRouter Android app), add a file 'local.properties' to main folder with your Android path (Windows sample)
+To compile BRouter including the BRouter Android app, add a file 'local.properties' to main folder with your Android path 
 
 ```
-sdk.dir=D\:\\Android\\android-sdk
+sdk.dir=<your/android/sdk/path>
 ```
 
 

--- a/brouter-map-creator/build.gradle
+++ b/brouter-map-creator/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'application'
 }
 
-version = '1.6.1'
 
 application {
     // Gradles 'application' plugin requires one main class; since we have multiple ones, just specify

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion 30
 
         versionCode 41
-        versionName "1.6.1"
+        versionName version
 
         setProperty("archivesBaseName","BRouterApp." + defaultConfig.versionName)
 

--- a/brouter-server/build.gradle
+++ b/brouter-server/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'application'
 }
 
-version = '1.6.1'
 
 application {
     mainClass.set('btools.server.BRouter')

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+
+   
+
+
 buildscript {
-    
+	
     repositories {
         mavenCentral()
         google()
@@ -16,6 +20,8 @@ buildscript {
 }
 
 allprojects {
+    version  "1.6.1"
+	
     repositories {
         mavenCentral()
         google()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,7 @@
 rootProject.name='brouter'
-include ':brouter-routing-app', ':brouter-mapaccess', ':brouter-core', ':brouter-util', ':brouter-expressions', ':brouter-codec', ':brouter-map-creator', ':brouter-server'
+if (file('local.properties').exists()) {
+	include ':brouter-routing-app'
+} else {
+    println "Note: To include Android app add 'local.properties' with 'sdk.dir=...' "
+}
+include ':brouter-mapaccess', ':brouter-core', ':brouter-util', ':brouter-expressions', ':brouter-codec', ':brouter-map-creator', ':brouter-server'


### PR DESCRIPTION
Removed the error message when no Android SDK is defined.
Add only one version code in main gradle file for all sub projects.