### PR TITLE
Update Lib Part Six - Change Export

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -171,6 +171,7 @@ public final class RoutingContext {
     showspeed = 0.f != expctxGlobal.getVariableValue("showspeed", 0.f);
     showSpeedProfile = 0.f != expctxGlobal.getVariableValue("showSpeedProfile", 0.f);
     inverseRouting = 0.f != expctxGlobal.getVariableValue("inverseRouting", 0.f);
+    showTime = 0.f != expctxGlobal.getVariableValue("showtime", 0.f);
 
     int tiMode = (int) expctxGlobal.getVariableValue("turnInstructionMode", 0.f);
     if (tiMode != 1) // automatic selection from coordinate source
@@ -233,6 +234,7 @@ public final class RoutingContext {
   public boolean showspeed;
   public boolean showSpeedProfile;
   public boolean inverseRouting;
+  public boolean showTime;
 
   public OsmPrePath firstPrePath;
 

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -511,6 +511,9 @@ public class RoutingEngine extends Thread {
     totaltrack.processVoiceHints(routingContext);
     totaltrack.prepareSpeedProfile(routingContext);
 
+    totaltrack.showTime = routingContext.showTime;
+    totaltrack.params = routingContext.keyValues;
+
     if (routingContext.poipoints != null)
       totaltrack.pois = routingContext.poipoints;
     totaltrack.matchedWaypoints = matchedWaypoints;

--- a/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
+++ b/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
@@ -26,12 +26,12 @@ interface IBRouterService {
     //  "nogos"           = lon,lat,radius|... (optional, radius in meters)
     //  "polylines"       = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)
     //  "polygons"        = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)
-    //  "profile"         = profile file name without .brf 
+    //  "profile"         = profile file name without .brf
     //  "alternativeidx"  = [0|1|2|3] (optional, default 0)
     //  "exportWaypoints" = 1 to export them (optional, default is no export)
     //  "pois"            = lon,lat,name|... (optional)
     //  "extraParams"     = Bundle key=value list for a profile setup (like "profile:")
-    //  "timode"          = turnInstructionMode [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-new-style, 8=cruiser-stylem, 9=brouter-intern] default 0
+    //  "timode"          = turnInstructionMode [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style] default 0
     //  "heading"         = angle (optional to give a route a start direction)
     //  "direction"       = angle (optional, used like "heading" on a recalculation request by Locus as start direction)
 

--- a/brouter-util/src/main/java/btools/util/CheapAngleMeter.java
+++ b/brouter-util/src/main/java/btools/util/CheapAngleMeter.java
@@ -46,4 +46,30 @@ public final class CheapAngleMeter {
     }
     return offset + sinp * (57.4539 + s2 * (9.57565 + s2 * (4.30904 + s2 * 2.56491)));
   }
+
+  public static double getAngle(int lon1, int lat1, int lon2, int lat2) {
+    double res = 0;
+    double xdiff = lat2 - lat1;
+    double ydiff = lon2 - lon1;
+    res = Math.toDegrees(Math.atan2(ydiff, xdiff));
+    return res;
+  }
+
+  public static double getDirection(int lon1, int lat1, int lon2, int lat2) {
+    double res = getAngle(lon1, lat1, lon2, lat2);
+    return normalize(res);
+  }
+
+  public static double normalize(double a) {
+    return a >= 360 ? a - (360 * (int) (a / 360))
+      : a < 0 ? a - (360 * ((int) (a / 360) - 1)) : a;
+  }
+
+  public static double getDifferenceFromDirection(double b1, double b2) {
+    double r = (b2 - b1) % 360.0;
+    if (r < -180.0) r += 360.0;
+    if (r >= 180.0) r -= 360.0;
+    return Math.abs(r);
+  }
+
 }

--- a/brouter-util/src/test/java/btools/util/CheapAngleMeterTest.java
+++ b/brouter-util/src/test/java/btools/util/CheapAngleMeterTest.java
@@ -109,4 +109,149 @@ public class CheapAngleMeterTest {
     }
   }
 
+  @Test
+  public void testGetAngle() {
+    CheapAngleMeter am = new CheapAngleMeter();
+    int lon1, lat1, lon2, lat2;
+
+    lon1 = toOsmLon(10.0);
+    lat1 = toOsmLat(50.0);
+    lon2 = toOsmLon(10.0);
+    lat2 = toOsmLat(60.0);
+
+    double angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, 0.0, angle, 0.0);
+
+    lon2 = toOsmLon(10.0);
+    lat2 = toOsmLat(40.0);
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, 180.0, angle, 0.0);
+
+    lon2 = toOsmLon(0.0);
+    lat2 = toOsmLat(50.0);
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, -90.0, angle, 0.0);
+
+    lon2 = toOsmLon(20.0);
+    lat2 = toOsmLat(50.0);
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, 90.0, angle, 0.0);
+
+    lon2 = toOsmLon(20.0);
+    lat2 = toOsmLat(60.0);
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, 45.0, angle, 0.0);
+
+    lon2 = toOsmLon(0.0);
+    lat2 = toOsmLat(60.0);
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, -45.0, angle, 0.0);
+
+    lon1 = 1;
+    lat1 = 1;
+    lon2 = 2;
+    lat2 = 2;
+    angle = am.getAngle(lon1, lat1, lon2, lat2);
+    assertEquals("Angle = " + angle, 45.0, angle, 0.0);
+
+  }
+
+  @Test
+  public void testGetDirection() {
+    CheapAngleMeter am = new CheapAngleMeter();
+    int lon1, lat1, lon2, lat2;
+
+    lon1 = toOsmLon(10.0);
+    lat1 = toOsmLat(50.0);
+    lon2 = toOsmLon(10.0);
+    lat2 = toOsmLat(60.0);
+
+    double angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 0.0, angle, 0.0);
+
+    lon2 = toOsmLon(10.0);
+    lat2 = toOsmLat(40.0);
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 180.0, angle, 0.0);
+
+    lon2 = toOsmLon(0.0);
+    lat2 = toOsmLat(50.0);
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 270.0, angle, 0.0);
+
+    lon2 = toOsmLon(20.0);
+    lat2 = toOsmLat(50.0);
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 90.0, angle, 0.0);
+
+    lon2 = toOsmLon(20.0);
+    lat2 = toOsmLat(60.0);
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 45.0, angle, 0.0);
+
+    lon2 = toOsmLon(0.0);
+    lat2 = toOsmLat(60.0);
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 315.0, angle, 0.0);
+
+    lon1 = 1;
+    lat1 = 1;
+    lon2 = 2;
+    lat2 = 2;
+    angle = am.getDirection(lon1, lat1, lon2, lat2);
+    assertEquals("Direction = " + angle, 45.0, angle, 0.0);
+
+  }
+
+  @Test
+  public void testNormalize() {
+    CheapAngleMeter am = new CheapAngleMeter();
+
+    double n = 1;
+    assertEquals("Direction  normalize = " + n, 1, am.normalize(n), 0.0);
+
+    n = -1;
+    assertEquals("Direction normalize  = " + n, 359, am.normalize(n), 0.0);
+
+    n = 361;
+    assertEquals("Direction normalize  = " + n, 1, am.normalize(n), 0.0);
+
+    n = 0;
+    assertEquals("Direction  normalize = " + n, 0, am.normalize(n), 0.0);
+
+    n = 360;
+    assertEquals("Direction  normalize = " + n, 0, am.normalize(n), 0.0);
+
+  }
+
+  @Test
+  public void testCalcAngle6() {
+    CheapAngleMeter am = new CheapAngleMeter();
+
+    double a1 = 90;
+    double a2 = 180;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 90, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+    a1 = 180;
+    a2 = 90;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 90, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+    a1 = 5;
+    a2 = 355;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 10, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+    a1 = 355;
+    a2 = 5;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 10, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+    a1 = 90;
+    a2 = 270;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 180, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+    a1 = 270;
+    a2 = 90;
+    assertEquals("Direction diff " + a1 + " " + a2 + " = ", 180, am.getDifferenceFromDirection(a1, a2), 0.0);
+
+  }
+
 }

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -97,7 +97,7 @@ Some variable names are pre-defined and accessed by the routing engine:
   - 3 variables to influence the generation of turn-instructions
 
     - `turnInstructionMode`          0=none, 1=auto-choose, 2=locus-style,
