### PR TITLE
Fix regression of travel time calculation

### DIFF
--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -202,26 +202,20 @@ final class StdPath extends OsmPath {
     elevation_buffer += delta_h;
     double incline = calcIncline(dist);
 
-    double wayMaxspeed;
-
-    wayMaxspeed = rc.expctxWay.getMaxspeed() / 3.6f;
-    if (wayMaxspeed == 0) {
-      wayMaxspeed = rc.maxSpeed;
+    double maxSpeed = rc.maxSpeed;
+    double speedLimit = rc.expctxWay.getMaxspeed() / 3.6f;
+    if (speedLimit > 0) {
+      maxSpeed = Math.min(maxSpeed, speedLimit);
     }
-    wayMaxspeed = Math.min(wayMaxspeed, rc.maxSpeed);
 
-    double speed; // Travel speed
+    double speed = maxSpeed; // Travel speed
     double f_roll = rc.totalMass * GRAVITY * (rc.defaultC_r + incline);
     if (rc.footMode) {
       // Use Tobler's hiking function for walking sections
-      speed = rc.maxSpeed * 3.6;
-      speed = (speed * FastMath.exp(-3.5 * Math.abs(incline + 0.05))) / 3.6;
+      speed = rc.maxSpeed * FastMath.exp(-3.5 * Math.abs(incline + 0.05));
     } else if (rc.bikeMode) {
       speed = solveCubic(rc.S_C_x, f_roll, rc.bikerPower);
-      speed = Math.min(speed, wayMaxspeed);
-    } else // all other
-    {
-      speed = wayMaxspeed;
+      speed = Math.min(speed, maxSpeed);
     }
     float dt = (float) (dist / speed);
     totalTime += dt;

--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -212,7 +212,7 @@ final class StdPath extends OsmPath {
 
     double speed; // Travel speed
     double f_roll = rc.totalMass * GRAVITY * (rc.defaultC_r + incline);
-    if (rc.footMode || rc.expctxWay.getCostfactor() > 4.9) {
+    if (rc.footMode) {
       // Use Tobler's hiking function for walking sections
       speed = rc.maxSpeed * 3.6;
       speed = (speed * FastMath.exp(-3.5 * Math.abs(incline + 0.05))) / 3.6;


### PR DESCRIPTION
The combination of bd02587 and 57da34d causes a bug in the travel time calculation in the kinematic model, which can lead to a significant miscalculation in certain cases:
| Old | New |
| :---: | :---: |
| ![old](https://user-images.githubusercontent.com/122357328/211588739-1cc59ccb-52a2-49fa-902f-165e9245d3b0.jpg) | ![new](https://user-images.githubusercontent.com/122357328/211588761-df89419c-ea82-4ffe-a0ed-b54f4bf6bc13.jpg) |

Example: https://brouter.de/brouter-web/#map=12/51.8281/10.7136/standard&lonlats=10.789197,51.839793;10.636347,51.816129;10.618328,51.799937&profile=fastbike
___
This pull request fixes the bug by removing the [seemingly undocumented behavior](https://brouter.de/brouter/profile_developers_guide.txt) of falling back into hiking mode (at a walking speed equal to the maximum cycling speed: `rc.maxSpeed`) on way segments with a `costfactor > 4.9`.