### PR TITLE
Automatically check codestyle using checkstyle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ allprojects {
             gpr(MavenPublication)
         }
     }
+
+    apply plugin: "checkstyle"
 }
 
 task clean(type: Delete) {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -8,9 +8,11 @@
       <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
 
-  <!-- <module name="FileTabCharacter"/> -->
+  <module name="FileTabCharacter"/>
 
   <module name="TreeWalker">
-    <!-- <module name="Indentation"/> -->
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+    </module>
   </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <module name="SuppressionFilter">
+      <property name="file" value="${config_loc}/suppressions.xml"/>
+  </module>
+
+  <!-- <module name="FileTabCharacter"/> -->
+
+  <module name="TreeWalker">
+    <!-- <module name="Indentation"/> -->
+  </module>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+</suppressions>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -5,4 +5,11 @@
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+  <suppress files="brouter-codec/.*" checks=".*"/>
+  <suppress files="brouter-core/.*" checks=".*"/>
+  <suppress files="brouter-expressions/.*" checks=".*"/>
+  <suppress files="brouter-map-creator/.*" checks=".*"/>
+  <suppress files="brouter-mapaccess/.*" checks=".*"/>
+  <suppress files="brouter-server/.*" checks=".*"/>
+  <suppress files="brouter-util/.*" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
As [suggested by @nrenner](https://github.com/abrensch/brouter/pull/441#issuecomment-1179185729) it's helpful to check code formatting automatically.

It seems for java [checkstyle](https://checkstyle.sourceforge.io/) is the usual way. Unfortunately our current codebase has a mixture of tabs and spaces and also mixed indentation which would cause build failures when enabling the checks. Therefore I've just added the configuration/integration but suppressed any results until we fix those issues.

We could manually fix those issues or do a mass reformat similar to #368. For #368 I used the default codestyle from Android Studio because I assumed that's what most people use for android development. As we now want to reformat the whole codebase we need to decide if we want this codestyle for everything or we prefer some different style.