### PR TITLE
Fix regression in travel time computation

### DIFF
--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -177,13 +177,11 @@ final class StdPath extends OsmPath {
 
   private double calcIncline(double dist) {
     double min_delta = 3.;
-    double shift;
+    double shift = 0.;
     if (elevation_buffer > min_delta) {
       shift = -min_delta;
-    } else if (elevation_buffer < min_delta) {
-      shift = -min_delta;
-    } else {
-      return 0.;
+    } else if (elevation_buffer < -min_delta) {
+      shift = min_delta;
     }
     double decayFactor = FastMath.exp(-dist / 100.);
     float new_elevation_buffer = (float) ((elevation_buffer + shift) * decayFactor - shift);


### PR DESCRIPTION
abrensch@17be365 introduced a bug that causes a negative bias in the calculated incline each time the elevation buffer is reset, which results in an additional misestimation of the travel time when via points are added.

| Old | New |
| :---: | :---: |
| ![old](https://user-images.githubusercontent.com/122357328/217801730-ec8b7fe2-bfb5-4179-8de5-531cd1e04640.jpg) | ![new](https://user-images.githubusercontent.com/122357328/217801771-fc376ea4-d8ed-44b2-914f-4f37545dfab2.jpg) |

Example: [https://brouter.de/brouter-web/#map=16/50.3334/6.9433/standard&lonlats=6.938351,50.329227;...](https://brouter.de/brouter-web/#map=16/50.3334/6.9433/standard&lonlats=6.938351,50.329227;6.938252,50.330235;6.938628,50.330996;6.937885,50.334007;6.939961,50.335616;6.94083,50.335806;6.94168,50.335962;6.942735,50.336113;6.944152,50.336339;6.945284,50.336544;6.946246,50.337144;6.947642,50.337477;6.949309,50.337702;6.949536,50.336719;6.948459,50.33604;6.947563,50.335441;6.946273,50.334561;6.945267,50.333934;6.943507,50.332825;6.941929,50.331944;6.941218,50.33175;6.94148,50.332735;6.938997,50.333348;6.938803,50.332778;6.940023,50.332263;6.938351,50.329227)
___
Due to the bug (probably a simple typo), the old code:
https://github.com/abrensch/brouter/blob/a49c43d1efa2332af23ba5ee6916f10af4d22c74/brouter-core/src/main/java/btools/router/StdPath.java#L180-L187
was equivalent to `double shift = -min_delta;`.
___
However, there are fundamental flaws in the way via points are currently handled, so even with this correction, the addition of via points may still degrade the travel time estimate.