### PR TITLE
change manifest, add dependson

### DIFF
--- a/brouter-server/build.gradle
+++ b/brouter-server/build.gradle
@@ -13,11 +13,15 @@ application {
             attributes "Main-Class": getMainClass(), "Implementation-Version": project.version
         }
     }
+	
     task fatJar(type: Jar) {
         archiveFileName = 'brouter-' + project.version + '-all.jar'
 
-        manifest.from jar.manifest
+        manifest {
+            attributes "Main-Class": getMainClass(), "Implementation-Version": project.version
+        }
         classifier = 'all'
+        dependsOn configurations.runtimeClasspath
         from {
             configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
         } {


### PR DESCRIPTION
Enable the pure run of the jar file. 
Like:
`
$java -jar brouter-1.6.2-all.jar
`

Add a dependsOn to remove some warnings.
