### PR TITLE
Update locus xml generation to have only one extension section

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -591,8 +591,10 @@ public final class OsmTrack
 
     if ( turnInstructionMode == 2 )
     {
-      sb.append( "  <extensions><locus:rteComputeType>" ).append( "" + voiceHints.getLocusRouteType() ).append( "</locus:rteComputeType></extensions>\n" );
-      sb.append( "  <extensions><locus:rteSimpleRoundabouts>1</locus:rteSimpleRoundabouts></extensions>\n" );
+      sb.append( "  <extensions>\n" );
+      sb.append( "   <locus:rteComputeType>" ).append( "" + voiceHints.getLocusRouteType() ).append( "</locus:rteComputeType>\n" );
+      sb.append( "   <locus:rteSimpleRoundabouts>1</locus:rteSimpleRoundabouts>\n" );
+      sb.append( "  </extensions>\n" );
     }
 
     sb.append( "  <trkseg>\n" );


### PR DESCRIPTION
I saw https://groups.google.com/g/osm-android-bikerouting/c/htEAGAOsBkc coming by and had a look at the details.

I could reproduce the XML validation problem using Renner_original.gpx but by adding http://www.garmin.com/xmlschemas/GpxExtensions/v3 as schema that problem is gone