### PR TITLE
Set preserveLegacyExternalStorage for easier upgrades

### DIFF
--- a/brouter-routing-app/src/main/AndroidManifest.xml
+++ b/brouter-routing-app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:preserveLegacyExternalStorage="true">
         <activity android:name=".BRouterActivity"
             android:label="@string/app_name"
             android:exported="true"


### PR DESCRIPTION
When updating from a previous app which has it's basedir on e.g.
/sdcard/emulated/0/brouter it's still possible to access the files on
android 11 with this flag.