### PR TITLE
Enable checkstyle for brouter-routing-app

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.java]
 indent_style = space

--- a/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNogoPolygonTest.java
@@ -11,7 +11,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import btools.router.OsmNogoPolygon.Point;
 import btools.util.CheapRuler;
 
 public class OsmNogoPolygonTest {
@@ -77,9 +76,9 @@ public class OsmNogoPolygonTest {
 
   @Test
   public void testIsWithin() {
-    double[] plons = {0.0, 0.5, 1.0, -1.5, -0.5, 1.0, 1.0, 0.5, 0.5, 0.5,};
-    double[] plats = {0.0, 1.5, 0.0, 0.5, -1.5, -1.0, -0.1, -0.1, 0.0, 0.1,};
-    boolean[] within = {true, false, false, false, false, true, true, true, true, true,};
+    double[] plons = {0.0, 0.5, 1.0, -1.5, -0.5, 1.0, 1.0, 0.5, 0.5, 0.5};
+    double[] plats = {0.0, 1.5, 0.0, 0.5, -1.5, -1.0, -0.1, -0.1, 0.0, 0.1};
+    boolean[] within = {true, false, false, false, false, true, true, true, true, true};
 
     for (int i = 0; i < plons.length; i++) {
       assertEquals("(" + plons[i] + "," + plats[i] + ")", within[i], polygon.isWithin(toOsmLon(plons[i], OFFSET_X), toOsmLat(plats[i], OFFSET_Y)));

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -101,6 +101,16 @@ dependencies {
     androidTestImplementation 'androidx.work:work-testing:2.7.1'
 }
 
+check.dependsOn 'checkstyle'
+
+task checkstyle(type: Checkstyle) {
+    source 'src'
+    include '**/*.java'
+    exclude '**/gen/**'
+
+    classpath = files()
+}
+
 task generateProfiles(type: Exec) {
     commandLine = "../misc/scripts/generate_profile_variants.sh"
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterActivity.java
@@ -96,77 +96,80 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
         return builder.create();
       case DIALOG_MAINACTION_ID:
         builder.setTitle("Select Main Action");
-        builder
-          .setItems(new String[]
-              {"Download Manager", "BRouter App"}, new DialogInterface.OnClickListener() {
+        builder.setItems(
+            new String[] { "Download Manager", "BRouter App" },
+            new DialogInterface.OnClickListener() {
               public void onClick(DialogInterface dialog, int item) {
                 if (item == 0)
                   startDownloadManager();
                 else
                   showDialog(DIALOG_SELECTPROFILE_ID);
               }
-            }
-          )
-          .setNegativeButton("Close", new DialogInterface.OnClickListener() {
+            })
+            .setNegativeButton("Close", new DialogInterface.OnClickListener() {
               public void onClick(DialogInterface dialog, int id) {
                 finish();
               }
-            }
-          );
+            });
         return builder.create();
       case DIALOG_SHOW_DM_INFO_ID:
         builder
-          .setTitle("BRouter Download Manager")
-          .setMessage(
-            "*** Attention: ***\n\n" + "The Download Manager is used to download routing-data "
-              + "files which can be up to 170MB each. Do not start the Download Manager " + "on a cellular data connection without a data plan! "
-              + "Download speed is restricted to 16 MBit/s.").setPositiveButton("I know", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-              Intent intent = new Intent(BRouterActivity.this, BInstallerActivity.class);
-              startActivity(intent);
-              showNewDialog(DIALOG_MAINACTION_ID);
-            }
-          }).setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-              finish();
-            }
-          });
+            .setTitle("BRouter Download Manager")
+            .setMessage(
+                "*** Attention: ***\n\n" + "The Download Manager is used to download routing-data "
+                    + "files which can be up to 170MB each. Do not start the Download Manager "
+                    + "on a cellular data connection without a data plan! "
+                    + "Download speed is restricted to 16 MBit/s.")
+            .setPositiveButton("I know", new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int id) {
+                Intent intent = new Intent(BRouterActivity.this, BInstallerActivity.class);
+                startActivity(intent);
+                showNewDialog(DIALOG_MAINACTION_ID);
+              }
+            }).setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int id) {
+                finish();
+              }
+            });
         return builder.create();
       case DIALOG_SHOW_REPEAT_TIMEOUT_HELP_ID:
         builder
