### PR TITLE
Allow hill cost and hill cutoff in way context

### DIFF
--- a/brouter-core/src/main/java/btools/router/KinematicPath.java
+++ b/brouter-core/src/main/java/btools/router/KinematicPath.java
@@ -248,12 +248,12 @@ final class KinematicPath extends OsmPath {
 
 
   @Override
-  public int elevationCorrection(RoutingContext rc) {
+  public int elevationCorrection() {
     return 0;
   }
 
   @Override
-  public boolean definitlyWorseThan(OsmPath path, RoutingContext rc) {
+  public boolean definitlyWorseThan(OsmPath path) {
     KinematicPath p = (KinematicPath) path;
 
     int c = p.cost;

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -409,9 +409,9 @@ abstract class OsmPath implements OsmLinkHolder {
   protected void computeKinematic(RoutingContext rc, double dist, double delta_h, boolean detailMode) {
   }
 
-  public abstract int elevationCorrection(RoutingContext rc);
+  public abstract int elevationCorrection();
 
-  public abstract boolean definitlyWorseThan(OsmPath p, RoutingContext rc);
+  public abstract boolean definitlyWorseThan(OsmPath p);
 
   public OsmNode getSourceNode() {
     return sourceNode;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -52,10 +52,6 @@ public final class RoutingContext {
 
   public int memoryclass = 64;
 
-  public int downhillcostdiv;
-  public int downhillcutoff;
-  public int uphillcostdiv;
-  public int uphillcutoff;
   public boolean carMode;
   public boolean bikeMode;
   public boolean footMode;
@@ -123,12 +119,6 @@ public final class RoutingContext {
 
     setModel(expctxGlobal._modelClass);
 
-    downhillcostdiv = (int) expctxGlobal.getVariableValue("downhillcost", 0.f);
-    downhillcutoff = (int) (expctxGlobal.getVariableValue("downhillcutoff", 0.f) * 10000);
-    uphillcostdiv = (int) expctxGlobal.getVariableValue("uphillcost", 0.f);
-    uphillcutoff = (int) (expctxGlobal.getVariableValue("uphillcutoff", 0.f) * 10000);
-    if (downhillcostdiv != 0) downhillcostdiv = 1000000 / downhillcostdiv;
-    if (uphillcostdiv != 0) uphillcostdiv = 1000000 / uphillcostdiv;
     carMode = 0.f != expctxGlobal.getVariableValue("validForCars", 0.f);
     bikeMode = 0.f != expctxGlobal.getVariableValue("validForBikes", 0.f);
     footMode = 0.f != expctxGlobal.getVariableValue("validForFoot", 0.f);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -977,7 +977,7 @@ public class RoutingEngine extends Thread {
               if (parentcost < firstMatchCost) firstMatchCost = parentcost;
 
               int costEstimate = path.cost
-                + path.elevationCorrection(routingContext)
+                + path.elevationCorrection()
                 + (costCuttingTrack.cost - pe.cost);
               if (costEstimate <= maxTotalCost) {
                 matchPath = OsmPathElement.create(path, routingContext.countTraffic);
@@ -1110,7 +1110,7 @@ public class RoutingEngine extends Thread {
               OsmLinkHolder dominator = link.getFirstLinkHolder(currentNode);
               while (!trafficSim && dominator != null) {
                 OsmPath dp = (OsmPath) dominator;
-                if (dp.airdistance != -1 && bestPath.definitlyWorseThan(dp, routingContext)) {
+                if (dp.airdistance != -1 && bestPath.definitlyWorseThan(dp)) {
                   break;
                 }
                 dominator = dominator.getNextForLink();

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
@@ -12,7 +12,7 @@ public final class BExpressionContextWay extends BExpressionContext implements T
   private boolean decodeForbidden = true;
 
   private static String[] buildInVariables =
-    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed"};
+    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff"};
 
   protected String[] getBuildInVariableNames() {
     return buildInVariables;
@@ -64,6 +64,22 @@ public final class BExpressionContextWay extends BExpressionContext implements T
 
   public float getMaxspeed() {
     return getBuildInVariable(11);
+  }
+
+  public float getUphillcost() {
+    return getBuildInVariable(12);
+  }
+
+  public float getDownhillcost() {
+    return getBuildInVariable(13);
+  }
+
+  public float getUphillcutoff() {
+    return getBuildInVariable(14);
+  }
+
+  public float getDownhillcutoff() {
+    return getBuildInVariable(15);
   }
 
   public BExpressionContextWay(BExpressionMetaData meta) {


### PR DESCRIPTION
This pull request removes the limitation that `downhillcutoff` and `uphillcutoff` as well as `downhillcost` and `uphillcost` cannot be used in the way context. This opens up new possibilities for the use of the underlying elevation data, as the cost of positive and negative elevation meters can now be evaluated differently depending on the steepness and condition of the way in question.

This is particularly useful for gravel and mountain bike profiles:

| MTB - Old | MTB - New |
| :---: | :---: |
| ![mtb-old](https://user-images.githubusercontent.com/122357328/212549751-358ef16f-55a4-4671-90b6-5a0b555898a1.jpg) | ![mtb-new](https://user-images.githubusercontent.com/122357328/212549759-75a1a231-826e-44e2-bedd-e05e2398cd33.jpg) |

Example: [https://bikerouter.de/#map=12/51.7542/10.7038/...&profile=mtb-zossebart](https://bikerouter.de/#map=12/51.7542/10.7038/standard&lonlats=10.789566,51.839084;10.618454,51.799794;10.789569,51.839086&profile=mtb-zossebart)

Old profile text:
```
---context:global

assign downhillcost   = 30
assign downhillcutoff = 4 
assign uphillcost     = 40
assign uphillcutoff   = 1.5
```
New profile text:
```
---context:way

assign has_decent_surface surface=asphalt|concrete|paved|paving_stones|fine_gravel|compacted
assign bad_when_steep ( and highway=track|path not ( or tracktype=grade1 has_decent_surface ) )

assign downhillcost switch bad_when_steep 120 80
assign downhillcutoff switch bad_when_steep 10 1.5
assign uphillcost switch bad_when_steep 240 160
assign uphillcutoff switch bad_when_steep 4 10
```

These lines are already enough to allow smart mountain bike routing, favoring good ways for elevation gains and unpaved - but not too steep - ways for elevation losses.

___

But it is also useful for normal trekking profiles:

| Trekking - Old | Trekking - New |
| :---: | :---: |
| ![trekking-old](https://user-images.githubusercontent.com/122357328/212551776-909911ab-9dd5-47a1-b694-6e6f0ec242c7.jpg) | ![trekking-new](https://user-images.githubusercontent.com/122357328/212551784-6c7b641d-a0a3-480c-8894-0b03a90a2417.jpg) |

Old profile text:
```
---context:global

assign downhillcost   = 60
assign downhillcutoff = 1.5
assign uphillcost     = 0
assign uphillcutoff   = 1.5
```
New profile text:
```
---context:way

assign has_decent_surface surface=asphalt|concrete|paved|paving_stones|fine_gravel|compacted
assign bad_when_steep ( and highway=track|path not ( or tracktype=grade1 has_decent_surface ) )

assign downhillcost switch bad_when_steep 150 30
assign downhillcutoff switch bad_when_steep 5 8
assign uphillcost switch bad_when_steep 300 60
assign uphillcutoff switch bad_when_steep 4 8
```

Example: [brouter.de/brouter-web/#map=14/39.7689/2.8031/...](https://brouter.de/brouter-web/#map=14/39.7689/2.8031/standard&lonlats=2.819,39.768574;2.795178,39.788868)