-      3=osmand-style
+      3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style
     - `turnInstructionCatchingRange` default=40m
     - `turnInstructionRoundabouts`   default=true generate explicit roundabout
       hints

--- a/misc/profiles2/car-vario.brf
+++ b/misc/profiles2/car-vario.brf
@@ -27,7 +27,7 @@ assign f_recup          = 400    # %f_recup% | Newton | number
 assign p_standby        = 250    # %p_standby% | Watt | number
 
 # Turn instructions settings
-assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style]
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 
 # Technical parameters
 assign pass1coefficient    = 1.3

--- a/misc/profiles2/fastbike-verylowtraffic.brf
+++ b/misc/profiles2/fastbike-verylowtraffic.brf
@@ -1,8 +1,8 @@
-#  "fastbike-verylowtraffic.brf" -- Version 23.08.2021  
+#  "fastbike-verylowtraffic.brf" -- Version 23.08.2021
 #  This profile, developed by Ess Bee, is based on the "fastbike-lowtraffic" profile
 #   it is intended for road cyclists who ride alone and / or in the middle of the week: thus trucks and high traffic are avoided
 #  (cyclists in group at the weekend will rather use "fastbike.brf" or "fastbike-lowprofile.brf" as groups are better respected by cars and trucks)
-# 
+#
 #     ==> where ever possible, choose:
 #     - an asphalted way (with good smoothness)
 #     - cycleways are prefered
@@ -11,13 +11,13 @@
 #          - avoid segments with high-traffic
 #
 #  The route is calculated using the taggs of the OSM map (such as highway, surface, smoothness, maxspeed, traffic_class...)
-#              
-  
----context:global   # following code refers to global config
-assign processUnusedTags false  # set to true if you want to display all tags in the "data" 
+#
 
-# to generate turn instructions, adapt the mode by need 
-assign   turnInstructionMode  = 1  # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style]
+---context:global   # following code refers to global config
+assign processUnusedTags false  # set to true if you want to display all tags in the "data"
+
+# to generate turn instructions, adapt the mode by need
+assign   turnInstructionMode  = 1  # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 
 # Use the following switches to change behaviour
 
@@ -25,11 +25,11 @@ assign   consider_elevation   = false   # %consider_elevation% | set to true to 
 assign   avoid_path           = false   # %avoid_path% | set to true to avoid pathes | boolean
 assign   consider_traffic   =  1        #  %consider_traffic% | 0 => no cost for "traffic_class" or "maxspeed", 1 => costs are considered!: value example 0.3 | number
 
-assign   cycleway_lane_penalty = 0      # 0 => when lane, no cost for traffic or max speed, 1 => same cost as on the highway itself: example 0.3 
+assign   cycleway_lane_penalty = 0      # 0 => when lane, no cost for traffic or max speed, 1 => same cost as on the highway itself: example 0.3
 
 assign turnInstructionCatchingRange = 8 # 2 turn instructions are generated only when distance > 8 m
 assign turnInstructionRoundabouts = false # roundabout, no "take exit N" (as "N" may be confusing compared to car)
-assign considerTurnRestrictions = true   # turn restrictions are considered  
+assign considerTurnRestrictions = true   # turn restrictions are considered
 
 assign   validForBikes        1
 
@@ -42,7 +42,7 @@ assign   validForBikes        1
 
 assign downhillcost  60
 assign downhillcutoff switch consider_elevation 1.5 15
-assign uphillcost 100 
+assign uphillcost 100
 assign uphillcutoff switch consider_elevation 1.5 15
 
 
@@ -57,19 +57,19 @@ assign cycleway_right if reversedirection=yes
 			      then if cycleway:left=track|lane|shared_lane then 1 else 0
                       else if cycleway:right=track|lane|shared_lane then 1 else 0
 
-assign any_cycleway  or cycleway=track|lane|shared_lane|shared cycleway_right 
-# as soon it is supported in lookup, add ==> bicycle_road=yes in any_cycleway 
+assign any_cycleway  or cycleway=track|lane|shared_lane|shared cycleway_right
+# as soon it is supported in lookup, add ==> bicycle_road=yes in any_cycleway
 
-# in relation with "route=bicycle" ? 
+# in relation with "route=bicycle" ?
 assign any_cycleroute or route_bicycle_icn=yes or route_bicycle_ncn=yes or route_bicycle_rcn=yes route_bicycle_lcn=yes
 
 assign nodeaccessgranted or any_cycleroute lcn=yes
 
 assign ispaved or surface=paved surface=asphalt
-assign isunpaved   surface=unpaved|gravel|dirt|earth|ground|sand  
+assign isunpaved   surface=unpaved|gravel|dirt|earth|ground|sand
 
-assign isfine_gravel  surface=fine_gravel|cobblestone|compacted|paving_stones     
-assign isconcrete surface=concrete     
+assign isfine_gravel  surface=fine_gravel|cobblestone|compacted|paving_stones
+assign isconcrete surface=concrete
 
 assign turncost = if junction=roundabout then 0
                   else 10
@@ -148,35 +148,35 @@ assign onewaypenalty =
        else 0.0
 
 assign surfacepenalty =
-# if "surface" is not defined...        
-        switch surface= 
+# if "surface" is not defined...
+        switch surface=
 #      then, for Primary, secondary and tertiary asphalt is very probable
                switch highway=primary|primary_link|secondary|secondary_link|tertiary|tertiary_link 0
