### PR TITLE
Remove cycleroute always having access granted

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -87,14 +87,13 @@ assign defaultaccess
 # calculate logical bike access
 #
 assign bikeaccess =
-       or any_cycleroute
-          switch bicycle=
-                 switch bicycle_road=yes
-                    true
-                    switch vehicle=
-                           ( if highway=footway then false else defaultaccess )
-                           not vehicle=private|no
-                 not or bicycle=private or bicycle=no bicycle=dismount
+       switch bicycle=
+              switch bicycle_road=yes
+                 true
+                 switch vehicle=
+                        ( if highway=footway then false else defaultaccess )
+                        not vehicle=private|no
+              not or bicycle=private or bicycle=no bicycle=dismount
 
 #
 # calculate logical foot access
@@ -115,7 +114,9 @@ assign accesspenalty
               0
               switch footaccess
                      6
-                     10000
+                     switch any_cycleroute
+                            15
+                            10000
 
 #
 # handle one-ways. On primary roads, wrong-oneways should

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -112,8 +112,7 @@ assign defaultaccess =
 # calculate logical bike access
 #
 assign bikeaccess =
-       if any_cycleroute then true
-       else if bicycle= then
+       if bicycle= then
        (
          if bicycle_road=yes then true
          else if vehicle= then ( if highway=footway then false else defaultaccess )
@@ -137,6 +136,7 @@ assign footaccess =
 assign accesspenalty =
        if bikeaccess then 0
        else if footaccess then 4
+       else if any_cycleroute then 15
        else 10000
 
 #


### PR DESCRIPTION
Some bicycle routes can have portions which are not accessible.

Potential reasons for this:
 - temporary construction work on the ways (sometimes for months),
 - local access change without simultaneous update of bicycle route relation
   (lack of mapper's knowledge or lack of time to redefine an updated route),  
 - ... 

This branch changes fastbike & trekking profiles so that being on a cycle 
route does not automatically mean "access granted" for bicycles. The normal 
access checkings are used instead.

However, the accesspenalty is set to 15 if the no-access way belongs to such a 
route, so that the way is not completely forbidden if there is no other 
alternative unavailable.