### PR TITLE
Update APK path

### DIFF
--- a/brouter-server/build.gradle
+++ b/brouter-server/build.gradle
@@ -59,10 +59,7 @@ distributions {
                 include 'readmes/osmand/*'
                 include 'profiles2/*'
             }
-            from ('../brouter-routing-app/build/outputs/apk/api19/release') {
-                include '*.apk'
-            }
-            from ('../brouter-routing-app/build/outputs/apk/api30/release') {
+            from ('../brouter-routing-app/build/outputs/apk/release') {
                 include '*.apk'
             }
              from ('../brouter-server/build/libs') {


### PR DESCRIPTION
After merging #439 only a single APK is provided which wasn't part of the provided zip.

Thanks @afischerdev for the fix