### PR TITLE
Fix rounding error in calcDistance

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmPathElement.java
+++ b/brouter-core/src/main/java/btools/router/OsmPathElement.java
@@ -75,7 +75,7 @@ public class OsmPathElement implements OsmPos {
   }
 
   public final int calcDistance(OsmPos p) {
-    return (int) (CheapRuler.distance(ilon, ilat, p.getILon(), p.getILat()) + 1.0);
+    return (int) Math.max(1.0, Math.round(CheapRuler.distance(ilon, ilat, p.getILon(), p.getILat())));
   }
 
   public OsmPathElement origin;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -462,7 +462,7 @@ public final class RoutingContext {
         }
       }
     }
-    return (int) (d + 0.5);
+    return (int) Math.max(1.0, Math.round(d));
   }
 
   public OsmPathModel pm;

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNode.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNode.java
@@ -100,7 +100,7 @@ public class OsmNode extends OsmLink implements OsmPos {
   }
 
   public final int calcDistance(OsmPos p) {
-    return (int) (CheapRuler.distance(ilon, ilat, p.getILon(), p.getILat()) + 1.0);
+    return (int) Math.max(1.0, Math.round(CheapRuler.distance(ilon, ilat, p.getILon(), p.getILat())));
   }
 
   public String toString() {


### PR DESCRIPTION
The way BRouter rounds floating-point numbers to integers in the calcDistance function introduces a round-off error accumulation that increases as the average distance between two nodes decreases. This bug caught me completely off guard when I first started working with BRouter.

Here is a comparison of the total distance error distributions of 100k random routes before and after fixing the bug:
![brouter_rounding_error](https://user-images.githubusercontent.com/122357328/213492827-5b440a05-fe6e-47bc-aa5b-1aee7ff9eb11.png)

Nürburgring Sprint course:
- https://www.openstreetmap.org/way/27852990:
- ![sprintcourse](https://user-images.githubusercontent.com/122357328/213422742-ef8aea9e-04ce-4962-9b3b-47e2508d2d08.jpg)
- [https://brouter.de/brouter-web/#map=16/50.3330/6.9438/standard...&profile=shortest](https://brouter.de/brouter-web/#map=16/50.3330/6.9438/standard&lonlats=6.938351,50.329227;6.946246,50.337144;6.946105,50.334522;6.939788,50.333517;6.938351,50.329227&profile=shortest)
- | BRouter: `(int) d + 1` | GPX track length | BRouter: `max(1, round(d))` |
  | ---: | ---: | ---: |
  | 3690 m | 3615 m | 3614 m |