### PR TITLE
Update lib part three - ignore misplaced via points

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -48,7 +48,7 @@ public final class OsmTrack {
 
   public List<OsmNodeNamed> pois = new ArrayList<OsmNodeNamed>();
 
-  private static class OsmPathElementHolder {
+  public static class OsmPathElementHolder {
     public OsmPathElement node;
     public OsmPathElementHolder nextHolder;
   }
@@ -928,6 +928,12 @@ public final class OsmTrack {
     return true;
   }
 
+  public OsmPathElementHolder getFromDetourMap(long id) {
+    if (detourMap == null)
+      return null;
+    return detourMap.get(id);
+  }
+
   public void prepareSpeedProfile(RoutingContext rc) {
     // sendSpeedProfile = rc.keyValues != null && rc.keyValues.containsKey( "vmax" );
   }
@@ -987,6 +993,17 @@ public final class OsmTrack {
     return nodes.get(nodes.size() - 1).getTime();
   }
 
+  public void removeVoiceHint(int i) {
+    if (voiceHints != null) {
+      VoiceHint remove = null;
+      for (VoiceHint vh : voiceHints.list) {
+        if (vh.indexInTrack == i)
+          remove = vh;
+      }
+      if (remove != null)
+        voiceHints.list.remove(remove);
+    }
+  }
 
   private MessageData startSection(OsmPathElement element, OsmPathElement root) {
     OsmPathElement e = element;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -78,6 +78,8 @@ public final class RoutingContext {
   public boolean transitonly;
 
   public double waypointCatchingRange;
+  public boolean correctMisplacedViaPoints;
+  public double correctMisplacedViaPointsDistance;
 
   private void setModel(String className) {
     if (className == null) {
@@ -114,8 +116,8 @@ public final class RoutingContext {
       // add parameter to context
       for (Map.Entry<String, String> e : keyValues.entrySet()) {
         float f = Float.parseFloat(e.getValue());
-        expctxWay.setVariableValue(e.getKey(), f, false);
-        expctxNode.setVariableValue(e.getKey(), f, false);
+        expctxWay.setVariableValue(e.getKey(), f, true);
+        expctxNode.setVariableValue(e.getKey(), f, true);
       }
     }
 
@@ -135,6 +137,9 @@ public final class RoutingContext {
 
     // turn-restrictions not used per default for foot profiles
     considerTurnRestrictions = 0.f != expctxGlobal.getVariableValue("considerTurnRestrictions", footMode ? 0.f : 1.f);
+
+    correctMisplacedViaPoints = 0.f != expctxGlobal.getVariableValue("correctMisplacedViaPoints", 1.f);
+    correctMisplacedViaPointsDistance = expctxGlobal.getVariableValue("correctMisplacedViaPointsDistance", 40.f);
 
     // process tags not used in the profile (to have them in the data-tab)
     processUnusedTags = 0.f != expctxGlobal.getVariableValue("processUnusedTags", 0.f);
@@ -457,7 +462,7 @@ public final class RoutingContext {
         }
       }
     }
-    return (int) (d + 1.0);
+    return (int) (d + 0.5);
   }
 
   public OsmPathModel pm;

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -834,6 +834,15 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
     Integer num = variableNumbers.get(name);
     if (num != null) {
       variableData[num.intValue()] = value;
+    } else if (create) {
+      num = getVariableIdx(name, create);
+      float[] readOnlyData = variableData;
+      int minWriteIdx = readOnlyData.length;
+      variableData = new float[variableNumbers.size()];
+      for (int i = 0; i < minWriteIdx; i++) {
+        variableData[i] = readOnlyData[i];
+      }
+      variableData[num.intValue()] = value;
     }
   }
 

--- a/brouter-server/src/test/java/btools/server/RouteServerTest.java
+++ b/brouter-server/src/test/java/btools/server/RouteServerTest.java
@@ -103,7 +103,6 @@ public class RouteServerTest {
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
     Assert.assertEquals(2, geoJson.query("/features/0/properties/voicehints/0/1")); // TL
-    Assert.assertEquals(1, geoJson.query("/features/0/properties/voicehints/1/1")); // C
   }
 
   @Test

--- a/brouter-server/src/test/java/btools/server/RouteServerTest.java
+++ b/brouter-server/src/test/java/btools/server/RouteServerTest.java
@@ -144,6 +144,18 @@ public class RouteServerTest {
     Assert.assertEquals("350", geoJson.query("/features/0/properties/track-length"));
   }
 
+  @Test
+  public void misplacedPoints() throws IOException {
+    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.708678,49.999188|8.71145,49.999761|8.715801,50.00065&nogos=&profile=trekking&alternativeidx=0&format=geojson&correctMisplacedViaPoints=1&timode=3");
+    HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
+    httpConnection.connect();
+
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, httpConnection.getResponseCode());
+
+    InputStream inputStream = httpConnection.getInputStream();
+    JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+    Assert.assertEquals("598", geoJson.query("/features/0/properties/track-length"));
+  }
 
   @Test
   public void uploadValidProfile() throws IOException {


### PR DESCRIPTION
This small routines recalculate the end/start of two tracks to avoid misplaced via points 
Max step go back in track is 10. 
There is also a user defined value for the distance to a misplaced via point. Default is zero - means all distance is used. Or you define e.g. 20 meters of distance so only inside 20 m the via point is removed.
If the via point is not misplaced the call can be done by adding a name to the via point. E.g.:
`8.708678,49.999188;8.71145,49.999761,stop here;8.715801,50.00065`

The output at the moment is not fully correct - the routines for re-calculation follow later on, just to keep it small.
The main discussion is found in #441.