-          .setTitle("Successfully prepared a timeout-free calculation")
-          .setMessage(
-            "You successfully repeated a calculation that previously run into a timeout "
-              + "when started from your map-tool. If you repeat the same request from your "
-              + "maptool, with the exact same destination point and a close-by starting point, "
-              + "this request is guaranteed not to time out.").setNegativeButton("Exit", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-              finish();
-            }
-          });
+            .setTitle("Successfully prepared a timeout-free calculation")
+            .setMessage(
+                "You successfully repeated a calculation that previously run into a timeout "
+                    + "when started from your map-tool. If you repeat the same request from your "
+                    + "maptool, with the exact same destination point and a close-by starting point, "
+                    + "this request is guaranteed not to time out.")
+            .setNegativeButton("Exit", new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int id) {
+                finish();
+              }
+            });
         return builder.create();
       case DIALOG_OLDDATAHINT_ID:
         builder
-          .setTitle("Local setup needs reset")
-          .setMessage(
-            "You are currently using an old version of the lookup-table " + "together with routing data made for this old table. "
-              + "Before downloading new datafiles made for the new table, "
-              + "you have to reset your local setup by 'moving away' (or deleting) "
-              + "your <basedir>/brouter directory and start a new setup by calling the " + "BRouter App again.")
-          .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-              finish();
-            }
-          });
+            .setTitle("Local setup needs reset")
+            .setMessage(
+                "You are currently using an old version of the lookup-table "
+                    + "together with routing data made for this old table. "
+                    + "Before downloading new datafiles made for the new table, "
+                    + "you have to reset your local setup by 'moving away' (or deleting) "
+                    + "your <basedir>/brouter directory and start a new setup by calling the " + "BRouter App again.")
+            .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int id) {
+                finish();
+              }
+            });
         return builder.create();
       case DIALOG_ROUTINGMODES_ID:
         builder.setTitle(message);
-        builder.setMultiChoiceItems(routingModes, routingModesChecked, new DialogInterface.OnMultiChoiceClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-            routingModesChecked[which] = isChecked;
-          }
-        });
+        builder.setMultiChoiceItems(routingModes, routingModesChecked,
+            new DialogInterface.OnMultiChoiceClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                routingModesChecked[which] = isChecked;
+              }
+            });
         builder.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int whichButton) {
             mBRouterView.configureService(routingModes, routingModesChecked);
@@ -174,11 +177,15 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
         });
         return builder.create();
       case DIALOG_EXCEPTION_ID:
-        builder.setTitle("An Error occured").setMessage(errorMessage).setPositiveButton("OK", new DialogInterface.OnClickListener() {
-          public void onClick(DialogInterface dialog, int id) {
-            mBRouterView.continueProcessing();
-          }
-        });
+        builder
+            .setTitle("An Error occured")
+            .setMessage(errorMessage)
+            .setPositiveButton("OK",
+                new DialogInterface.OnClickListener() {
+                  public void onClick(DialogInterface dialog, int id) {
+                    mBRouterView.continueProcessing();
+                  }
+                });
         return builder.create();
       case DIALOG_TEXTENTRY_ID:
         builder.setTitle("Enter SDCARD base dir:");
@@ -214,16 +221,17 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
         return builder.create();
       case DIALOG_VIASELECT_ID:
         builder.setTitle("Check VIA Selection:");
