### PR TITLE
GitHub Workflow: Provide Artifacts (APK & ZIP)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,11 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'zulu'
         cache: gradle
+    - name: Create local.properties
+      run: touch local.properties
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,3 +26,8 @@ jobs:
       run: touch local.properties
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Upload ZIP
+      uses: actions/upload-artifact@v2
+      with:
+        name: ZIP
+        path: brouter-server/build/distributions/brouter-*.zip

--- a/brouter-server/build.gradle
+++ b/brouter-server/build.gradle
@@ -30,7 +30,8 @@ application {
 }
 
 distZip {
-     archiveFileName = 'brouter-' + project.version + '.zip'
+    dependsOn fatJar
+    archiveFileName = 'brouter-' + project.version + '.zip'
 }
 
 distributions {


### PR DESCRIPTION
To simplify testing the result of each build is attached as an artifact to the workflow run.

It seems like the GitHub runners have the android SDK installed so it's possible to provide the APKs in addition to the brouter.zip. The GitHub UI is a bit [quirky](https://github.com/actions/upload-artifact/issues/3#issuecomment-743985727) and the brouter.zip download is zipped again before the download.