### PR TITLE
Restore access to legacy storage when targeting older SDK

### DIFF
--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -17,6 +17,8 @@ android {
         setProperty("archivesBaseName","BRouterApp." + defaultConfig.versionName)
 
         minSdkVersion 14
+        
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     sourceSets.main.assets.srcDirs += new File(project.buildDir, 'assets')
@@ -99,6 +101,10 @@ dependencies {
     implementation project(':brouter-expressions')
     implementation project(':brouter-util')
 
+    testImplementation 'junit:junit:4.13.2'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 task generateProfiles(type: Exec) {

--- a/brouter-routing-app/src/androidTest/java/btools/routingapp/BRouterActivityTest.java
+++ b/brouter-routing-app/src/androidTest/java/btools/routingapp/BRouterActivityTest.java
@@ -1,0 +1,47 @@
+package btools.routingapp;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import android.os.Build;
+import android.os.Environment;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class BRouterActivityTest {
+  @Rule
+  public ActivityScenarioRule<BRouterActivity> rule = new ActivityScenarioRule<>(BRouterActivity.class);
+
+  @Test
+  public void storageDirectories() {
+    ActivityScenario<BRouterActivity> scenario = rule.getScenario();
+    scenario.onActivity(activity -> {
+      List<File> storageDirectories = activity.getStorageDirectories();
+
+      // Before Android Q (10) legacy storage access is possible
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        assertThat(storageDirectories, hasItem(Environment.getExternalStorageDirectory()));
+      }
+
+      // When targeting older SDK we can access legacy storage on any android version
+      if (activity.getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.Q) {
+        assertThat(storageDirectories, hasItem(Environment.getExternalStorageDirectory()));
+      }
+
+      assertThat(storageDirectories, not(empty()));
+    });
+  }
+
+}

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
@@ -596,8 +596,7 @@ public class BRouterActivity extends Activity implements ActivityCompat.OnReques
       }
     }
 
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R
-        && checkExternalStorageWritable()) {
+    if (checkExternalStorageWritable()) {
       res.add(Environment.getExternalStorageDirectory());
     }
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
@@ -127,7 +127,7 @@ public class BRouterView extends View {
             // don't ask twice
             String version = "v" + getContext().getString(R.string.app_version);
             File vFile = new File(brd, "profiles2/"+version );
-            if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.Q
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
                 && vFile.exists()) {
               startSetup(baseDir, false);
               return;


### PR DESCRIPTION
As discussed in https://github.com/abrensch/brouter/issues/379#issuecomment-1002991547 changes which restore access for older target SDK.

This also adds some instrumented tests which can be run against emulator or devices. To run those tests use either Android Studio or `./gradlew connectedApi30DebugAndroidTest` or similar.