### PR TITLE
Update for Android 11 part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,4 @@ misc/customprofiles
 *.BAK
 .classpath
 .project
-*.iml
 !/.idea/runConfigurations

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -123,6 +123,15 @@ public final class RoutingContext
   {
     BExpressionContext expctxGlobal = expctxWay; // just one of them...
 
+    if (keyValues != null) {
+      // add parameter to context
+      for (Map.Entry<String, String> e : keyValues.entrySet()) {
+        float f = Float.parseFloat(e.getValue());
+        expctxWay.setVariableValue(e.getKey(), f, false );
+        expctxNode.setVariableValue(e.getKey(), f, false );
+      }
+    }
+
     setModel( expctxGlobal._modelClass );
 
     downhillcostdiv = (int)expctxGlobal.getVariableValue( "downhillcost", 0.f );

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -798,6 +798,13 @@ public abstract class BExpressionContext implements IByteArrayUnifier
     return result;
   }
 
+  public void setVariableValue(String name, float value, boolean create ) {
+    Integer num = variableNumbers.get( name );
+    if ( num != null )
+    {
+      variableData[num.intValue()] = value;
+    }
+  }
 
   public float getVariableValue( String name, float defaultValue )
   {

--- a/brouter-routing-app/src/main/AndroidManifest.xml
+++ b/brouter-routing-app/src/main/AndroidManifest.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="btools.routingapp">
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="btools.routingapp">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <application android:icon="@drawable/icon" android:label="@string/app_name" android:allowBackup="true">
+    <application
+        android:icon="@drawable/icon"
+        android:label="@string/app_name"
+        android:allowBackup="true">
         <activity android:name=".BRouterActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait" android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
@@ -17,13 +23,14 @@
         </activity>
         <activity android:name=".BInstallerActivity"
             android:label="@string/app_name"
-            android:screenOrientation="landscape" android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+            android:screenOrientation="landscape"
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
         </activity>
         <service
             android:exported="true"
             android:name=".BRouterService"
             android:enabled="true"
-            android:process=":brouter_service">
-        </service>
+            android:process=":brouter_service" />
+
     </application>
 </manifest>

--- a/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
+++ b/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
@@ -6,10 +6,10 @@ interface IBRouterService {
 
     //param params--> Map of params:
     //  "pathToFileResult"-->String with the path to where the result must be saved, including file name and extension
-    //                    -->if null, the track is passed via the return argument
+    //                    -->if null, the track is passed via the return argument, this should be default when Android Q or later
     //  "maxRunningTime"-->String with a number of seconds for the routing timeout, default = 60
     //  "turnInstructionFormat"-->String selecting the format for turn-instructions values: osmand, locus
-    //  "trackFormat"-->[kml|gpx] default = gpx
+    //  "trackFormat"-->[kml|gpx|json] default = gpx
     //  "lats"-->double[] array of latitudes; 2 values at least.
     //  "lons"-->double[] array of longitudes; 2 values at least.
     //  "nogoLats"-->double[] array of nogo latitudes; may be null.
@@ -18,8 +18,21 @@ interface IBRouterService {
     //  "fast"-->[0|1]
     //  "v"-->[motorcar|bicycle|foot]
     //  "remoteProfile"--> (String), net-content of a profile. If remoteProfile != null, v+fast are ignored
-    //return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
-    //call in a background thread, heavy task!
+    //
+    //  "lonlats"         = lon,lat|... (unlimited list of lon,lat waypoints separated by |)
+    //  "nogos"           = lon,lat,radius|... (optional, radius in meters)
+    //  "polylines"       = lon,lat,weight|... (unlimited list of lon,lat and weight (optional) separated by |)
+    //  "polygons"        = lon,lat,weight|... (unlimited list of lon,lat and weight (optional) separated by |)
+    //  "profile"         = profile file name without .brf 
+    //  "alternativeidx"  = [0|1|2|3] (optional, default 0)
+    //  "exportWaypoints" = 1 to export them (optional, default is no export)
+    //  "pois"            = lon,lat,name|... (optional)
+    //  "extraParams"     = Bundle key=value list for a profile setup (like "profile:")
+    //  "timode"          = turnInstructionMode [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style] default 0
+
+    // return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
+    //        the resultas string when 'pathToFileResult' is null, this should be default when Android Q or later
+    // call in a background thread, heavy task!
 
     String getTrackFromParams(in Bundle params);
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/AppLogger.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/AppLogger.java
@@ -25,7 +25,7 @@ public class AppLogger
         // open logfile if existing
     	File sd = Environment.getExternalStorageDirectory();
     	if ( sd == null ) return;
-        File debugLog = new File( sd, "Android/data/btools.routingapp/files/brouterapp.txt" );
+        File debugLog = new File( sd, "Android/media/btools.routingapp/brouter/brouterapp.txt" );
         if ( debugLog.exists() )
         {
           debugLogWriter = new FileWriter( debugLog, true );

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
@@ -23,6 +23,7 @@ import android.os.PowerManager.WakeLock;
 import android.os.StatFs;
 import android.speech.tts.TextToSpeech.OnInitListener;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.widget.EditText;
 
 import androidx.core.app.ActivityCompat;
@@ -81,10 +82,12 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
   protected Dialog onCreateDialog( int id )
   {
     AlertDialog.Builder builder;
+    builder = new AlertDialog.Builder( this );
+    builder.setCancelable(false);
+
     switch ( id )
     {
     case DIALOG_SELECTPROFILE_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Select a routing profile" );
       builder.setItems( availableProfiles, new DialogInterface.OnClickListener()
       {
@@ -96,22 +99,30 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_MAINACTION_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Select Main Action" );
-      builder.setItems( new String[]
-      { "Download Manager", "BRouter App" }, new DialogInterface.OnClickListener()
-      {
-        public void onClick( DialogInterface dialog, int item )
-        {
-          if ( item == 0 )
-            startDownloadManager();
-          else
-            showDialog( DIALOG_SELECTPROFILE_ID );
-        }
-      } );
+      builder
+              .setItems( new String[]
+                { "Download Manager", "BRouter App" }, new DialogInterface.OnClickListener()
+                {
+                  public void onClick( DialogInterface dialog, int item )
+                  {
+                    if ( item == 0 )
+                      startDownloadManager();
+                    else
+                      showDialog( DIALOG_SELECTPROFILE_ID );
+                  }
+                }
+                )
+              .setNegativeButton( "Close", new DialogInterface.OnClickListener()
+                {
+                  public void onClick( DialogInterface dialog, int id )
+                  {
+                    finish();
+                  }
+                }
+              );
       return builder.create();
     case DIALOG_SHOW_DM_INFO_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "BRouter Download Manager" )
           .setMessage(
@@ -134,7 +145,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_SHOW_WP_HELP_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "No Waypoint Database found" )
           .setMessage(
@@ -160,7 +170,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_SHOW_API23_HELP_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "Android >=6 limitations" )
           .setMessage(
@@ -183,7 +192,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_SHOW_REPEAT_TIMEOUT_HELP_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "Successfully prepared a timeout-free calculation" )
           .setMessage(
@@ -199,7 +207,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_SHOW_WP_SCANRESULT_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "Waypoint Database " )
           .setMessage( "Found Waypoint-Database(s) for maptool-dir: " + maptoolDirCandidate
@@ -218,7 +225,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_OLDDATAHINT_ID:
-      builder = new AlertDialog.Builder( this );
       builder
           .setTitle( "Local setup needs reset" )
           .setMessage(
@@ -235,7 +241,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
           } );
       return builder.create();
     case DIALOG_ROUTINGMODES_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( message );
       builder.setMultiChoiceItems( routingModes, routingModesChecked, new DialogInterface.OnMultiChoiceClickListener()
       {
@@ -254,7 +259,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_EXCEPTION_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "An Error occured" ).setMessage( errorMessage ).setPositiveButton( "OK", new DialogInterface.OnClickListener()
       {
         public void onClick( DialogInterface dialog, int id )
@@ -264,7 +268,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_TEXTENTRY_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Enter SDCARD base dir:" );
       builder.setMessage( message );
       final EditText input = new EditText( this );
@@ -280,7 +283,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_SELECTBASEDIR_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Choose brouter data base dir:" );
       // builder.setMessage( message );
       builder.setSingleChoiceItems( basedirOptions, 0, new DialogInterface.OnClickListener()
@@ -307,7 +309,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_VIASELECT_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Check VIA Selection:" );
       builder.setMultiChoiceItems( availableVias, getCheckedBooleanArray( availableVias.length ), new DialogInterface.OnMultiChoiceClickListener()
       {
@@ -334,7 +335,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_NOGOSELECT_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Check NoGo Selection:" );
       String[] nogoNames = new String[nogoList.size()];
       for ( int i = 0; i < nogoList.size(); i++ )
@@ -360,7 +360,7 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
     case DIALOG_SHOWRESULT_ID:
       String leftLabel = wpCount < 0 ? ( wpCount != -2 ? "Exit" : "Help") : ( wpCount == 0 ? "Select from" : "Select to/via" );
       String rightLabel = wpCount < 2 ? ( wpCount == -3 ? "Help" : "Server-Mode" ) : "Calc Route";
-      builder = new AlertDialog.Builder( this );
+
       builder.setTitle( title ).setMessage( errorMessage ).setPositiveButton( leftLabel, new DialogInterface.OnClickListener()
       {
         public void onClick( DialogInterface dialog, int id )
@@ -399,7 +399,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_MODECONFIGOVERVIEW_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( "Success" ).setMessage( message ).setPositiveButton( "Exit", new DialogInterface.OnClickListener()
       {
         public void onClick( DialogInterface dialog, int id )
@@ -409,7 +408,6 @@ public class BRouterActivity extends Activity implements OnInitListener, Activit
       } );
       return builder.create();
     case DIALOG_PICKWAYPOINT_ID:
-      builder = new AlertDialog.Builder( this );
       builder.setTitle( wpCount > 0 ? "Select to/via" : "Select from" );
       builder.setItems( availableWaypoints, new DialogInterface.OnClickListener()
       {


### PR DESCRIPTION
This update has some parts for the move to Android 11

- change the inferface #314
- change main folder .../Android/media/btools.routingapp/
- has an own import folder for files like favorites or nogo* gpx
- export json #246
- update all tiles #306
- hardcoded speed #301
- black screen #286


still pending
- new icon brouter-web [286](https://github.com/nrenner/brouter-web/issues/286)
- refreshed profiles
- Android watchdog #277 - no error results during testing
- download manager #271 - no error results during testing
- download rd5 in background #227
- update for lookups.dat and profiles over the air

others
- git workflow: is there someone how can do the move to gradle? I've never done it and doesn't have a test environment.


This version is based on the idea other apps use the interface with a 'pathToFileResult' set to null - so the result comes back as string.
It is still possible to use the interface file driven - in Android 10+. But only if the result path is inside the .../Android/media/btools.routingapp/.. folder. This means to other apps using BRouter file export they have to deal with the Android storage access framework via a document url.

