### PR TITLE
Use layouts in DownloadManager

### DIFF
--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -93,6 +93,7 @@ android {
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "androidx.constraintlayout:constraintlayout:2.1.2"
 
     implementation project(':brouter-mapaccess')
     implementation project(':brouter-core')

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -19,7 +19,7 @@ public class BInstallerActivity extends Activity {
 
   private static final int DIALOG_CONFIRM_DELETE_ID = 1;
   private BInstallerView mBInstallerView;
-  private DownloadReceiver myReceiver;
+  private DownloadReceiver downloadReceiver;
 
   static public long getAvailableSpace(String baseDir) {
     StatFs stat = new StatFs(baseDir);
@@ -49,8 +49,8 @@ public class BInstallerActivity extends Activity {
     IntentFilter filter = new IntentFilter();
     filter.addAction(DOWNLOAD_ACTION);
 
-    myReceiver = new DownloadReceiver();
-    registerReceiver(myReceiver, filter);
+    downloadReceiver = new DownloadReceiver();
+    registerReceiver(downloadReceiver, filter);
   }
 
   @Override
@@ -61,7 +61,7 @@ public class BInstallerActivity extends Activity {
   @Override
   public void onDestroy() {
     super.onDestroy();
-    if (myReceiver != null) unregisterReceiver(myReceiver);
+    if (downloadReceiver != null) unregisterReceiver(downloadReceiver);
     System.exit(0);
   }
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -11,8 +11,6 @@ import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.PowerManager;
-import android.os.PowerManager.WakeLock;
 import android.os.StatFs;
 
 public class BInstallerActivity extends Activity {
@@ -21,8 +19,6 @@ public class BInstallerActivity extends Activity {
 
   private static final int DIALOG_CONFIRM_DELETE_ID = 1;
   private BInstallerView mBInstallerView;
-  private PowerManager mPowerManager;
-  private WakeLock mWakeLock;
   private DownloadReceiver myReceiver;
 
   static public long getAvailableSpace(String baseDir) {
@@ -40,13 +36,6 @@ public class BInstallerActivity extends Activity {
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    // Get an instance of the PowerManager
-    mPowerManager = (PowerManager) getSystemService(POWER_SERVICE);
-
-    // Create a bright wake lock
-    mWakeLock = mPowerManager.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, getClass()
-      .getName());
-
     setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
     mBInstallerView = new BInstallerView(this);
@@ -56,12 +45,6 @@ public class BInstallerActivity extends Activity {
   @Override
   protected void onResume() {
     super.onResume();
-    /*
-     * when the activity is resumed, we acquire a wake-lock so that the
-     * screen stays on, since the user will likely not be fiddling with the
-     * screen or buttons.
-     */
-    mWakeLock.acquire();
 
     IntentFilter filter = new IntentFilter();
     filter.addAction(DOWNLOAD_ACTION);
@@ -73,12 +56,6 @@ public class BInstallerActivity extends Activity {
   @Override
   protected void onPause() {
     super.onPause();
-
-
-    super.onPause();
-
-    mWakeLock.release();
-
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -28,7 +28,7 @@ public class BInstallerActivity extends Activity {
   private PowerManager mPowerManager;
   private WakeLock mWakeLock;
   private DownloadReceiver myReceiver;
-  private final Set<Integer> dialogIds = new HashSet<Integer>();
+  private final Set<Integer> dialogIds = new HashSet<>();
 
   /**
    * Called when the activity is first created.
@@ -120,10 +120,10 @@ public class BInstallerActivity extends Activity {
   }
 
   private void showNewDialog(int id) {
-    if (dialogIds.contains(Integer.valueOf(id))) {
+    if (dialogIds.contains(id)) {
       removeDialog(id);
     }
-    dialogIds.add(Integer.valueOf(id));
+    dialogIds.add(id);
     showDialog(id);
   }
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -38,8 +38,8 @@ public class BInstallerActivity extends Activity {
 
     setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
-    mBInstallerView = new BInstallerView(this);
-    setContentView(mBInstallerView);
+    setContentView(R.layout.activity_binstaller);
+    mBInstallerView = findViewById(R.id.BInstallerView);
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -62,8 +62,11 @@ public class BInstallerActivity extends Activity {
       view -> {
         if (mBInstallerView.getSelectedTiles(MASK_DELETED_RD5).size() > 0) {
           showConfirmDelete();
+        } else if (mBInstallerView.getSelectedTiles(MASK_SELECTED_RD5).size() > 0) {
+          downloadSelectedTiles();
+        } else {
+          downloadInstalledTiles();
         }
-        mBInstallerView.toggleDownload();
       }
     );
     mDownloadInfo = findViewById(R.id.view_download_progress);
@@ -204,6 +207,17 @@ public class BInstallerActivity extends Activity {
     scanExistingFiles();
   }
 
+  private void downloadSelectedTiles() {
+    ArrayList<Integer> selectedTiles = mBInstallerView.getSelectedTiles(MASK_SELECTED_RD5);
+    downloadAll(selectedTiles);
+    mBInstallerView.clearAllTilesStatus(MASK_SELECTED_RD5);
+  }
+
+  private void downloadInstalledTiles() {
+    ArrayList<Integer> selectedTiles = mBInstallerView.getSelectedTiles(MASK_INSTALLED_RD5);
+    downloadAll(selectedTiles);
+  }
+
   private int tileForBaseName(String basename) {
     String uname = basename.toUpperCase(Locale.ROOT);
     int idx = uname.indexOf("_");
@@ -219,7 +233,7 @@ public class BInstallerActivity extends Activity {
     return (ilon + 180) / 5 + 72 * ((ilat + 90) / 5);
   }
 
-  protected String baseNameForTile(int tileIndex) {
+  private String baseNameForTile(int tileIndex) {
     int lon = (tileIndex % 72) * 5 - 180;
     int lat = (tileIndex / 72) * 5 - 90;
     String slon = lon < 0 ? "W" + (-lon) : "E" + lon;

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -15,26 +15,31 @@ import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
 import android.os.StatFs;
 
-import java.util.HashSet;
-import java.util.Set;
-
 public class BInstallerActivity extends Activity {
 
   public static final String DOWNLOAD_ACTION = "btools.routingapp.download";
 
   private static final int DIALOG_CONFIRM_DELETE_ID = 1;
-
   private BInstallerView mBInstallerView;
   private PowerManager mPowerManager;
   private WakeLock mWakeLock;
   private DownloadReceiver myReceiver;
-  private final Set<Integer> dialogIds = new HashSet<>();
+
+  static public long getAvailableSpace(String baseDir) {
+    StatFs stat = new StatFs(baseDir);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      return stat.getAvailableBlocksLong() * stat.getBlockSizeLong();
+    } else {
+      //noinspection deprecation
+      return (long) stat.getAvailableBlocks() * stat.getBlockSize();
+    }
+  }
 
   /**
    * Called when the activity is first created.
    */
   @Override
-  @SuppressWarnings("deprecation")
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
@@ -91,7 +96,6 @@ public class BInstallerActivity extends Activity {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   protected Dialog onCreateDialog(int id) {
     AlertDialog.Builder builder;
     switch (id) {
@@ -114,17 +118,8 @@ public class BInstallerActivity extends Activity {
     }
   }
 
-  @SuppressWarnings("deprecation")
   public void showConfirmDelete() {
     showDialog(DIALOG_CONFIRM_DELETE_ID);
-  }
-
-  private void showNewDialog(int id) {
-    if (dialogIds.contains(id)) {
-      removeDialog(id);
-    }
-    dialogIds.add(id);
-    showDialog(id);
   }
 
   public class DownloadReceiver extends BroadcastReceiver {
@@ -136,17 +131,6 @@ public class BInstallerActivity extends Activity {
         boolean ready = intent.getBooleanExtra("ready", false);
         mBInstallerView.setState(txt, ready);
       }
-    }
-  }
-
-
-  static public long getAvailableSpace(String baseDir) {
-    StatFs stat = new StatFs(baseDir);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      return stat.getAvailableBlocksLong() * stat.getBlockSizeLong();
-    } else {
-      return stat.getAvailableBlocks() * stat.getBlockSize();
     }
   }
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -36,9 +36,6 @@ public class BInstallerActivity extends Activity {
     }
   }
 
-  /**
-   * Called when the activity is first created.
-   */
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -52,7 +49,6 @@ public class BInstallerActivity extends Activity {
 
     setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
-    // instantiate our simulation view and set it as the activity's content
     mBInstallerView = new BInstallerView(this);
     setContentView(mBInstallerView);
   }
@@ -72,9 +68,6 @@ public class BInstallerActivity extends Activity {
 
     myReceiver = new DownloadReceiver();
     registerReceiver(myReceiver, filter);
-
-    // Start the download manager
-    mBInstallerView.startInstaller();
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -12,14 +12,24 @@ import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.StatFs;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import java.io.File;
+import java.util.ArrayList;
 
 public class BInstallerActivity extends Activity {
 
   public static final String DOWNLOAD_ACTION = "btools.routingapp.download";
-
   private static final int DIALOG_CONFIRM_DELETE_ID = 1;
+  public static boolean downloadCanceled = false;
+  private File baseDir;
   private BInstallerView mBInstallerView;
   private DownloadReceiver downloadReceiver;
+  private View mDownloadInfo;
+  private TextView mDownloadInfoText;
+  private Button mButtonDownloadCancel;
 
   static public long getAvailableSpace(String baseDir) {
     StatFs stat = new StatFs(baseDir);
@@ -40,6 +50,58 @@ public class BInstallerActivity extends Activity {
 
     setContentView(R.layout.activity_binstaller);
     mBInstallerView = findViewById(R.id.BInstallerView);
+    mDownloadInfo = findViewById(R.id.view_download_progress);
+    mDownloadInfoText = findViewById(R.id.textViewDownloadProgress);
+    mButtonDownloadCancel = findViewById(R.id.buttonDownloadCancel);
+    mButtonDownloadCancel.setOnClickListener(view -> {
+      cancelDownload();
+    });
+
+    baseDir = ConfigHelper.getBaseDir(this);
+  }
+
+  private String baseNameForTile(int tileIndex) {
+    int lon = (tileIndex % 72) * 5 - 180;
+    int lat = (tileIndex / 72) * 5 - 90;
+    String slon = lon < 0 ? "W" + (-lon) : "E" + lon;
+    String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
+    return slon + "_" + slat;
+  }
+
+  private void deleteRawTracks() {
+    File modeDir = new File(baseDir, "brouter/modes");
+    String[] fileNames = modeDir.list();
+    if (fileNames == null) return;
+    for (String fileName : fileNames) {
+      if (fileName.endsWith("_rawtrack.dat")) {
+        File f = new File(modeDir, fileName);
+        f.delete();
+      }
+    }
+  }
+
+  private void cancelDownload() {
+    downloadCanceled = true;
+    mDownloadInfoText.setText(getString(R.string.download_info_cancel));
+  }
+
+  public void downloadAll(ArrayList<Integer> downloadList) {
+    ArrayList<String> urlparts = new ArrayList<>();
+    for (Integer i : downloadList) {
+      urlparts.add(baseNameForTile(i));
+    }
+
+    mBInstallerView.setVisibility(View.GONE);
+    mDownloadInfo.setVisibility(View.VISIBLE);
+    downloadCanceled = false;
+    mDownloadInfoText.setText(R.string.download_info_start);
+
+    Intent intent = new Intent(this, DownloadService.class);
+    intent.putExtra("dir", baseDir.getAbsolutePath() + "/brouter/");
+    intent.putExtra("urlparts", urlparts);
+    startService(intent);
+
+    deleteRawTracks(); // invalidate raw-tracks after data update
   }
 
   @Override
@@ -99,7 +161,12 @@ public class BInstallerActivity extends Activity {
       if (intent.hasExtra("txt")) {
         String txt = intent.getStringExtra("txt");
         boolean ready = intent.getBooleanExtra("ready", false);
-        mBInstallerView.setState(txt, ready);
+        if (!ready) {
+          mBInstallerView.setVisibility(View.VISIBLE);
+          mDownloadInfo.setVisibility(View.GONE);
+          scanExistingFiles();
+        }
+        mDownloadInfoText.setText(txt);
       }
     }
   }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -1,8 +1,5 @@
 package btools.routingapp;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -16,9 +13,10 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
-import android.speech.tts.TextToSpeech.OnInitListener;
 import android.os.StatFs;
-import android.util.Log;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class BInstallerActivity extends Activity {
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -167,7 +167,7 @@ public class BInstallerActivity extends Activity {
   }
 
   private void scanExistingFiles() {
-    mBInstallerView.clearAllTilesStatus(MASK_INSTALLED_RD5 | MASK_CURRENT_RD5);
+    mBInstallerView.clearAllTilesStatus(MASK_CURRENT_RD5 | MASK_INSTALLED_RD5 | MASK_DELETED_RD5 | MASK_SELECTED_RD5);
 
     scanExistingFiles(new File(mBaseDir, "brouter/segments4"));
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -28,20 +28,7 @@ public class BInstallerActivity extends Activity {
   private PowerManager mPowerManager;
   private WakeLock mWakeLock;
   private DownloadReceiver myReceiver;
-
-
-  public class DownloadReceiver extends BroadcastReceiver {
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-      if (intent.hasExtra("txt")) {
-        String txt = intent.getStringExtra("txt");
-        boolean ready = intent.getBooleanExtra("ready", false);
-        mBInstallerView.setState(txt, ready);
-      }
-    }
-  }
-
+  private final Set<Integer> dialogIds = new HashSet<Integer>();
 
   /**
    * Called when the activity is first created.
@@ -132,14 +119,24 @@ public class BInstallerActivity extends Activity {
     showDialog(DIALOG_CONFIRM_DELETE_ID);
   }
 
-  private Set<Integer> dialogIds = new HashSet<Integer>();
-
   private void showNewDialog(int id) {
     if (dialogIds.contains(Integer.valueOf(id))) {
       removeDialog(id);
     }
     dialogIds.add(Integer.valueOf(id));
     showDialog(id);
+  }
+
+  public class DownloadReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      if (intent.hasExtra("txt")) {
+        String txt = intent.getStringExtra("txt");
+        boolean ready = intent.getBooleanExtra("ready", false);
+        mBInstallerView.setState(txt, ready);
+      }
+    }
   }
 
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -28,6 +28,13 @@ public class BInstallerView extends View {
   private static final int MASK_INSTALLED_RD5 = 4;
   private static final int MASK_CURRENT_RD5 = 8;
   public static boolean downloadCanceled = false;
+  private final int imgwOrig;
+  private final int imghOrig;
+  private final float scaleOrig;
+  private final int imgw;
+  private final int imgh;
+  private final float[] testVector = new float[2];
+  private final Matrix matText;
   Paint pnt_1 = new Paint();
   Paint pnt_2 = new Paint();
   Paint paint = new Paint();
@@ -35,16 +42,10 @@ public class BInstallerView extends View {
   int btnh = 40;
   int btnw = 160;
   float tx, ty;
-  private final int imgwOrig;
-  private final int imghOrig;
-  private final float scaleOrig;
-  private final int imgw;
-  private final int imgh;
   private float lastDownX;
   private float lastDownY;
   private Bitmap bmp;
   private float viewscale;
-  private final float[] testVector = new float[2];
   private int[] tileStatus;
   private boolean tilesVisible = false;
   private long availableSize;
@@ -57,7 +58,6 @@ public class BInstallerView extends View {
   private long rd5Tiles = 0;
   private long delTiles = 0;
   private Matrix mat;
-  private final Matrix matText;
 
   public BInstallerView(Context context) {
     super(context);

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -28,50 +28,63 @@ public class BInstallerView extends View {
   private static final int MASK_DELETED_RD5 = 2;
   private static final int MASK_INSTALLED_RD5 = 4;
   private static final int MASK_CURRENT_RD5 = 8;
-
-  private int imgwOrig;
-  private int imghOrig;
-  private float scaleOrig;
-
-  private int imgw;
-  private int imgh;
-
-  private float lastDownX;
-  private float lastDownY;
-
-  private Bitmap bmp;
-
-  private float viewscale;
-
-  private float[] testVector = new float[2];
-
-  private int[] tileStatus;
-
-  private boolean tilesVisible = false;
-
-  private long availableSize;
-  private File baseDir;
-  private File segmentDir;
-
-  private boolean isDownloading = false;
   public static boolean downloadCanceled = false;
-
-  private long currentDownloadSize;
-  private String currentDownloadFile = "";
-  private volatile String currentDownloadOperation = "";
-  private String downloadAction = "";
-  private volatile String newDownloadAction = "";
-
-  private long totalSize = 0;
-  private long rd5Tiles = 0;
-  private long delTiles = 0;
-
   Paint pnt_1 = new Paint();
   Paint pnt_2 = new Paint();
   Paint paint = new Paint();
-
   Activity mActivity;
+  int btnh = 40;
+  int btnw = 160;
+  float tx, ty;
+  private final int imgwOrig;
+  private final int imghOrig;
+  private final float scaleOrig;
+  private final int imgw;
+  private final int imgh;
+  private float lastDownX;
+  private float lastDownY;
+  private Bitmap bmp;
+  private float viewscale;
+  private final float[] testVector = new float[2];
+  private int[] tileStatus;
+  private boolean tilesVisible = false;
+  private long availableSize;
+  private File baseDir;
+  private File segmentDir;
+  private boolean isDownloading = false;
+  private long currentDownloadSize;
+  private final String currentDownloadFile = "";
+  private volatile String currentDownloadOperation = "";
+  private String downloadAction = "";
+  private final String newDownloadAction = "";
+  private long totalSize = 0;
+  private long rd5Tiles = 0;
+  private long delTiles = 0;
+  private Matrix mat;
+  private final Matrix matText;
 
+  public BInstallerView(Context context) {
+    super(context);
+    mActivity = (Activity) context;
+
+    DisplayMetrics metrics = new DisplayMetrics();
+    ((Activity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(metrics);
+    imgwOrig = metrics.widthPixels;
+    imghOrig = metrics.heightPixels;
+    int im = imgwOrig > imghOrig ? imgwOrig : imghOrig;
+
+    scaleOrig = im / 480.f;
+
+    matText = new Matrix();
+    matText.preScale(scaleOrig, scaleOrig);
+
+    imgw = (int) (imgwOrig / scaleOrig);
+    imgh = (int) (imghOrig / scaleOrig);
+
+    totalSize = 0;
+    rd5Tiles = 0;
+    delTiles = 0;
+  }
 
   protected String baseNameForTile(int tileIndex) {
     int lon = (tileIndex % 72) * 5 - 180;
@@ -99,7 +112,6 @@ public class BInstallerView extends View {
     if (ilat < -90 || ilat >= 90 || ilat % 5 != 0) return -1;
     return (ilon + 180) / 5 + 72 * ((ilat + 90) / 5);
   }
-
 
   public boolean isDownloadCanceled() {
     return downloadCanceled;
@@ -167,7 +179,6 @@ public class BInstallerView extends View {
     deleteRawTracks(); // invalidate raw-tracks after data update
   }
 
-
   public void downloadDone(boolean success) {
     isDownloading = false;
     if (success) {
@@ -234,7 +245,7 @@ public class BInstallerView extends View {
 
     availableSize = -1;
     try {
-      availableSize = (long) ((BInstallerActivity) getContext()).getAvailableSpace(baseDir.getAbsolutePath());
+      availableSize = ((BInstallerActivity) getContext()).getAvailableSpace(baseDir.getAbsolutePath());
       //StatFs stat = new StatFs(baseDir.getAbsolutePath ());
       //availableSize = (long)stat.getAvailableBlocksLong()*stat.getBlockSizeLong();
     } catch (Exception e) { /* ignore */ }
@@ -255,9 +266,6 @@ public class BInstallerView extends View {
       }
     }
   }
-
-  private Matrix mat;
-  private Matrix matText;
 
   public void startInstaller() {
 
@@ -283,29 +291,6 @@ public class BInstallerView extends View {
     mat = new Matrix();
     mat.postScale(viewscale, viewscale);
     tilesVisible = false;
-  }
-
-  public BInstallerView(Context context) {
-    super(context);
-    mActivity = (Activity) context;
-
-    DisplayMetrics metrics = new DisplayMetrics();
-    ((Activity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(metrics);
-    imgwOrig = metrics.widthPixels;
-    imghOrig = metrics.heightPixels;
-    int im = imgwOrig > imghOrig ? imgwOrig : imghOrig;
-
-    scaleOrig = im / 480.f;
-
-    matText = new Matrix();
-    matText.preScale(scaleOrig, scaleOrig);
-
-    imgw = (int) (imgwOrig / scaleOrig);
-    imgh = (int) (imghOrig / scaleOrig);
-
-    totalSize = 0;
-    rd5Tiles = 0;
-    delTiles = 0;
   }
 
   @Override
@@ -410,12 +395,6 @@ public class BInstallerView extends View {
       canvas.drawText(btnText, imgw - btnw + 5, imgh - 10, paint);
     }
   }
-
-  int btnh = 40;
-  int btnw = 160;
-
-
-  float tx, ty;
 
   private void drawSelectedTiles(Canvas canvas, Paint pnt, float fw, float fh, int status, int mask, boolean doCount, boolean cntDel, boolean doDraw) {
     for (int ix = 0; ix < 72; ix++)

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -1,6 +1,5 @@
 package btools.routingapp;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
@@ -10,7 +9,6 @@ import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -29,13 +27,7 @@ public class BInstallerView extends View {
   private final File segmentDir;
   private final Matrix mat;
   private final Bitmap bmp;
-  private final float viewscale;
   private final int[] tileStatus;
-  private final int imgwOrig;
-  private final int imghOrig;
-  private final float scaleOrig;
-  private final int imgw;
-  private final int imgh;
   private final float[] testVector = new float[2];
   private final Matrix matText;
   Paint pnt_1 = new Paint();
@@ -44,8 +36,14 @@ public class BInstallerView extends View {
   int btnh = 40;
   int btnw = 160;
   float tx, ty;
+  private int imgwOrig;
+  private int imghOrig;
+  private float scaleOrig;
+  private int imgw;
+  private int imgh;
   private float lastDownX;
   private float lastDownY;
+  private float viewscale;
   private boolean tilesVisible = false;
   private long availableSize;
   private long totalSize = 0;
@@ -55,20 +53,6 @@ public class BInstallerView extends View {
 
   public BInstallerView(Context context, AttributeSet attrs) {
     super(context, attrs);
-
-    DisplayMetrics metrics = new DisplayMetrics();
-    ((Activity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(metrics);
-    imgwOrig = metrics.widthPixels;
-    imghOrig = metrics.heightPixels;
-    int im = Math.max(imgwOrig, imghOrig);
-
-    scaleOrig = im / 480.f;
-
-    matText = new Matrix();
-    matText.preScale(scaleOrig, scaleOrig);
-
-    imgw = (int) (imgwOrig / scaleOrig);
-    imgh = (int) (imghOrig / scaleOrig);
 
     File baseDir = ConfigHelper.getBaseDir(getContext());
     segmentDir = new File(baseDir, "brouter/segments4");
@@ -83,14 +67,8 @@ public class BInstallerView extends View {
     }
 
     tileStatus = new int[72 * 36];
-
-    float scaleX = imgwOrig / ((float) bmp.getWidth());
-    float scaley = imghOrig / ((float) bmp.getHeight());
-
-    viewscale = Math.min(scaleX, scaley);
-
+    matText = new Matrix();
     mat = new Matrix();
-    mat.postScale(viewscale, viewscale);
   }
 
   public void setAvailableSize(long availableSize) {
@@ -151,6 +129,25 @@ public class BInstallerView extends View {
   @Override
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
+
+    imgwOrig = getWidth();
+    imghOrig = getHeight();
+    int im = Math.max(imgwOrig, imghOrig);
+
+    scaleOrig = im / 480.f;
+
+    matText.preScale(scaleOrig, scaleOrig);
+
+    imgw = (int) (imgwOrig / scaleOrig);
+    imgh = (int) (imghOrig / scaleOrig);
+
+    float scaleX = imgwOrig / ((float) bmp.getWidth());
+    float scaley = imghOrig / ((float) bmp.getHeight());
+
+    viewscale = Math.min(scaleX, scaley);
+
+    mat.postScale(viewscale, viewscale);
+    tilesVisible = false;
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -60,11 +60,13 @@ public class BInstallerView extends View {
   }
 
   private void setRatio(float ratio, float focusX, float focusY) {
-    mat.postScale(ratio, ratio, focusX, focusY);
-    fitBounds();
-    tilesVisible = currentScale() >= SCALE_GRID_VISIBLE;
+    if (currentScale() * ratio >= 1) {
+      mat.postScale(ratio, ratio, focusX, focusY);
+      fitBounds();
+      tilesVisible = currentScale() >= SCALE_GRID_VISIBLE;
 
-    invalidate();
+      invalidate();
+    }
   }
 
   private void setScale(float scale, float focusX, float focusY) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -86,7 +86,6 @@ public class BInstallerView extends View {
     }
 
     tileStatus = new int[72 * 36];
-    scanExistingFiles();
 
     float scaleX = imgwOrig / ((float) bmp.getWidth());
     float scaley = imghOrig / ((float) bmp.getHeight());
@@ -95,10 +94,6 @@ public class BInstallerView extends View {
 
     mat = new Matrix();
     mat.postScale(viewscale, viewscale);
-  }
-
-  private void scanExistingFiles() {
-
   }
 
   public void setAvailableSize(long availableSize) {
@@ -119,6 +114,20 @@ public class BInstallerView extends View {
     invalidate();
   }
 
+  public ArrayList<Integer> getSelectedTiles(int tileMask) {
+    ArrayList<Integer> selectedTiles = new ArrayList<>();
+    for (int ix = 0; ix < 72; ix++) {
+      for (int iy = 0; iy < 36; iy++) {
+        int tileIndex = gridPos2Tileindex(ix, iy);
+        if ((tileStatus[tileIndex] & tileMask) != 0 && BInstallerSizes.getRd5Size(tileIndex) > 0) {
+          selectedTiles.add(tileIndex);
+        }
+      }
+    }
+
+    return selectedTiles;
+  }
+
   @Override
   public void setOnClickListener(OnClickListener listener) {
     mOnClickListener = listener;
@@ -137,11 +146,6 @@ public class BInstallerView extends View {
   }
 
   public void toggleDownload() {
-    if (delTiles > 0) {
-      ((BInstallerActivity) getContext()).showConfirmDelete();
-      return;
-    }
-
     int min_size = Integer.MAX_VALUE;
 
     ArrayList<Integer> downloadList = new ArrayList<>();
@@ -296,19 +300,6 @@ public class BInstallerView extends View {
           }
         }
       }
-  }
-
-  public void deleteSelectedTiles() {
-    for (int ix = 0; ix < 72; ix++) {
-      for (int iy = 0; iy < 36; iy++) {
-        int tidx = gridPos2Tileindex(ix, iy);
-        if ((tileStatus[tidx] & MASK_DELETED_RD5) != 0) {
-          new File(baseDir, "brouter/segments4/" + baseNameForTile(tidx) + ".rd5").delete();
-        }
-      }
-    }
-    scanExistingFiles();
-    invalidate();
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -1,15 +1,5 @@
 package btools.routingapp;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Locale;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -20,21 +10,18 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
-import android.os.AsyncTask;
-import android.os.PowerManager;
-import android.os.StatFs;
-import android.util.AttributeSet;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Toast;
 
-import btools.mapaccess.PhysicalFile;
-import btools.mapaccess.Rd5DiffManager;
-import btools.mapaccess.Rd5DiffTool;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Locale;
+
 import btools.router.RoutingHelper;
-import btools.util.ProgressListener;
 
 public class BInstallerView extends View {
   private static final int MASK_SELECTED_RD5 = 1;

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -35,6 +35,12 @@ public class BInstallerView extends View {
   private final int imgh;
   private final float[] testVector = new float[2];
   private final Matrix matText;
+  private final File baseDir;
+  private final File segmentDir;
+  private final Matrix mat;
+  private final Bitmap bmp;
+  private final float viewscale;
+  private final int[] tileStatus;
   Paint pnt_1 = new Paint();
   Paint pnt_2 = new Paint();
   Paint paint = new Paint();
@@ -44,20 +50,14 @@ public class BInstallerView extends View {
   float tx, ty;
   private float lastDownX;
   private float lastDownY;
-  private Bitmap bmp;
-  private float viewscale;
-  private int[] tileStatus;
   private boolean tilesVisible = false;
   private long availableSize;
-  private File baseDir;
-  private File segmentDir;
   private boolean isDownloading = false;
   private volatile String currentDownloadOperation = "";
   private String downloadAction = "";
   private long totalSize = 0;
   private long rd5Tiles = 0;
   private long delTiles = 0;
-  private Matrix mat;
 
   public BInstallerView(Context context) {
     super(context);
@@ -76,6 +76,29 @@ public class BInstallerView extends View {
 
     imgw = (int) (imgwOrig / scaleOrig);
     imgh = (int) (imghOrig / scaleOrig);
+
+    baseDir = ConfigHelper.getBaseDir(getContext());
+    segmentDir = new File(baseDir, "brouter/segments4");
+
+    try {
+      AssetManager assetManager = getContext().getAssets();
+      InputStream istr = assetManager.open("world.png");
+      bmp = BitmapFactory.decodeStream(istr);
+      istr.close();
+    } catch (IOException io) {
+      throw new RuntimeException("cannot read world.png from assets");
+    }
+
+    tileStatus = new int[72 * 36];
+    scanExistingFiles();
+
+    float scaleX = imgwOrig / ((float) bmp.getWidth());
+    float scaley = imghOrig / ((float) bmp.getHeight());
+
+    viewscale = Math.min(scaleX, scaley);
+
+    mat = new Matrix();
+    mat.postScale(viewscale, viewscale);
   }
 
   protected String baseNameForTile(int tileIndex) {
@@ -238,32 +261,6 @@ public class BInstallerView extends View {
         if (age < 10800000) tileStatus[tidx] |= MASK_CURRENT_RD5; // 3 hours
       }
     }
-  }
-
-  public void startInstaller() {
-
-    baseDir = ConfigHelper.getBaseDir(getContext());
-    segmentDir = new File(baseDir, "brouter/segments4");
-    try {
-      AssetManager assetManager = getContext().getAssets();
-      InputStream istr = assetManager.open("world.png");
-      bmp = BitmapFactory.decodeStream(istr);
-      istr.close();
-    } catch (IOException io) {
-      throw new RuntimeException("cannot read world.png from assets");
-    }
-
-    tileStatus = new int[72 * 36];
-    scanExistingFiles();
-
-    float scaleX = imgwOrig / ((float) bmp.getWidth());
-    float scaley = imghOrig / ((float) bmp.getHeight());
-
-    viewscale = Math.min(scaleX, scaley);
-
-    mat = new Matrix();
-    mat.postScale(viewscale, viewscale);
-    tilesVisible = false;
   }
 
   @Override

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -10,6 +10,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
+import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
@@ -59,8 +60,8 @@ public class BInstallerView extends View {
   private long rd5Tiles = 0;
   private long delTiles = 0;
 
-  public BInstallerView(Context context) {
-    super(context);
+  public BInstallerView(Context context, AttributeSet attrs) {
+    super(context, attrs);
     mActivity = (Activity) context;
 
     DisplayMetrics metrics = new DisplayMetrics();

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -26,7 +26,6 @@ public class BInstallerView extends View {
   public static final int MASK_DELETED_RD5 = 2;
   public static final int MASK_INSTALLED_RD5 = 4;
   public static final int MASK_CURRENT_RD5 = 8;
-  private final File baseDir;
   private final File segmentDir;
   private final Matrix mat;
   private final Bitmap bmp;
@@ -42,7 +41,6 @@ public class BInstallerView extends View {
   Paint pnt_1 = new Paint();
   Paint pnt_2 = new Paint();
   Paint paint = new Paint();
-  Activity mActivity;
   int btnh = 40;
   int btnw = 160;
   float tx, ty;
@@ -57,7 +55,6 @@ public class BInstallerView extends View {
 
   public BInstallerView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    mActivity = (Activity) context;
 
     DisplayMetrics metrics = new DisplayMetrics();
     ((Activity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(metrics);
@@ -73,7 +70,7 @@ public class BInstallerView extends View {
     imgw = (int) (imgwOrig / scaleOrig);
     imgh = (int) (imghOrig / scaleOrig);
 
-    baseDir = ConfigHelper.getBaseDir(getContext());
+    File baseDir = ConfigHelper.getBaseDir(getContext());
     segmentDir = new File(baseDir, "brouter/segments4");
 
     try {
@@ -133,44 +130,8 @@ public class BInstallerView extends View {
     mOnClickListener = listener;
   }
 
-  protected String baseNameForTile(int tileIndex) {
-    int lon = (tileIndex % 72) * 5 - 180;
-    int lat = (tileIndex / 72) * 5 - 90;
-    String slon = lon < 0 ? "W" + (-lon) : "E" + lon;
-    String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
-    return slon + "_" + slat;
-  }
-
   private int gridPos2Tileindex(int ix, int iy) {
     return (35 - iy) * 72 + (ix >= 70 ? ix - 70 : ix + 2);
-  }
-
-  public void toggleDownload() {
-    int min_size = Integer.MAX_VALUE;
-
-    ArrayList<Integer> downloadList = new ArrayList<>();
-    // prepare download list
-    for (int ix = 0; ix < 72; ix++) {
-      for (int iy = 0; iy < 36; iy++) {
-        int tidx = gridPos2Tileindex(ix, iy);
-        if ((tileStatus[tidx] & MASK_SELECTED_RD5) != 0) {
-          int tilesize = BInstallerSizes.getRd5Size(tidx);
-          downloadList.add(tidx);
-          if (tilesize > 0 && tilesize < min_size) {
-            min_size = tilesize;
-          }
-        }
-      }
-    }
-
-    if (downloadList.size() > 0) {
-      // isDownloading = true;
-      ((BInstallerActivity) getContext()).downloadAll(downloadList);
-      for (Integer i : downloadList) {
-        tileStatus[i] ^= tileStatus[i] & MASK_SELECTED_RD5;
-      }
-      downloadList.clear();
-    }
   }
 
   private int tileIndex(float x, float y) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -15,12 +15,9 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-
-import btools.router.RoutingHelper;
 
 public class BInstallerView extends View {
   public static final int MASK_SELECTED_RD5 = 1;
@@ -31,34 +28,17 @@ public class BInstallerView extends View {
   private final Bitmap bmp;
   private final float[] testVector = new float[2];
   private final int[] tileStatus;
-  private final File segmentDir;
   private final Matrix mat;
-  private final Matrix matText;
   private final GestureDetector mGestureDetector;
   private final ScaleGestureDetector mScaleGestureDetector;
-  Paint pnt_1 = new Paint();
-  Paint pnt_2 = new Paint();
-  Paint paint = new Paint();
-  int btnh = 40;
-  int btnw = 160;
-  private int imgwOrig;
-  private int imghOrig;
-  private float scaleOrig;
-  private int imgw;
-  private int imgh;
+  Paint paintGrid = new Paint();
+  Paint paintTiles = new Paint();
   private float viewscale;
   private boolean tilesVisible = false;
-  private long availableSize;
-  private long totalSize = 0;
-  private long rd5Tiles = 0;
-  private long delTiles = 0;
-  private OnClickListener mOnClickListener;
+  private OnSelectListener mOnSelectListener;
 
   public BInstallerView(Context context, AttributeSet attrs) {
     super(context, attrs);
-
-    File baseDir = ConfigHelper.getBaseDir(getContext());
-    segmentDir = new File(baseDir, "brouter/segments4");
 
     try {
       AssetManager assetManager = getContext().getAssets();
@@ -70,10 +50,13 @@ public class BInstallerView extends View {
     }
 
     tileStatus = new int[72 * 36];
-    matText = new Matrix();
     mat = new Matrix();
     mGestureDetector = new GestureDetector(context, new GestureListener());
     mScaleGestureDetector = new ScaleGestureDetector(context, new ScaleGestureListener());
+  }
+
+  public void setOnSelectListener(OnSelectListener listener) {
+    mOnSelectListener = listener;
   }
 
   private void setRatio(float ratio, float focusX, float focusY) {
@@ -89,12 +72,20 @@ public class BInstallerView extends View {
     setRatio(ratio, focusX, focusY);
   }
 
-  public void setAvailableSize(long availableSize) {
-    this.availableSize = availableSize;
-  }
-
   public void setTileStatus(int tileIndex, int tileMask) {
     tileStatus[tileIndex] |= tileMask;
+    if (mOnSelectListener != null) {
+      mOnSelectListener.onSelect();
+    }
+    invalidate();
+  }
+
+  public void toggleTileStatus(int tileIndex, int tileMask) {
+    tileStatus[tileIndex] ^= tileMask;
+    if (mOnSelectListener != null) {
+      mOnSelectListener.onSelect();
+    }
+    invalidate();
   }
 
   public void clearAllTilesStatus(int tileMask) {
@@ -103,6 +94,9 @@ public class BInstallerView extends View {
         int tileIndex = gridPos2Tileindex(ix, iy);
         tileStatus[tileIndex] ^= tileStatus[tileIndex] & tileMask;
       }
+    }
+    if (mOnSelectListener != null) {
+      mOnSelectListener.onSelect();
     }
     invalidate();
   }
@@ -121,11 +115,6 @@ public class BInstallerView extends View {
     return selectedTiles;
   }
 
-  @Override
-  public void setOnClickListener(OnClickListener listener) {
-    mOnClickListener = listener;
-  }
-
   private int gridPos2Tileindex(int ix, int iy) {
     return (35 - iy) * 72 + (ix >= 70 ? ix - 70 : ix + 2);
   }
@@ -139,30 +128,22 @@ public class BInstallerView extends View {
 
   // get back the current image scale
   private float currentScale() {
-    testVector[1] = 1.f;
+    testVector[0] = 1.f;
     mat.mapVectors(testVector);
-    return testVector[1] / viewscale;
+    return testVector[0] / viewscale;
   }
 
   @Override
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
 
-    imgwOrig = getWidth();
-    imghOrig = getHeight();
-    int im = Math.max(imgwOrig, imghOrig);
-
-    scaleOrig = im / 480.f;
-
-    matText.preScale(scaleOrig, scaleOrig);
-
-    imgw = (int) (imgwOrig / scaleOrig);
-    imgh = (int) (imghOrig / scaleOrig);
+    int imgwOrig = getWidth();
+    int imghOrig = getHeight();
 
     float scaleX = imgwOrig / ((float) bmp.getWidth());
     float scaleY = imghOrig / ((float) bmp.getHeight());
 
-    viewscale = Math.min(scaleX, scaleY);
+    viewscale = Math.max(scaleX, scaleY);
 
     mat.postScale(viewscale, viewscale);
     tilesVisible = false;
@@ -180,93 +161,47 @@ public class BInstallerView extends View {
     float fh = ih / 36.f;
 
     if (tilesVisible) {
-      pnt_1.setColor(Color.GREEN);
-      pnt_1.setStyle(Paint.Style.STROKE);
+      paintGrid.setColor(Color.GREEN);
+      paintGrid.setStyle(Paint.Style.STROKE);
       for (int ix = 0; ix < 72; ix++) {
         for (int iy = 0; iy < 36; iy++) {
           int tidx = gridPos2Tileindex(ix, iy);
           int tilesize = BInstallerSizes.getRd5Size(tidx);
           if (tilesize > 0) {
-            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt_1);
+            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, paintGrid);
           }
         }
       }
-    }
 
-    rd5Tiles = 0;
-    delTiles = 0;
-    totalSize = 0;
-    int mask2 = MASK_SELECTED_RD5 | MASK_DELETED_RD5 | MASK_INSTALLED_RD5;
-    int mask3 = mask2 | MASK_CURRENT_RD5;
+      int mask2 = MASK_SELECTED_RD5 | MASK_DELETED_RD5 | MASK_INSTALLED_RD5;
+      int mask3 = mask2 | MASK_CURRENT_RD5;
 
-    pnt_2.setStyle(Paint.Style.STROKE);
-    pnt_2.setColor(Color.GRAY);
-    pnt_2.setStrokeWidth(1);
-    drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_INSTALLED_RD5, mask3, false, false, tilesVisible);
-    pnt_2.setColor(Color.BLUE);
-    pnt_2.setStrokeWidth(1);
-    drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_INSTALLED_RD5 | MASK_CURRENT_RD5, mask3, false, false, tilesVisible);
-    pnt_2.setColor(Color.GREEN);
-    pnt_2.setStrokeWidth(2);
-    drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_SELECTED_RD5, mask2, true, false, tilesVisible);
-    pnt_2.setColor(Color.YELLOW);
-    pnt_2.setStrokeWidth(2);
-    drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_SELECTED_RD5 | MASK_INSTALLED_RD5, mask2, true, false, tilesVisible);
-    pnt_2.setColor(Color.RED);
-    pnt_2.setStrokeWidth(2);
-    drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_DELETED_RD5 | MASK_INSTALLED_RD5, mask2, false, true, tilesVisible);
-
-    canvas.setMatrix(matText);
-
-    paint.setColor(Color.RED);
-
-    long mb = 1024 * 1024;
-
-    if (!this.tilesVisible) {
-      paint.setTextSize(35);
-      canvas.drawText("Touch region to zoom in!", 30, (imgh / 3) * 2, paint);
-    }
-    paint.setTextSize(20);
-
-
-    String totmb = ((totalSize + mb - 1) / mb) + " MB";
-    String freemb = availableSize >= 0 ? ((availableSize + mb - 1) / mb) + " MB" : "?";
-    canvas.drawText("Selected segments=" + rd5Tiles, 10, 25, paint);
-    canvas.drawText("Size=" + totmb + " Free=" + freemb, 10, 45, paint);
-
-
-    String btnText = null;
-    if (delTiles > 0) btnText = "Delete " + delTiles + " tiles";
-    else if (rd5Tiles > 0) btnText = "Start Download";
-    else if (this.tilesVisible &&
-      rd5Tiles == 0 &&
-      RoutingHelper.hasDirectoryAnyDatafiles(segmentDir)) btnText = "Update all";
-
-    if (btnText != null) {
-      paint.setStyle(Paint.Style.STROKE);
-      canvas.drawRect(imgw - btnw, imgh - btnh, imgw - 2, imgh - 2, paint);
-      paint.setStyle(Paint.Style.FILL);
-      canvas.drawText(btnText, imgw - btnw + 5, imgh - 10, paint);
+      paintTiles.setStyle(Paint.Style.STROKE);
+      paintTiles.setColor(Color.GRAY);
+      paintTiles.setStrokeWidth(1);
+      drawSelectedTiles(canvas, paintTiles, fw, fh, MASK_INSTALLED_RD5, mask3);
+      paintTiles.setColor(Color.BLUE);
+      paintTiles.setStrokeWidth(1);
+      drawSelectedTiles(canvas, paintTiles, fw, fh, MASK_INSTALLED_RD5 | MASK_CURRENT_RD5, mask3);
+      paintTiles.setColor(Color.GREEN);
+      paintTiles.setStrokeWidth(2);
+      drawSelectedTiles(canvas, paintTiles, fw, fh, MASK_SELECTED_RD5, mask2);
+      paintTiles.setColor(Color.YELLOW);
+      paintTiles.setStrokeWidth(2);
+      drawSelectedTiles(canvas, paintTiles, fw, fh, MASK_SELECTED_RD5 | MASK_INSTALLED_RD5, mask2);
+      paintTiles.setColor(Color.RED);
+      paintTiles.setStrokeWidth(2);
+      drawSelectedTiles(canvas, paintTiles, fw, fh, MASK_DELETED_RD5 | MASK_INSTALLED_RD5, mask2);
     }
   }
 
-  private void drawSelectedTiles(Canvas canvas, Paint pnt, float fw, float fh, int status, int mask, boolean doCount, boolean cntDel, boolean doDraw) {
+  private void drawSelectedTiles(Canvas canvas, Paint pnt, float fw, float fh, int status, int mask) {
     for (int ix = 0; ix < 72; ix++)
       for (int iy = 0; iy < 36; iy++) {
         int tidx = gridPos2Tileindex(ix, iy);
         if ((tileStatus[tidx] & mask) == status) {
           int tilesize = BInstallerSizes.getRd5Size(tidx);
           if (tilesize > 0) {
-            if (doCount) {
-              rd5Tiles++;
-              totalSize += BInstallerSizes.getRd5Size(tidx);
-            }
-            if (cntDel) {
-              delTiles++;
-              totalSize += BInstallerSizes.getRd5Size(tidx);
-            }
-            if (!doDraw)
-              continue;
             // draw cross
             canvas.drawLine(fw * ix, fh * iy, fw * (ix + 1), fh * (iy + 1), pnt);
             canvas.drawLine(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt);
@@ -310,36 +245,31 @@ public class BInstallerView extends View {
     return retVal || super.onTouchEvent(event);
   }
 
+  interface OnSelectListener {
+    void onSelect();
+  }
+
   class GestureListener extends GestureDetector.SimpleOnGestureListener {
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent e) {
-      // Download Button
-      if ((delTiles > 0 || rd5Tiles >= 0) && e.getX() > imgwOrig - btnw * scaleOrig && e.getY() > imghOrig - btnh * scaleOrig) {
-        if (mOnClickListener != null) {
-          mOnClickListener.onClick(null);
-        }
-        invalidate();
-        return true;
-      }
-
       if (tilesVisible) {
         Matrix imat = new Matrix();
         if (mat.invert(imat)) {
-          float[] touchpoint = {e.getX(), e.getY()};
-          imat.mapPoints(touchpoint);
+          float[] touchPoint = {e.getX(), e.getY()};
+          imat.mapPoints(touchPoint);
 
-          int tidx = tileIndex(touchpoint[0], touchpoint[1]);
+          int tidx = tileIndex(touchPoint[0], touchPoint[1]);
           if (tidx != -1) {
             if ((tileStatus[tidx] & MASK_SELECTED_RD5) != 0) {
-              tileStatus[tidx] ^= MASK_SELECTED_RD5;
+              toggleTileStatus(tidx, MASK_SELECTED_RD5);
               if ((tileStatus[tidx] & MASK_INSTALLED_RD5) != 0) {
-                tileStatus[tidx] |= MASK_DELETED_RD5;
+                setTileStatus(tidx, MASK_DELETED_RD5);
               }
             } else if ((tileStatus[tidx] & MASK_DELETED_RD5) != 0) {
-              tileStatus[tidx] ^= MASK_DELETED_RD5;
+              toggleTileStatus(tidx, MASK_DELETED_RD5);
             } else {
-              tileStatus[tidx] ^= MASK_SELECTED_RD5;
+              toggleTileStatus(tidx, MASK_SELECTED_RD5);
             }
           }
         }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -284,24 +284,26 @@ public class BInstallerView extends View {
     boolean drawGrid = tilesVisible && !isDownloading;
 
     if (drawGrid) {
-
       pnt_1.setColor(Color.GREEN);
-
-      for (int ix = 1; ix < 72; ix++) {
-        float fx = fw * ix;
-        canvas.drawLine(fx, 0, fx, ih, pnt_1);
-      }
-      for (int iy = 1; iy < 36; iy++) {
-        float fy = fh * iy;
-        canvas.drawLine(0, fy, iw, fy, pnt_1);
+      pnt_1.setStyle(Paint.Style.STROKE);
+      for (int ix = 0; ix < 72; ix++) {
+        for (int iy = 0; iy < 36; iy++) {
+          int tidx = gridPos2Tileindex(ix, iy);
+          int tilesize = BInstallerSizes.getRd5Size(tidx);
+          if (tilesize > 0) {
+            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt_1);
+          }
+        }
       }
     }
+
     rd5Tiles = 0;
     delTiles = 0;
     totalSize = 0;
     int mask2 = MASK_SELECTED_RD5 | MASK_DELETED_RD5 | MASK_INSTALLED_RD5;
     int mask3 = mask2 | MASK_CURRENT_RD5;
 
+    pnt_2.setStyle(Paint.Style.STROKE);
     pnt_2.setColor(Color.GRAY);
     pnt_2.setStrokeWidth(1);
     drawSelectedTiles(canvas, pnt_2, fw, fh, MASK_INSTALLED_RD5, mask3, false, false, drawGrid);
@@ -381,10 +383,7 @@ public class BInstallerView extends View {
             canvas.drawLine(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt);
 
             // draw frame
-            canvas.drawLine(fw * ix, fh * iy, fw * (ix + 1), fh * iy, pnt);
-            canvas.drawLine(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * (iy + 1), pnt);
-            canvas.drawLine(fw * ix, fh * iy, fw * ix, fh * (iy + 1), pnt);
-            canvas.drawLine(fw * (ix + 1), fh * iy, fw * (ix + 1), fh * (iy + 1), pnt);
+            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt);
           }
         }
       }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -352,11 +352,9 @@ public class BInstallerView extends View {
       RoutingHelper.hasDirectoryAnyDatafiles(segmentDir)) btnText = "Update all";
 
     if (btnText != null) {
-      canvas.drawLine(imgw - btnw, imgh - btnh, imgw - btnw, imgh - 2, paint);
-      canvas.drawLine(imgw - btnw, imgh - btnh, imgw - 2, imgh - btnh, paint);
-      canvas.drawLine(imgw - btnw, imgh - btnh, imgw - btnw, imgh - 2, paint);
-      canvas.drawLine(imgw - 2, imgh - btnh, imgw - 2, imgh - 2, paint);
-      canvas.drawLine(imgw - btnw, imgh - 2, imgw - 2, imgh - 2, paint);
+      paint.setStyle(Paint.Style.STROKE);
+      canvas.drawRect(imgw - btnw, imgh - btnh, imgw - 2, imgh - 2, paint);
+      paint.setStyle(Paint.Style.FILL);
       canvas.drawText(btnText, imgw - btnw + 5, imgh - 10, paint);
     }
   }

--- a/brouter-routing-app/src/main/java/btools/routingapp/DownloadService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/DownloadService.java
@@ -481,7 +481,7 @@ public class DownloadService extends Service implements ProgressListener {
 
 
   public boolean isCanceled() {
-    return BInstallerView.downloadCanceled;
+    return BInstallerActivity.downloadCanceled;
   }
 
 }

--- a/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
+++ b/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <btools.routingapp.BInstallerView
+        android:id="@+id/BInstallerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
+++ b/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
@@ -1,13 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <btools.routingapp.BInstallerView
-        android:id="@+id/BInstallerView"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/view_segments"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <btools.routingapp.BInstallerView
+            android:id="@+id/BInstallerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/buttonDownload"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="@string/action_select"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
+            android:id="@+id/textViewSegmentSummary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginBottom="8dp"
+            android:textColor="@android:color/primary_text_light"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:id="@+id/view_download_progress"
@@ -21,7 +52,7 @@
             android:id="@+id/textViewDownloadProgress"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="34sp" />
+            android:textSize="20sp" />
 
         <Space
             android:layout_width="match_parent"

--- a/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
+++ b/brouter-routing-app/src/main/res/layout/activity_binstaller.xml
@@ -1,11 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <btools.routingapp.BInstallerView
         android:id="@+id/BInstallerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <LinearLayout
+        android:id="@+id/view_download_progress"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="8dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/textViewDownloadProgress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="34sp" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <Button
+            android:id="@+id/buttonDownloadCancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:text="@string/cancel_download" />
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/brouter-routing-app/src/main/res/values/strings.xml
+++ b/brouter-routing-app/src/main/res/values/strings.xml
@@ -15,10 +15,19 @@
 -->
 
 <resources>
+    <plurals name="numberOfSegments">
+        <item quantity="one">%d segment</item>
+        <item quantity="other">%d segments</item>
+    </plurals>
     <string name="app_name">BRouter</string>
     <string name="cancel_download">Cancel Download</string>
     <string name="import_profile">Import Profile</string>
     <string name="profile_filename_example">filename.brf</string>
     <string name="download_info_start">Starting download…</string>
     <string name="download_info_cancel">Cancelling…</string>
+    <string name="action_download">Download %s</string>
+    <string name="action_delete">Delete %s</string>
+    <string name="action_update">Update %s</string>
+    <string name="action_select">Select segments</string>
+    <string name="summary_segments">Size=%s\nFree=%s</string>
 </resources>

--- a/brouter-routing-app/src/main/res/values/strings.xml
+++ b/brouter-routing-app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
 
 <resources>
     <string name="app_name">BRouter</string>
+    <string name="cancel_download">Cancel Download</string>
     <string name="import_profile">Import Profile</string>
     <string name="profile_filename_example">filename.brf</string>
+    <string name="download_info_start">Starting download…</string>
+    <string name="download_info_cancel">Cancelling…</string>
 </resources>


### PR DESCRIPTION
Currently DownloadManager has most of the logic in `BInstallerView`. This includes showing segment selection and download progress. Views should only be used for displaying information, not general logic like deleting files etc.

I've moved most logic `BInstallerActivity` and used layouts to show information/button and download progress.
- Replaced custom touch event handling with `GestureDetector` and `ScaleGestureDetector`
- Avoid moving map out of bounds
- Simplify drawing code