-        builder.setMultiChoiceItems(availableVias, getCheckedBooleanArray(availableVias.length), new DialogInterface.OnMultiChoiceClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-            if (isChecked) {
-              selectedVias.add(availableVias[which]);
-            } else {
-              selectedVias.remove(availableVias[which]);
-            }
-          }
-        });
+        builder.setMultiChoiceItems(availableVias, getCheckedBooleanArray(availableVias.length),
+            new DialogInterface.OnMultiChoiceClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                if (isChecked) {
+                  selectedVias.add(availableVias[which]);
+                } else {
+                  selectedVias.remove(availableVias[which]);
+                }
+              }
+            });
         builder.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int whichButton) {
             mBRouterView.updateViaList(selectedVias);
@@ -237,12 +245,13 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
         for (int i = 0; i < nogoList.size(); i++)
           nogoNames[i] = nogoList.get(i).name;
         final boolean[] nogoEnabled = getCheckedBooleanArray(nogoList.size());
-        builder.setMultiChoiceItems(nogoNames, getCheckedBooleanArray(nogoNames.length), new DialogInterface.OnMultiChoiceClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-            nogoEnabled[which] = isChecked;
-          }
-        });
+        builder.setMultiChoiceItems(nogoNames, getCheckedBooleanArray(nogoNames.length),
+            new DialogInterface.OnMultiChoiceClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                nogoEnabled[which] = isChecked;
+              }
+            });
         builder.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int whichButton) {
             mBRouterView.updateNogoList(nogoEnabled);
@@ -293,11 +302,15 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
 
         return builder.create();
       case DIALOG_MODECONFIGOVERVIEW_ID:
-        builder.setTitle("Success").setMessage(message).setPositiveButton("Exit", new DialogInterface.OnClickListener() {
-          public void onClick(DialogInterface dialog, int id) {
-            finish();
-          }
-        });
+        builder
+            .setTitle("Success")
+            .setMessage(message)
+            .setPositiveButton("Exit",
+                new DialogInterface.OnClickListener() {
+                  public void onClick(DialogInterface dialog, int id) {
+                    finish();
+                  }
+                });
         return builder.create();
       case DIALOG_PICKWAYPOINT_ID:
         builder.setTitle(wpCount > 0 ? "Select to/via" : "Select from");
@@ -345,7 +358,8 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
       try {
         StatFs stat = new StatFs(f.getAbsolutePath());
         size = (long) stat.getAvailableBlocks() * stat.getBlockSize();
-      } catch (Exception e) { /* ignore */ }
+      } catch (Exception e) {
+        /* ignore */ }
       dirFreeSizes.add(size);
     }
 
@@ -358,7 +372,8 @@ public class BRouterActivity extends AppCompatActivity implements ActivityCompat
     int bdidx = 0;
     DecimalFormat df = new DecimalFormat("###0.00");
     for (int idx = 0; idx < availableBasedirs.size(); idx++) {
-      basedirOptions[bdidx++] = availableBasedirs.get(idx) + " (" + df.format(dirFreeSizes.get(idx) / 1024. / 1024. / 1024.) + " GB free)";
+      basedirOptions[bdidx++] = availableBasedirs.get(idx) + " ("
+          + df.format(dirFreeSizes.get(idx) / 1024. / 1024. / 1024.) + " GB free)";
     }
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       basedirOptions[bdidx] = "Enter path manually";

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -1,6 +1,5 @@
 package btools.routingapp;
 
-
 import android.app.Service;
 import android.content.Intent;
 import android.os.Bundle;
@@ -49,10 +48,11 @@ public class BRouterService extends Service {
         baseDir = br.readLine();
       } catch (Exception e) {
       } finally {
-        if (configInput != null) try {
-          configInput.close();
-        } catch (Exception ee) {
-        }
+        if (configInput != null)
+          try {
+            configInput.close();
+          } catch (Exception ee) {
+          }
       }
       worker.baseDir = baseDir;
       worker.segmentDir = new File(baseDir, "brouter/segments4");