-#      then, for residential & Co. probably asphalt..          
-               switch highway=road|residential|unclassified          0.1 
+#      then, for residential & Co. probably asphalt..
+               switch highway=road|residential|unclassified          0.1
 #      then, for living_street something paved ..
                switch highway=living_street                          0.3
 #      then, for "service & cycleway"  possibly good (but not sure!) ...
-               switch highway=service|cycleway 0.5 
+               switch highway=service|cycleway 0.5
 # in some cases only smoothness is tagged but surface not!
                switch smoothness=intermediate|good|excellent         0
-# else, check if tracktype=grade1, then it is "something" paved, so middle penalty 
+# else, check if tracktype=grade1, then it is "something" paved, so middle penalty
                switch tracktype=grade1                               0.2
-# if a cycleroute is defined, surface can not be horrible...               
+# if a cycleroute is defined, surface can not be horrible...
                switch any_cycleroute                                 3.5 5
         switch surface=asphalt                                       0
         switch surface=paved switch smoothness=good|excellent        0.1  0.3 # befestigte(harte)Oberfl sche
         switch surface=gravel|sand|pebblestone|unpaved               10       # Schotter, Sand, Kies, unbefestigt
         switch surface=ground|grass|dirt|earth|mud|clay              25       # naturbelassene Oberfl sche, Gras, Schutz Schlamm...
-        switch surface=fine_gravel|compacted switch smoothness=good|excellent 1  4        # Splitt,verdichtete Oberflaesche  
+        switch surface=fine_gravel|compacted switch smoothness=good|excellent 1  4        # Splitt,verdichtete Oberflaesche
         switch surface=sett switch smoothness=good|excellent         0.1  0.3 # behauene Pflastersteine
         switch concrete=plates                                       1        # Betonplattenwege
         switch surface=concrete|paving_stones|wood|metal             0.8      # Beton, Pflastersteine (geschnitzt), Holz, Metall
         switch surface=cobblestone|sett switch smoothness=good|excellent  1 2 # Kopfsteinpflaster
 #       switch surface=unhewn_cobblestone                            3        # ungeschnitzter Pflasterstein
         switch concrete=lanes                                        3        # Betonspurplatten
-        switch surface=grass_paver                                   5        # Rasengittersteine 
-        
+        switch surface=grass_paver                                   5        # Rasengittersteine
+
 # surface not known and probably not paved / no asphalt...
                                                                      8
 
@@ -189,7 +189,7 @@ assign tracktypepenalty
 
 
 assign trafficpenalty =
-#	if any_cycleway then   0 
+#	if any_cycleway then   0
 #	else
 if highway=primary|primary_link then
     (
@@ -229,12 +229,12 @@ assign smoothnesspenalty =
 assign maxspeedpenalty =
        switch or highway=primary highway=primary_link
 # as soon "name" is supported in lookup, replace with "switch maxspeed= switch name= 2.2 1
-         switch maxspeed=50 multiply 0.2      consider_traffic    
+         switch maxspeed=50 multiply 0.2      consider_traffic
 #         switch any_cycleway multiply 0.2    consider_traffic
          switch maxspeed=60 multiply 0.7      consider_traffic
          switch maxspeed=70 multiply 1.2      consider_traffic
-         switch maxspeed=80 multiply 1.5      consider_traffic 
-         switch maxspeed=90 multiply 2.0      consider_traffic 
+         switch maxspeed=80 multiply 1.5      consider_traffic
+         switch maxspeed=90 multiply 2.0      consider_traffic
          switch maxspeed=100 multiply 3.0     consider_traffic
          switch maxspeed=110 multiply 11      consider_traffic
          switch maxspeed=120 multiply 12      consider_traffic
@@ -275,36 +275,36 @@ assign usesidepathpenalty =
 # give a light advantage to highways with a relation cycleroute
 assign nocycleroute_penalty switch any_cycleroute  0 0.05
 
-assign not_bicycle_designatedpenalty switch bicycle=designated 0 0.1              
+assign not_bicycle_designatedpenalty switch bicycle=designated 0 0.1
 
 assign sum_highwaypenalty
   add surfacepenalty
   add tracktypepenalty
   add trafficpenalty
-  add smoothnesspenalty 
+  add smoothnesspenalty
   add maxspeedpenalty
   add usesidepathpenalty
   add nocycleroute_penalty
       not_bicycle_designatedpenalty
-          
+
 # penalties differ when a cycleway is associated to the highway with "cycleway=yes"
 
-assign cycleway_surfacepenalty 
-  switch any_cycleway 
-        switch cycleway:surface=                                              surfacepenalty  # if not specified,  same as highway    
+assign cycleway_surfacepenalty
+  switch any_cycleway
+        switch cycleway:surface=                                              surfacepenalty  # if not specified,  same as highway
         switch cycleway:surface=asphalt                                       0
         switch cycleway:surface=sett                                          0.3      # behauene Pflastersteine
         switch cycleway:surface=paved                                         0.3      # befestigte(harte)Oberflaesche
         switch cycleway:surface=concrete|paving_stones                        0.8      # Beton, Pflastersteine (geschnitzt)
         switch cycleway:surface=cobblestone|sett                              2        # Kopfsteinpflaster
-        switch cycleway:surface=fine_gravel|compacted                         4        # Splitt,verdichtete Oberflaesche  
+        switch cycleway:surface=fine_gravel|compacted                         4        # Splitt,verdichtete Oberflaesche
         switch cycleway:surface=gravel                                        10       # Schotter
                                                                               0        # unknown value...
         1000    # noc cycleway
 
-# to be activated after implementation of #241                                                                                                                                         
+# to be activated after implementation of #241
 #assign cycleway_smoothnesspenalty
-#        switch cycleway:smoothness=                                          smoothnesspenalty # if not specified,  same as highway    
+#        switch cycleway:smoothness=                                          smoothnesspenalty # if not specified,  same as highway
 #        switch cycleway:smoothness=intermediate                               0.3
 #        switch cycleway:smoothness=bad                                        1
 #        switch cycleway:smoothness=very_bad                                   2
@@ -312,17 +312,17 @@ assign cycleway_surfacepenalty
 #        0
 
 # temporary...
-assign cycleway_smoothnesspenalty             smoothnesspenalty # temporray same as highway    
+assign cycleway_smoothnesspenalty             smoothnesspenalty # temporray same as highway
 
 assign sum_cyclewaypenalty
    switch any_cycleway                                                        # cycleway exists
-       add multiply maxspeedpenalty cycleway_lane_penalty 
-       add multiply trafficpenalty cycleway_lane_penalty 
+       add multiply maxspeedpenalty cycleway_lane_penalty
+       add multiply trafficpenalty cycleway_lane_penalty
        add cycleway_surfacepenalty
-       add cycleway_smoothnesspenalty 
+       add cycleway_smoothnesspenalty
            usesidepathpenalty
 #       add nocycleroute_penalty
-#       add not_bicycle_designatedpenalty  
+#       add not_bicycle_designatedpenalty
                                                                               10000  # no cycleway
 
 assign costfactor
@@ -345,7 +345,7 @@ assign costfactor
   switch    highway=residential switch bicycle_road=yes  1      1.4
   switch    highway=service switch ( or service=  service=alley ) 1.1 11
   switch    highway=track|road                        0.9
-  switch    highway=path   switch avoid_path           2 1 
+  switch    highway=path   switch avoid_path           2 1
   switch    highway=footway   switch bicycle=yes      1.7      4.7
                                                       19.9
 
@@ -368,7 +368,7 @@ assign priorityclassifier =
   else if ( highway=service                   ) then  8
   else if ( highway=cycleway                  ) then  8
   else if ( bicycle=designated                ) then  8
-  else if ( highway=track|road|path ) 
+  else if ( highway=track|road|path )
         then if or surface=asphalt|paved|paving_stones|concrete|wood|metal tracktype=grade1 then 8 else 6
   else if ( highway=steps                     ) then  2
   else if ( highway=pedestrian                ) then  2
@@ -388,7 +388,7 @@ assign isgoodforcars = if greater priorityclassifier 6 then true
 
 # ... encoded into a bitmask
 
-assign classifiermask 
+assign classifiermask
 #      add          isbadoneway	# no voice hint if 1 of the 2 possibilities is badoneway
                       add multiply isgoodoneway   2
                       add multiply isroundabout   4
@@ -426,12 +426,12 @@ assign footaccess
                         1
 
 assign railwaypenalty switch railway= 0 155
-# assign signalpenalty  switch highway=traffic_signals  99 
+# assign signalpenalty  switch highway=traffic_signals  99
 #                             switch crossing=traffic_signals 49 0
 # note: in case of a "left-turn" at the traffic-signal the penalty is counted twice...
 
-assign barrierpenalty  switch barrier= 0 
-                       switch barrier=block|bollard 59 139 
+assign barrierpenalty  switch barrier= 0
+                       switch barrier=block|bollard 59 139
 
 assign initialcost
        add railwaypenalty

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -47,7 +47,7 @@ assign C_r        = 0.01   # %C_r% | Rolling resistance coefficient (dimensionle
 assign bikerPower = 100    # %bikerPower% | Average power (in W) provided by the biker, for travel time computation | number
 
 # Turn instructions settings
-assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style]
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 assign turnInstructionCatchingRange = 40    # %turnInstructionCatchingRange% | Within this distance (in m) several turning instructions are combined into one and the turning angles are better approximated to the general direction | number
 assign turnInstructionRoundabouts   = true  # %turnInstructionRoundabouts% | Set to "false" to avoid generating special turning instructions for roundabouts | boolean
 

