### PR TITLE
Update lib part four - recalculation at end of track

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmPathElement.java
+++ b/brouter-core/src/main/java/btools/router/OsmPathElement.java
@@ -36,6 +36,10 @@ public class OsmPathElement implements OsmPos {
     return selev;
   }
 
+  public final void setSElev(short s) {
+    selev = s;
+  }
+
   public final double getElev() {
     return selev / 4.;
   }
@@ -60,6 +64,12 @@ public class OsmPathElement implements OsmPos {
     }
   }
 
+  public final void setAngle(float e) {
+    if (message != null) {
+      message.turnangle = e;
+    }
+  }
+
   public final long getIdFromPos() {
     return ((long) ilon) << 32 | ilat;
   }
@@ -73,7 +83,7 @@ public class OsmPathElement implements OsmPos {
   // construct a path element from a path
   public static final OsmPathElement create(OsmPath path, boolean countTraffic) {
     OsmNode n = path.getTargetNode();
-    OsmPathElement pe = create(n.getILon(), n.getILat(), path.selev, path.originElement, countTraffic);
+    OsmPathElement pe = create(n.getILon(), n.getILat(), n.getSElev(), path.originElement, countTraffic);
     pe.cost = path.cost;
     pe.message = path.message;
     return pe;
@@ -96,6 +106,10 @@ public class OsmPathElement implements OsmPos {
 
   public String toString() {
     return ilon + "_" + ilat;
+  }
+
+  public boolean positionEquals(OsmPathElement e) {
+    return this.ilat == e.ilat && this.ilon == e.ilon;
   }
 
   public void writeToStream(DataOutput dos) throws IOException {

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -378,13 +378,17 @@ public class RoutingEngine extends Thread {
       if (routingContext.correctMisplacedViaPoints && !matchedWaypoints.get(i).direct) {
         changed = snappPathConnection(totaltrack, seg, routingContext.inverseRouting ? matchedWaypoints.get(i + 1) : matchedWaypoints.get(i));
       }
-//      if (wptIndex > 0)
-//        matchedWaypoints.get(wptIndex).indexInTrack = totaltrack.nodes.size() - 1;
 
       totaltrack.appendTrack(seg);
       lastTracks[i] = seg;
     }
-    if (routingContext.poipoints != null) totaltrack.pois = routingContext.poipoints;
+
+    totaltrack.matchedWaypoints = matchedWaypoints;
+    totaltrack.processVoiceHints(routingContext);
+    totaltrack.prepareSpeedProfile(routingContext);
+
+    if (routingContext.poipoints != null)
+      totaltrack.pois = routingContext.poipoints;
     totaltrack.matchedWaypoints = matchedWaypoints;
     return totaltrack;
   }
@@ -1214,8 +1218,6 @@ public class RoutingEngine extends Thread {
     // for final track..
     if (guideTrack != null) {
       track.copyDetours(guideTrack);
-      track.processVoiceHints(routingContext);
-      track.prepareSpeedProfile(routingContext);
     }
     return track;
   }

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -382,6 +382,8 @@ public class RoutingEngine extends Thread {
       if (routingContext.correctMisplacedViaPoints && !matchedWaypoints.get(i).direct) {
         changed = snappPathConnection(totaltrack, seg, routingContext.inverseRouting ? matchedWaypoints.get(i + 1) : matchedWaypoints.get(i));
       }
+      if (wptIndex > 0)
+        matchedWaypoints.get(wptIndex).indexInTrack = totaltrack.nodes.size() - 1;
 
       totaltrack.appendTrack(seg);
       lastTracks[i] = seg;
@@ -389,6 +391,7 @@ public class RoutingEngine extends Thread {
 
     recalcTrack(totaltrack);
 
+    matchedWaypoints.get(matchedWaypoints.size() - 1).indexInTrack = totaltrack.nodes.size() - 1;
     totaltrack.matchedWaypoints = matchedWaypoints;
     totaltrack.processVoiceHints(routingContext);
     totaltrack.prepareSpeedProfile(routingContext);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -237,6 +237,119 @@ public class RoutingEngine extends Thread {
     }
   }
 
+  private void postElevationCheck(OsmTrack track) {
+    OsmPathElement lastPt = null;
+    OsmPathElement startPt = null;
+    short lastElev = Short.MIN_VALUE;
+    short startElev = Short.MIN_VALUE;
+    short endElev = Short.MIN_VALUE;
+    int startIdx = 0;
+    int endIdx = -1;
+    int dist = 0;
+    for (int idx = 0; idx < track.nodes.size(); idx++) {
+      OsmPathElement n = track.nodes.get(idx);
+      if (n.getSElev() == Short.MIN_VALUE && lastElev != Short.MIN_VALUE) {
+        // start one point before entry point to get better elevation results
+        if (idx > 1)
+          startElev = track.nodes.get(idx - 2).getSElev();
+        if (startElev == Short.MIN_VALUE)
+          startElev = lastElev;
+        startIdx = idx;
+        startPt = lastPt;
+        dist = 0;
+        if (lastPt != null)
+          dist += n.calcDistance(lastPt);
+      } else if (n.getSElev() != Short.MIN_VALUE && lastElev == Short.MIN_VALUE && startElev != Short.MIN_VALUE) {
+        // end one point behind exit point to get better elevation results
+        if (idx + 1 < track.nodes.size())
+          endElev = track.nodes.get(idx + 1).getSElev();
+        if (endElev == Short.MIN_VALUE)
+          endElev = n.getSElev();
+        endIdx = idx;
+        OsmPathElement tmpPt = track.nodes.get(startIdx > 1 ? startIdx - 2 : startIdx - 1);
+        int diffElev = endElev - startElev;
+        dist += tmpPt.calcDistance(startPt);
+        dist += n.calcDistance(lastPt);
+        int distRest = dist;
+        double incline = diffElev / (dist / 100.);
+        String lastMsg = "";
+        double tmpincline = 0;
+        double startincline = 0;
+        double selev = track.nodes.get(startIdx - 2).getSElev();
+        boolean hasInclineTags = false;
+        for (int i = startIdx - 1; i < endIdx + 1; i++) {
+          OsmPathElement tmp = track.nodes.get(i);
+          if (tmp.message != null) {
+            MessageData md = tmp.message.copy();
+            String msg = md.wayKeyValues;
+            if (!msg.equals(lastMsg)) {
+              boolean revers = msg.contains("reversedirection=yes");
+              int pos = msg.indexOf("incline=");
+              if (pos != -1) {
+                hasInclineTags = true;
+                String s = msg.substring(pos + 8);
+                pos = s.indexOf(" ");
+                if (pos != -1)
+                  s = s.substring(0, pos);
+
+                if (s.length() > 0) {
+                  try {
+                    int ind = s.indexOf("%");
+                    if (ind != -1)
+                      s = s.substring(0, ind);
+                    ind = s.indexOf("�");
+                    if (ind != -1)
+                      s = s.substring(0, ind);
+                    tmpincline = Double.parseDouble(s.trim());
+                    if (revers)
+                      tmpincline *= -1;
+                  } catch (NumberFormatException e) {
+                    tmpincline = 0;
+                  }
+                }
+              } else {
+                tmpincline = 0;
+              }
+              if (startincline == 0) {
+                startincline = tmpincline;
+              } else if (startincline < 0 && tmpincline > 0) {
+                // for the way ?p find the exit point
+                double diff = endElev - selev;
+                tmpincline = diff / (distRest / 100.);
+              }
+            }
+            lastMsg = msg;
+          }
+          int tmpdist = tmp.calcDistance(tmpPt);
+          distRest -= tmpdist;
+          if (hasInclineTags)
+            incline = tmpincline;
+          selev = (selev + (tmpdist / 100. * incline));
+          tmp.setSElev((short) selev);
+          tmp.message.ele = (short) selev;
+          tmpPt = tmp;
+        }
+        dist = 0;
+      } else if (n.getSElev() != Short.MIN_VALUE && lastElev == Short.MIN_VALUE && startIdx == 0) {
+        // fill at start
+        for (int i = 0; i < idx; i++) {
+          track.nodes.get(i).setSElev(n.getSElev());
+        }
+      } else if (n.getSElev() == Short.MIN_VALUE && idx == track.nodes.size() - 1) {
+        // fill at end
+        for (int i = startIdx; i < track.nodes.size(); i++) {
+          track.nodes.get(i).setSElev(startElev);
+        }
+      } else if (n.getSElev() == Short.MIN_VALUE) {
+        if (lastPt != null)
+          dist += n.calcDistance(lastPt);
+      }
+      lastElev = n.getSElev();
+      lastPt = n;
+    }
+
+  }
+
   private void logException(Throwable t) {
     errorMessage = t instanceof IllegalArgumentException ? t.getMessage() : t.toString();
     logInfo("Error (linksProcessed=" + linksProcessed + " open paths: " + openSet.getSize() + "): " + errorMessage);
@@ -388,6 +501,8 @@ public class RoutingEngine extends Thread {
       totaltrack.appendTrack(seg);
       lastTracks[i] = seg;
     }
+
+    postElevationCheck(totaltrack);
 
     recalcTrack(totaltrack);
 
@@ -1315,7 +1430,7 @@ public class RoutingEngine extends Thread {
       }
       OsmPathElement nextElement = element.origin;
       // ignore double element
-      if (nextElement != null && nextElement.equals(element)) {
+      if (nextElement != null && nextElement.positionEquals(element)) {
         element = nextElement;
         continue;
       }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
@@ -8,6 +8,8 @@ package btools.mapaccess;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
 
 public final class MatchedWaypoint {
   public OsmNode node1;
@@ -17,7 +19,11 @@ public final class MatchedWaypoint {
   public String name;  // waypoint name used in error messages
   public double radius;  // distance in meter between waypoint and crosspoint
   public boolean direct;  // from this point go direct to next = beeline routing
+  public int indexInTrack = 0;
+  public double directionToNext = -1;
+  public double directionDiff = 361;
 
+  public List<MatchedWaypoint> wayNearest = new ArrayList<>();
   public boolean hasUpdate;
 
   public void writeToStream(DataOutput dos) throws IOException {

--- a/brouter-server/src/test/java/btools/server/RouteServerTest.java
+++ b/brouter-server/src/test/java/btools/server/RouteServerTest.java
@@ -76,7 +76,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("1204", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("1169", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test
@@ -89,7 +89,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("1902", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("1866", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test
@@ -115,7 +115,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("521", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("505", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test
@@ -128,7 +128,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("520", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("506", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("350", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("347", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test
@@ -154,7 +154,7 @@ public class RouteServerTest {
 
     InputStream inputStream = httpConnection.getInputStream();
     JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-    Assert.assertEquals("598", geoJson.query("/features/0/properties/track-length"));
+    Assert.assertEquals("546", geoJson.query("/features/0/properties/track-length"));
   }
 
   @Test


### PR DESCRIPTION
The calculation for voice hints and speed profile is moved to the end of track generation. 
This only effects tracks with more then two points.
And a recalculation is done for elevation data and track distances.

The output at the moment is not fully correct - the routines for voice hints will follow.
The main discussion is found in #441.