### PR TITLE
Fix priorityclassifier initialization

### DIFF
--- a/brouter-core/src/main/java/btools/router/KinematicPath.java
+++ b/brouter-core/src/main/java/btools/router/KinematicPath.java
@@ -23,7 +23,6 @@ final class KinematicPath extends OsmPath {
     totalEnergy = origin.totalEnergy;
     floatingAngleLeft = origin.floatingAngleLeft;
     floatingAngleRight = origin.floatingAngleRight;
-    priorityclassifier = origin.priorityclassifier;
   }
 
   @Override

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -112,6 +112,7 @@ abstract class OsmPath implements OsmLinkHolder {
     this.lastClassifier = origin.lastClassifier;
     this.lastInitialCost = origin.lastInitialCost;
     this.bitfield = origin.bitfield;
+    this.priorityclassifier = origin.priorityclassifier;
     init(origin);
     addAddionalPenalty(refTrack, detailMode, origin, link, rc);
   }


### PR DESCRIPTION
The correct initialization of the [priorityclassifier](https://github.com/abrensch/brouter/blob/c15913c1ab9befd8d583d4a7716d5043d2966f64/brouter-core/src/main/java/btools/router/OsmPath.java#L51) used to be skipped [unless the KinematicModel was selected](https://github.com/abrensch/brouter/blob/c15913c1ab9befd8d583d4a7716d5043d2966f64/brouter-core/src/main/java/btools/router/KinematicPath.java#L26), which only happens in the car profiles. This resulted in the [lastpriorityclassifier](https://github.com/abrensch/brouter/blob/c15913c1ab9befd8d583d4a7716d5043d2966f64/brouter-core/src/main/java/btools/router/OsmPath.java#L155) always being zero in both foot and bicycle profiles.

This is a non-functional change, as the `lastpriorityclassifier` is not currently used in either the foot or bicycle profiles.