@@ -94,7 +94,7 @@ public class BRouterService extends Service {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             baos.write("z64".getBytes(Charset.forName("UTF-8"))); // marker prefix
             OutputStream os = new GZIPOutputStream(baos);
-            byte[] ab = gpxMessage.getBytes(Charset.forName("UTF-8")); //StandardCharsets.UTF_8
+            byte[] ab = gpxMessage.getBytes(Charset.forName("UTF-8")); // StandardCharsets.UTF_8
             gpxMessage = null;
             os.write(ab);
             ab = null;
@@ -119,7 +119,7 @@ public class BRouterService extends Service {
       try {
         String modesFile = baseDir + "/brouter/modes/serviceconfig.dat";
         br = new BufferedReader(new FileReader(modesFile));
-        for (; ; ) {
+        for (;;) {
           String line = br.readLine();
           if (line == null)
             break;
@@ -137,10 +137,11 @@ public class BRouterService extends Service {
       } catch (Exception e) {
         return "no brouter service config found, mode " + mode_key;
       } finally {
-        if (br != null) try {
-          br.close();
-        } catch (Exception ee) {
-        }
+        if (br != null)
+          try {
+            br.close();
+          } catch (Exception ee) {
+          }
       }
       return "no brouter service config found for mode " + mode_key;
     }
@@ -163,10 +164,11 @@ public class BRouterService extends Service {
             os = new FileOutputStream(profileFile);
             os.write(profileBytes);
           } finally {
-            if (os != null) try {
-              os.close();
-            } catch (IOException io) {
-            }
+            if (os != null)
+              try {
+                os.close();
+              } catch (IOException io) {
+              }
           }
         }
       } catch (Exception e) {
@@ -182,7 +184,6 @@ public class BRouterService extends Service {
       worker.nogoPolygonsList = new ArrayList<OsmNodeNamed>();
     }
 
-
     private boolean fileEqual(byte[] fileBytes, File file) throws Exception {
       if (!file.exists()) {
         return false;
@@ -196,8 +197,10 @@ public class BRouterService extends Service {
         is = new FileInputStream(file);
         while (pos < nbytes) {
           int len = is.read(buf, 0, blen);
-          if (len <= 0) return false;
-          if (pos + len > nbytes) return false;
+          if (len <= 0)
+            return false;
+          if (pos + len > nbytes)
+            return false;
           for (int j = 0; j < len; j++) {
             if (fileBytes[pos++] != buf[j]) {
               return false;
@@ -206,21 +209,23 @@ public class BRouterService extends Service {
         }
         return true;
       } finally {
-        if (is != null) try {
-          is.close();
-        } catch (IOException io) {
-        }
+        if (is != null)
+          try {
+            is.close();
+          } catch (IOException io) {
+          }
       }
     }
 
     private String checkForTestDummy(String baseDir) {
       File testdummy = new File(baseDir + "/brouter/profiles2/remotetestdummy.brf");
-      if (!testdummy.exists()) return null;
+      if (!testdummy.exists())
+        return null;
       BufferedReader br = null;
       StringBuilder sb = new StringBuilder();
       try {
         br = new BufferedReader(new FileReader(testdummy));
-        for (; ; ) {
+        for (;;) {
           String line = br.readLine();
           if (line == null)
             break;
@@ -230,10 +235,11 @@ public class BRouterService extends Service {
       } catch (Exception e) {
         throw new RuntimeException("error reading " + testdummy);
       } finally {
-        if (br != null) try {
-          br.close();
-        } catch (Exception ee) {
-        }
+        if (br != null)
+          try {
+            br.close();
+          } catch (Exception ee) {
+          }
       }
     }
 
@@ -261,9 +267,8 @@ public class BRouterService extends Service {
     Log.d(getClass().getSimpleName(), "onDestroy()");
   }
 
-
   // This is the old onStart method that will be called on the pre-2.0
-  // platform.  On 2.0 or later we override onStartCommand() so this
+  // platform. On 2.0 or later we override onStartCommand() so this
   // method will not be called.
   @Override
   @SuppressWarnings("deprecation")

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -12,10 +12,17 @@
 
   <module name="TreeWalker">
     <module name="Indentation">
-      <property name="basicOffset" value="2"/>
-      <property name="caseIndent" value="2"/>
-      <property name="throwsIndent" value="2"/>
-      <property name="lineWrappingIndentation" value="2"/>
+      <property name="basicOffset" value="2" />
+      <property name="caseIndent" value="2" />
+      <property name="throwsIndent" value="2" />
+      <property name="lineWrappingIndentation" value="2" />
     </module>
+
+    <module name="ParenPad" />
+    <module name="NoWhitespaceBefore">
+      <property name="allowLineBreaks" value="true" />
+    </module>
+    <module name="WhitespaceAfter" />
+
   </module>
 </module>


### PR DESCRIPTION
The gradle checkstyle plugin works only for modules which use the `java` or `java-library` plugin. The use checkstyle also for our android app gradle needs some additional setup.

In addition I've added some more checkstyle rules which enforce whitespace handling according to our style after reformatting.