### PR TITLE
Add support for highway=no, see #402

### DIFF
--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -183,7 +183,7 @@ assign costfactor
   # exclude motorways and proposed roads
   #
   else if ( highway=motorway|motorway_link ) then   10000
-  else if ( highway=proposed|abandoned     ) then   10000
+  else if ( highway=proposed|abandoned|no  ) then   10000
 
   #
   # all other exclusions below (access, steps, ferries,..)


### PR DESCRIPTION
See #402.

Not used that often, highway=no, 1912 time, but so is highway=abandoned, 2893 times.