### PR TITLE
Fix regression in elevation filter logic

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -772,16 +772,15 @@ public class RoutingEngine extends Thread {
         if (ele_last != Short.MIN_VALUE) {
           ehb = ehb + (ele_last - ele) * eleFactor;
         }
-        if (ehb > 10.) {
-          ascend += ehb - 10.;
-          ehb = 10.;
-        } else if (ehb < 0.) {
-          ehb = 0.;
+        if (ehb > 0) {
+          ascend += ehb;
+          ehb = 0;
+        } else if (ehb < -10) {
+          ehb = -10;
         }
       }
 
     }
-    ascend += ehb;
 
     t.ascend = (int) ascend;
     t.plainAscend = (int) ((ele_start - ele_end) * eleFactor + 0.5);


### PR DESCRIPTION
25e506d changed the order in which the elevation deltas are passed through the elevation filter, which can lead to the undesirable behavior that appending segments to the end of a route can decrease the calculated total ascent. This fixes the bug by adjusting the elevation filter accordingly.