--- a/misc/profiles2/hiking-mountain.brf
+++ b/misc/profiles2/hiking-mountain.brf
@@ -1,7 +1,7 @@
 # Walking-Hiking-Mountain/Alpine Hiking profile TEMPLATE
 # 18/5/2016  v1.8.7   ! Fixed down/uphillcostfactors for shortest_way - to be really shortest
 #
-# SAC T3 - demanding_mountain_hiking - exposed sites may be secured, possible need of hands for balance,	Partly exposed with fall hazard, Well sure-footed, Good hiking shoes, Basic alpine experience 
+# SAC T3 - demanding_mountain_hiking - exposed sites may be secured, possible need of hands for balance,	Partly exposed with fall hazard, Well sure-footed, Good hiking shoes, Basic alpine experience
 #
 # Legend above is placeholder for generated comments of final profile
 # See the profile bottom for changelogs and verbose *) comments
@@ -13,7 +13,7 @@
 assign   consider_elevation       1    # 0 as default, otherwise less interesting flat roads are chosen.
 assign   shortest_way             0    # 0 as default, duplicate shortest standard profile, SAC access limit ignored for now
 
-assign   turnInstructionMode  =   1       # 0=none, 1=auto-choose, 2=locus-style, 3=osmand-style
+assign   turnInstructionMode  =   1       # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 assign   turnInstructionCatchingRange  20 # V1.8.5 / default=40, but foot paths may be more distingushed, especially in cities.
 
 assign   iswet                     0       # 0 as default, 1 tries to prevent muddy boots and wet buttocks
@@ -28,10 +28,10 @@ assign   path_preference          0.0 # 0.0 as default, try 20.0 to penalize non
 assign   SAC_scale_limit          3    # 0..6, 0 to avoid any SAC paths, 1 for T1 as maximum, 6 for T6 as maximum
                                        # all paths with sac_scale higher than  SAC_scale_limit are forbidden.
 assign   SAC_scale_preferred      1    # The same, but the preferred SAC scale level. Level below are slightly, above strongly penalized
-assign   SAC_access_penalty       9000 # costfactor 9999 means the most horrible but allowed road., 
+assign   SAC_access_penalty       9000 # costfactor 9999 means the most horrible but allowed road.,
                                        # 100000=forbidden. This makes difference if forbidden way is the only option.
-assign  SAC_K1 0.05                    # Penalizing of SAC levels below preferred 
-assign  SAC_K2 0.6                     # Penalizing of SAC levels above preferred  
+assign  SAC_K1 0.05                    # Penalizing of SAC levels below preferred
+assign  SAC_K2 0.6                     # Penalizing of SAC levels above preferred
 
 #orientation/decision penalties, not used for preferred hiking routes
 assign   turncost_value           0 # not used now
@@ -58,14 +58,14 @@ assign   Offroad_hillcostfactor   multiply -0.3333 ( max -3.0 ( multiply -1.0 ( 
                   # progressively decreases hillcosts to be 0.0 at Offroad_factor = 3.0
                   # if Offroad_factor = 1 , then downhillcost decreases e.g. from 60 to 40
 
-assign   downhillcost if consider_elevation  then 
+assign   downhillcost if consider_elevation  then
         ( multiply ( add 1.0 ( multiply Offroad_hillcostfactor -1.0 ) ) downhillcostvalue ) else 0
 
 assign   uphillcost   if consider_elevation  then
         ( multiply ( add 1.0 ( multiply Offroad_hillcostfactor -1.0 ) ) uphillcostvalue ) else 0
 
 assign   uphillcutoff    if  consider_elevation   then    uphillcutoffvalue else 1.5
-assign   downhillcutoff  if  consider_elevation   then  downhillcutoffvalue else 1.5 
+assign   downhillcutoff  if  consider_elevation   then  downhillcutoffvalue else 1.5
 
 assign   nonhiking_route_penalty    add 1.0 max 0.0 hiking_routes_preference
 
@@ -80,7 +80,7 @@ assign   validForFoot        1
 #Penalty is ( 1 + SAC_K1)^(SAC_scale_preferred - SAC) -1 for  SAC_scale_preferred > SAC, SAC <= SAC_scale_limit
 #Penalty is ( 1 + SAC_K2)^(SAC - SAC_scale_preferred) -1 for  SAC_scale_preferred < SAC, SAC <= SAC_scale_limit
 
-#extra complexity of code below, with adding +/- 1.0 
+#extra complexity of code below, with adding +/- 1.0
 #is to keep final penalties additive, even with multiplicative incremental penalty approach
 #code is run only once, being in global context
 
@@ -109,35 +109,35 @@ assign any_hiking_route or route=hiking             or route_hiking_iwn=yes
                         or route_hiking_nwn=yes     or route_hiking_rwn=yes
                         or route_hiking_lwn=yes     or route_hiking_=yes
                         or route_foot_=yes          or route_foot_nwn=yes
-                        or route_foot_rwn=yes       route_foot_lwn=yes      
-                        
+                        or route_foot_rwn=yes       route_foot_lwn=yes
+
 assign any_cycleroute =
      if      route_bicycle_icn=yes then true
      else if route_bicycle_ncn=yes then true
      else if route_bicycle_rcn=yes then true
      else if route_bicycle_lcn=yes then true
-     else false                        
-                       
+     else false
+
 assign is_ldhr                  and any_hiking_route not equal 0.0 hiking_routes_preference
 assign nodeaccessgranted        any_hiking_route
 
 # ismuddy addresses potentially bad surface conditions during wet weather ( mud, slickiness of grass)
-assign ismuddy      and or isunpaved surface= 
+assign ismuddy      and or isunpaved surface=
                     and iswet
-                    not or surface=gravel surface=pebblestone 
+                    not or surface=gravel surface=pebblestone
 
 assign issidewalk   sidewalk=left|right|both|yes
 
 assign istrack      highway=track|road|path|footway
 assign ismainroad   highway=motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified
 
-#assign turncost   switch or shortest_way  is_ldhr   0 turncost_value  #v1.5 
+#assign turncost   switch or shortest_way  is_ldhr   0 turncost_value  #v1.5
 assign turncost   0 #v1.8.3
 
-assign initialcost 
-   switch route=ferry 10000  
-      
-   switch or shortest_way  is_ldhr  0 initialcost_value 
+assign initialcost
+   switch route=ferry 10000
+
+   switch or shortest_way  is_ldhr  0 initialcost_value
 
 assign defaultaccess    switch access=    not motorroad=yes    switch or access=private access=no   0   1
 
@@ -151,28 +151,28 @@ assign bikeaccess
                                1
                  not or bicycle=private or bicycle=no bicycle=dismount
 
-assign footaccess     or any_hiking_route 
-                      or issidewalk 
+assign footaccess     or any_hiking_route
+                      or issidewalk
                       or and bikeaccess  not foot=no
                       or bicycle=dismount
                       switch foot=      defaultaccess    not foot=private|no
-                         
+
 assign accesspenalty switch footaccess 0 switch bikeaccess 4 100000
 
 assign badoneway = 0
 assign onewaypenalty = 0
 
 
-#SAC is estimated path difficulty, 
+#SAC is estimated path difficulty,
 #integrating both MTB and SAC scales with estimated MTB/SAC difficulty matching
 #see http://wiki.openstreetmap.org/wiki/Key:mtb:scale
 #    http://wiki.openstreetmap.org/wiki/Key:sac_scale
 
-assign SAC 
+assign SAC
     if sac_scale= then (
-    
+
         if mtb:scale=        then 0
-        
+
         else if mtb:scale=6|5     then 5
         else if mtb:scale=4       then 4
         else if mtb:scale=3       then 3
@@ -181,7 +181,7 @@ assign SAC
         else 0
         )
     else
-    
+
         if      sac_scale=difficult_alpine_hiking   then 6
         else if sac_scale=demanding_alpine_hiking   then 5
         else if sac_scale=alpine_hiking             then 4
@@ -189,29 +189,29 @@ assign SAC
         else if sac_scale=mountain_hiking           then 2
         else if sac_scale=hiking|T1-hiking|yes      then 1
         else 0
-                                                                 
-assign  SAC_scale_access   # if SAC_scale_limit < SAC then true else false 
-    if sac_scale= then true  else equal ( max SAC_scale_limit SAC ) SAC_scale_limit  
-                                      
+
+assign  SAC_scale_access   # if SAC_scale_limit < SAC then true else false
+    if sac_scale= then true  else equal ( max SAC_scale_limit SAC ) SAC_scale_limit
+
 assign  SAC_scale_penalty
 
     if not SAC_scale_access  then  SAC_access_penalty  # not allowed SAC scale
-    
+
        else if equal SAC           SAC_scale_preferred       then 0.0
        else if equal ( add SAC 1 ) SAC_scale_preferred       then SAC_K1
-       else if equal ( add SAC 2 ) SAC_scale_preferred       then SAC_K1_2 
-       else if equal ( add SAC 3 ) SAC_scale_preferred       then SAC_K1_3 
-       else if equal ( add SAC 4 ) SAC_scale_preferred       then SAC_K1_4 
-       else if equal ( add SAC 5 ) SAC_scale_preferred       then SAC_K1_5 
-       else if equal ( add SAC 6 ) SAC_scale_preferred       then SAC_K1_6 
-       else if equal ( add SAC_scale_preferred 1 ) SAC       then SAC_K2 
+       else if equal ( add SAC 2 ) SAC_scale_preferred       then SAC_K1_2
+       else if equal ( add SAC 3 ) SAC_scale_preferred       then SAC_K1_3
+       else if equal ( add SAC 4 ) SAC_scale_preferred       then SAC_K1_4
+       else if equal ( add SAC 5 ) SAC_scale_preferred       then SAC_K1_5
+       else if equal ( add SAC 6 ) SAC_scale_preferred       then SAC_K1_6
+       else if equal ( add SAC_scale_preferred 1 ) SAC       then SAC_K2
        else if equal ( add SAC_scale_preferred 2 ) SAC       then SAC_K2_2
-       else if equal ( add SAC_scale_preferred 3 ) SAC       then SAC_K2_3 
-       else if equal ( add SAC_scale_preferred 4 ) SAC       then SAC_K2_4 
-       else if equal ( add SAC_scale_preferred 5 ) SAC       then SAC_K2_5 
-       else if equal ( add SAC_scale_preferred 6 ) SAC       then SAC_K2_6 
-       else 1.0   
-       
+       else if equal ( add SAC_scale_preferred 3 ) SAC       then SAC_K2_3
+       else if equal ( add SAC_scale_preferred 4 ) SAC       then SAC_K2_4
+       else if equal ( add SAC_scale_preferred 5 ) SAC       then SAC_K2_5
+       else if equal ( add SAC_scale_preferred 6 ) SAC       then SAC_K2_6
+       else 1.0
+
 assign tracktype_penalty (
     if not istrack           then 0.0    else if tracktype=       then 0.0
     else if tracktype=grade1 then 0.1    else if tracktype=grade2 then 0.05
@@ -240,91 +240,91 @@ assign wet_penalty (
         )
 
 assign Offroad_factor_for_road
-  if  ( equal Offroad_factor 0.0 ) then 0.0  else 
+  if  ( equal Offroad_factor 0.0 ) then 0.0  else
   (
-    if    ismainroad    then  Offroad_factor  
-    else if ( or ispaved highway=residential|living_street|service|pedestrian )  then ( multiply 0.33 Offroad_factor )   
-    else if ( not isunpaved )                                                                  then ( multiply -0.33 Offroad_factor )   
+    if    ismainroad    then  Offroad_factor
+    else if ( or ispaved highway=residential|living_street|service|pedestrian )  then ( multiply 0.33 Offroad_factor )
+    else if ( not isunpaved )                                                                  then ( multiply -0.33 Offroad_factor )
       else  ( multiply -1 multiply Offroad_factor ( add 1.0 ( multiply 0.33 SAC_scale_penalty ) ) )
     )
-                
+
 assign nonpath_penalty =
 if ( equal path_preference 0.0 ) then 0.0                  # nonpath_penalty inactive
 else if not istrack then path_preference                   #istrack = highway=track/path/road/footway
 else if ispaved then                                      ( multiply path_preference 0.5 )
-else if or ( and not isunpaved not highway=path ) 
+else if or ( and not isunpaved not highway=path )
            ( tracktype=grade1|grade2 )  then              ( multiply path_preference 0.25 )
-else if not ( and isunpaved 
-              and highway=path 
-              and tracktype=grade1|grade2  
-                   not surface=gravel|cobblestone|pebblestone )  
+else if not ( and isunpaved
+              and highway=path
+              and tracktype=grade1|grade2
+                   not surface=gravel|cobblestone|pebblestone )
                                         then              ( multiply path_preference 0.125 )
-else 0.0                
-        
+else 0.0
+
 assign rawcostfactor # can be <1.0, is treated later
 
     if shortest_way  then (   add 1 accesspenalty )   else
-  
+
   add      nonpath_penalty
   add      accesspenalty
   (
-  if    ( and highway= not route=ferry )  then 100000 
+  if    ( and highway= not route=ferry )  then 100000
   else if    highway=steps then ( switch allow_steps   ( switch consider_elevation 1.0 3.0 )     100000 )
   else  if    route=ferry    then ( if allow_ferries then 2.34 else 100000 )
-  
+
 # iswet=1 in global context section means wet weather, increases penalty for eventually inconvenient ways
 # ismuddy boolean relates in wet weather to unpaved or unclassified surface, that can have mud or get slicky in wet weather.
 
   else if    highway=pedestrian       then ( switch ismuddy 1.3 1.0 )
   else if    highway=bridleway        then ( switch ismuddy 2.5     switch iswet   1.4 1.2 )
   else if    highway=cycleway         then ( switch ismuddy 1.4     switch iswet   1.0 1.1 )
-  else if    highway=residential|living_street    
+  else if    highway=residential|living_street
                                      then  ( switch ismuddy 1.5     switch iswet   1.0 1.1 )
   else if    highway=service         then  ( switch ismuddy 1.5     switch iswet   1.1 1.2 )
-  
-  else if    istrack                 then 
+
+  else if    istrack                 then
        ( add 1.0 add tracktype_penalty add surface_penalty      add wet_penalty        SAC_scale_penalty      )
 
   else if highway=motorway|motorway_link  then  100000
   else if highway=proposed|abandoned|construction then (  switch ismuddy 10  switch iswet 6 4 )
-  
-  else if highway=trunk|trunk_link    then 
+
+  else if highway=trunk|trunk_link    then
       ( switch iswet ( switch issidewalk 1.5 10 )    ( switch issidewalk 2.0 20 ) )
- else if highway=primary|primary_link    then 
-      ( switch iswet ( switch issidewalk 1.5 5 )    ( switch issidewalk 2.0 10 ) )     
-  else if highway=secondary|secondary_link        then    
+ else if highway=primary|primary_link    then
+      ( switch iswet ( switch issidewalk 1.5 5 )    ( switch issidewalk 2.0 10 ) )
+  else if highway=secondary|secondary_link        then
       ( switch iswet  ( switch issidewalk 1.2 2.5 )    ( switch issidewalk 1.5 4.0 ) )
   else if highway=tertiary|tertiary_link        then
       ( if iswet then ( switch issidewalk 1.1 1.5 ) else ( switch issidewalk 1.2 2.5 ) )
   else if highway=unclassified                 then
-        ( if ismuddy then 3.0 else if iswet then ( switch issidewalk 1.0 1.3 ) else ( switch issidewalk 1.1 1.5 ) ) 
-  
+        ( if ismuddy then 3.0 else if iswet then ( switch issidewalk 1.0 1.3 ) else ( switch issidewalk 1.1 1.5 ) )
+
   else add cost_of_unknown switch ismuddy 0.5 0.0
   )
-  
-assign rawcostfactor2   
-  
+
+assign rawcostfactor2
+
   if equal hiking_routes_preference 0.0     then    rawcostfactor  # Not preferring hiking routes
   else if is_ldhr                 then    rawcostfactor  # is hiking route
-                          else    multiply rawcostfactor nonhiking_route_penalty    
-                          
-assign costfactor if shortest_way  then  ( add 1 accesspenalty )   
-       else max 1.0 add rawcostfactor2 Offroad_factor_for_road                            
+                          else    multiply rawcostfactor nonhiking_route_penalty
+
+assign costfactor if shortest_way  then  ( add 1 accesspenalty )
+       else max 1.0 add rawcostfactor2 Offroad_factor_for_road
 
 assign downhillcostfactor
     if shortest_way  then (   add 1 accesspenalty )   else
-    max 1.0 
+    max 1.0
     add rawcostfactor2
-    add Offroad_factor_for_road    
+    add Offroad_factor_for_road
     if ismuddy                     then 0.5                     # slicky
     else if surface=grass          then -0.2                    # soft impact
     else if ispaved                then 0.2                     # hard impact
     else if surface=gravel|pebblestone|fine_gravel  then 0.3    # slides
                                                     else 0.0
 
-assign uphillcostfactor 
+assign uphillcostfactor
     if shortest_way  then (   add 1 accesspenalty )   else
-    max 1.0 
+    max 1.0
     add rawcostfactor2
     add Offroad_factor_for_road
     if ismuddy                      then 0.3    # slicky
@@ -332,9 +332,9 @@ assign uphillcostfactor
     else if ispaved                 then -0.1   # sure foot
     else if surface=gravel|pebblestone|fine_gravel  then 0.2 # slides
                                                     else 0.0
-        
+
 # way priorities used for voice hint generation
-        
+
 assign priorityclassifier =
 
   if      ( highway=motorway                  ) then  30
@@ -350,12 +350,12 @@ assign priorityclassifier =
   else if ( highway=unclassified              ) then  20
   else if ( highway=residential|living_street ) then  18
   else if ( highway=steps|pedestrian          ) then  16
-  else if ( highway=service|cycleway          ) then  if ( or tracktype=grade1 ispaved ) then  14 else 12 
-  else if ( highway=track|road|bridleway      ) then  if ( or tracktype=grade1 ispaved ) then  10 else 8 
+  else if ( highway=service|cycleway          ) then  if ( or tracktype=grade1 ispaved ) then  14 else 12
+  else if ( highway=track|road|bridleway      ) then  if ( or tracktype=grade1 ispaved ) then  10 else 8
   else if ( highway=path|footway   )            then  (    if ( or tracktype=grade1 ispaved )   then  6
                                                       else if tracktype=grade2                  then  4
                                                       else if not surface=grass|gravel          then  3
-                                                                                                else  2 )   
+                                                                                                else  2 )
   else 0
 
 # some more classifying bits used for voice hint generation...
@@ -375,8 +375,8 @@ assign classifiermask add          isbadoneway
                       add multiply isgoodoneway   2
                       add multiply isroundabout   4
                       add multiply islinktype     8
-                          multiply isgoodforcars 16  
- 
+                          multiply isgoodforcars 16
+
 ---context:node  # following code refers to node tags
 
 
@@ -436,9 +436,9 @@ assign initialcost switch or bikeaccess footaccess 0 1000000
 # - 0.33 * MTB_factor                             for not paved/not unpaved roads,
 # - MTB_factor * ( 1 + 0.33 * smoothnesspenalty ) for unpaved roads.  - at MTB_factor 3.0 smootheness is ignored
 #
-# Default   is 0.0 = no effect. 
+# Default   is 0.0 = no effect.
 # Recommended -0.5 - +1.0
-# Reasonable  -2.0 .. +3.0, 
+# Reasonable  -2.0 .. +3.0,
 #
 # Final costfactor is kept >= 1 for final costfacto values.
 #############################################################################################
@@ -453,13 +453,13 @@ assign initialcost switch or bikeaccess footaccess 0 1000000
 #
 # 2014-10-10 v1.1 - changed hiking route preference logic
 # 1.2 - fixed preference counting bug
-# 2014-10-11 1.3 - adding foot route to hiking routes,  
+# 2014-10-11 1.3 - adding foot route to hiking routes,
 # fixed ferry cost to respect initial cost triggerring.
 #      added bikeaccess,  added shortest way mode,  code cleanup
 # 2014-10-12: v1.4 - involving turncosts and way/node initial costs as orientation/decision penalties,
 #           but turning them off for sticking to hiking routes as extra preference,
 #           tweaking cost preferences
-# 2014-10-13 v1.5 
+# 2014-10-13 v1.5
 # redesigned route preference policy - turncost turned off even for nonsticky but preferred hiking routes
 # cost tweaking.
 # removed uniform cost=1 for sticky hiking routes, to distinguish quality
@@ -467,14 +467,14 @@ assign initialcost switch or bikeaccess footaccess 0 1000000
 # used not round costs to often trigger initial cost calculation
 #v1.51 - bugfix of redundant routing penalty
 #v 1.6 - initialcost penalty only for sticking routes, decreased way penalties for preferring routes
-# 31/5/2015 v 1.7 ALFA  + sac_scale + sac_scale_limit implemented 
+# 31/5/2015 v 1.7 ALFA  + sac_scale + sac_scale_limit implemented
 # 10/6/2015 v1.7.1 ALFA * sac_scale improved
 #                        + MTB scale integrated to SAC scale
 #                       + sac_scale_preferred implemented, with progressive penalizing for SAC <> SAC preferred
 # 10/6/2015 v1.7.2 BETA ! Fixed general way access penalties
 # 15/6/2015 v1.7.3 BETA * SAC-MTB scale integration reevaluated, increased MTB scale penalty
 #                       * MTB scale penalty used as fallback if no SAC rating
-# 16/6/2015 v1.7.4 ALFA * Optimized SAC logic 
+# 16/6/2015 v1.7.4 ALFA * Optimized SAC logic
 # 17/6/2015 v1.7.5 BETA + Track penalty system
 # 20/6/2015 v1.7.6 RELEASE * Modified and simplified route preferencing
 # 01/12/2015 v1.8.1 ALFA   +ported MTB_factor from bicycle Trekking template, renamed for hiking context to Offroad_factor

--- a/misc/profiles2/moped.brf
+++ b/misc/profiles2/moped.brf
@@ -16,7 +16,7 @@ assign uphillcutoff 0
 assign   validForBikes       1
 assign   validForCars        1
 
-assign turnInstructionMode  = 1  # 0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style
+assign turnInstructionMode  = 1  # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 
 ---context:way   # following code refers to way-tags
 

--- a/misc/profiles2/shortest.brf
+++ b/misc/profiles2/shortest.brf
@@ -7,7 +7,7 @@ assign downhillcutoff 1.5
 assign uphillcost 0
 assign uphillcutoff 1.5
 
-assign   turnInstructionMode  = 1  # 0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style
+assign   turnInstructionMode  = 1  # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 assign   validForFoot        1
 
 ---context:way   # following code refers to way-tags

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -35,7 +35,7 @@ assign C_r        = 0.01   # %C_r% | Rolling resistance coefficient (dimensionle
 assign bikerPower = 100    # %bikerPower% | Average power (in W) provided by the biker, for travel time computation | number
 
 # Turn instructions settings
-assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style]
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
 assign turnInstructionCatchingRange = 40    # %turnInstructionCatchingRange% | Within this distance (in m) several turning instructions are combined into one and the turning angles are better approximated to the general direction | number
 assign turnInstructionRoundabouts   = true  # %turnInstructionRoundabouts% | Set to "false" to avoid generating special turning instructions for roundabouts | boolean
 

--- a/misc/profiles2/vm-forum-liegerad-schnell.brf
+++ b/misc/profiles2/vm-forum-liegerad-schnell.brf
@@ -23,9 +23,9 @@ assign bikerPower = 125    # %bikerPower% | Dauerleistung in Watt, für Fahrtzei
 assign ignore_bicycle_no = false # %ignore_bicycle_no% | für Regionen mit falschen bicyle=no tags können sie mit "true" ignoriert werden. Auch Shuttletransporte (bicycle=dismount + foot=no) werden geroutet | boolean
 
 
-assign turnInstructionMode          = 1     # %turnInstructionMode% | Modus für die Abbiegehinweise | [0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style, 4=comment-Style, 5=gpsies-Style, 6=orux-Style]
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Modus für die Abbiegehinweise | [0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style, 4=comment-Style, 5=gpsies-Style, 6=orux-Style, 7=locus-old-Style]
 assign turnInstructionCatchingRange 20 # innerhalb dieser Strecke werden mehrere Abiegehinweise zu einem zusammengefasst und die Abiegewinkel werden besser an die generelle Richtung angenähert
-assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert 
+assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert
 
 assign avoidmr2 multiply 0.04 multiply avoid_main_roads avoid_main_roads
 assign avoidsr multiply 0.2 avoid_small_roads
@@ -69,7 +69,7 @@ assign cycleway
 assign footway
  or highway=footway|pedestrian and highway=path foot=designated|yes
 
-assign turncost 
+assign turncost
  switch junction=roundabout 0
  150 # Kosten die für eine 90 Grad Abbiegung berechnet werden. Für kleinere Winkel werden sie mit turncost*cos(Winkel) berechnet, bei Kreisverkehr keine weitere Kosten
 
@@ -172,7 +172,7 @@ assign maxspeed_backward
   switch maxspeed:backward=rural 100
   0
 
-assign maxspeed 
+assign maxspeed
   switch and reversedirection=yes maxspeed_backward maxspeed_backward
   switch and not reversedirection=yes maxspeed_forward maxspeed_forward
   switch maxspeed=50 50
@@ -320,7 +320,7 @@ assign uphillcostfactor
  switch footway 30
  switch highway=steps 40
  switch highway=path
-  switch surface= multiply avoidbw 40 
+  switch surface= multiply avoidbw 40
   multiply avoidsr add 0.28 multiply avoid_cycleways 0.24
  switch highway=bridleway multiply avoidbw 80
  20
@@ -363,7 +363,7 @@ assign downhillcostfactor
  switch footway 30
  switch highway=steps 40
  switch highway=path
-  switch surface= multiply avoidbw 40 
+  switch surface= multiply avoidbw 40
   multiply avoidsr add 0.5 multiply avoid_cycleways 0.5
  switch highway=bridleway multiply avoidbw 80
  20
@@ -454,7 +454,7 @@ assign initialcost
   switch highway=steps switch no_steps 1000000 dismount_cost #Kosten für Stufe
   0
  switch bikeaccess
-  0 
+  0
  switch footaccess
   dismount_cost # Kosten fürs Aussteigen
  1000000 #Kosten für verbotene oder private Wege

--- a/misc/profiles2/vm-forum-velomobil-schnell.brf
+++ b/misc/profiles2/vm-forum-velomobil-schnell.brf
@@ -23,9 +23,9 @@ assign bikerPower = 125    # %bikerPower% | Dauerleistung in Watt, für Fahrtzei
 assign ignore_bicycle_no = false # %ignore_bicycle_no% | für Regionen mit falschen bicyle=no tags können sie mit "true" ignoriert werden. Auch Shuttletransporte (bicycle=dismount + foot=no) werden geroutet | boolean
 
 
-assign turnInstructionMode          = 1     # %turnInstructionMode% | Modus für die Abbiegehinweise | [0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style, 4=comment-Style, 5=gpsies-Style, 6=orux-Style]
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Modus für die Abbiegehinweise | [0=keine, 1=automatische Wahl, 2=locus-Style, 3=osmand-Style, 4=comment-Style, 5=gpsies-Style, 6=orux-Style, 7=locus-old-Style]
 assign turnInstructionCatchingRange 20 # innerhalb dieser Strecke werden mehrere Abiegehinweise zu einem zusammengefasst und die Abiegewinkel werden besser an die generelle Richtung angenähert
-assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert 
+assign turnInstructionRoundabouts true # mit "false" werden keine speziellen Abiegehinweise für den Kreisverkehr generiert
 
 assign avoidmr2 multiply 0.11111111 multiply avoid_main_roads avoid_main_roads
 assign avoidsr multiply 0.2 avoid_small_roads
@@ -69,7 +69,7 @@ assign cycleway
 assign footway
  or highway=footway|pedestrian and highway=path foot=designated|yes
 
-assign turncost 
+assign turncost
  switch junction=roundabout 0
  150 # Kosten die für eine 90 Grad Abbiegung berechnet werden. Für kleinere Winkel werden sie mit turncost*cos(Winkel) berechnet, bei Kreisverkehr keine weitere Kosten
 
@@ -172,7 +172,7 @@ assign maxspeed_backward
   switch maxspeed:backward=rural 100
   0
 
-assign maxspeed 
+assign maxspeed
   switch and reversedirection=yes maxspeed_backward maxspeed_backward
   switch and not reversedirection=yes maxspeed_forward maxspeed_forward
   switch maxspeed=50 50
@@ -320,7 +320,7 @@ assign uphillcostfactor
  switch footway 30
  switch highway=steps 40
  switch highway=path
-  switch surface= multiply avoidbw 40 
+  switch surface= multiply avoidbw 40
   add 4 multiply avoidsr 6
  switch highway=bridleway multiply avoidbw 80
  20
@@ -363,7 +363,7 @@ assign downhillcostfactor
  switch footway 30
  switch highway=steps 40
  switch highway=path
-  switch surface= multiply avoidbw 40 
+  switch surface= multiply avoidbw 40
   add 4 multiply avoidsr 6
  switch highway=bridleway multiply avoidbw 80
  20
@@ -454,7 +454,7 @@ assign initialcost
   switch highway=steps switch no_steps 1000000 dismount_cost #Kosten für Stufe
   0
  switch bikeaccess
-  0 
+  0
  switch footaccess
   dismount_cost # Kosten fürs Aussteigen
  1000000 #Kosten für verbotene oder private Wege


### PR DESCRIPTION
The new voice hint rules need an update for the export.

The main changes in voice hint was
- add 180 degree u-turn
- add beeline routing between two points


This cannot be used for all outputs due to unknown commands in the clients. So at the moment we have the following changes:

- Locus GPX output changes from wpt to trkpt route points, using only standard GPX tags
- OsmAnd, Comment Style, Gpsies, Orux work as before
- add old Locus output to keep it for other users/apps (has a 180 degree u-turn but no beeline information)
- there are two hidden turn instruction modes:
  - Cruiser export (8) is like OsmAnd but has the new rules (u-turn and straight line)
  - BRouter internal (9) with routing hints at trkpt tags (contains information only found in JSON export)
  
The Cruiser output is temporary and will be removed when OsmAnd supports 180-u-turns and beelines. It can be used to test against new rules.
BRouter internal is experimental for control. So please don't use it for anything else.

@vodie
You did initiate the Orux output in the past, May be you have more info about u-turn and beeline to get the output improved.

@vshcherb 
For OsmAnd the new voice hint constants are in [VoiceHint](https://github.com/abrensch/brouter/blob/b735cd3e4ea1d4f25b37bdfa2c1384ad24cba69b/brouter-core/src/main/java/btools/router/VoiceHint.java#L13)
It can be tested against the Cruiser output (8). The publishing of the features will be done some day.

The main discussion for the 1.6.4 lib is in #441.
