### PR TITLE
App update: control update for serverconfig

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
@@ -287,10 +287,17 @@ public class DownloadWorker extends Worker {
           String profileLocation = mServerConfig.getProfilesUrl() + fileName;
           URL profileUrl = new URL(profileLocation);
           int size = (int) (profileFile.exists() ? profileFile.length() : 0);
-          downloadProgressListener.onDownloadStart(fileName, DownloadType.PROFILE);
-          downloadFile(profileUrl, profileFile, size, false, DownloadType.PROFILE);
-          downloadProgressListener.onDownloadFinished();
-          done.add(profileUrl);
+
+          try {
+            downloadProgressListener.onDownloadStart(fileName, DownloadType.PROFILE);
+            downloadFile(profileUrl, profileFile, size, false, DownloadType.PROFILE);
+            downloadProgressListener.onDownloadFinished();
+            done.add(profileUrl);
+          } catch (IOException e) {
+            // no need to block other updates
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e.getMessage());
+          }
         }
       }
     }

--- a/brouter-routing-app/src/main/java/btools/routingapp/ServerConfig.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/ServerConfig.java
@@ -1,13 +1,20 @@
 package btools.routingapp;
 
 import android.content.Context;
+import android.content.res.AssetManager;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class ServerConfig {
+  private static String mServerConfigName = "serverconfig.txt";
+
   private String mSegmentUrl = "https://brouter.de/brouter/segments4/";
   private String mLookupsUrl = "https://brouter.de/brouter/profiles2/";
   private String mProfilesUrl = "https://brouter.de/brouter/profiles2/";
@@ -16,10 +23,19 @@ public class ServerConfig {
   private String[] mProfiles = new String[0];
 
   public ServerConfig(Context ctx) {
-    File configFile = new File(ConfigHelper.getBaseDir(ctx), "/brouter/segments4/serverconfig.txt");
-    if (configFile.exists()) {
+    File configFile = new File(ConfigHelper.getBaseDir(ctx), "/brouter/segments4/" + mServerConfigName);
+    readConfigFile(configFile);
+  }
+
+  public ServerConfig(Context context, File file) {
+    readConfigFile(file);
+  }
+
+  private void readConfigFile(File file) {
+    if (file.exists()) {
+      BufferedReader br = null;
       try {
-        BufferedReader br = new BufferedReader(new FileReader(configFile));
+        br = new BufferedReader(new FileReader(file));
         for (; ; ) {
           String line = br.readLine();
           if (line == null) break;
@@ -35,11 +51,84 @@ public class ServerConfig {
             mProfiles = line.substring(15).split(",");
           }
         }
-        br.close();
       } catch (IOException e) {
         e.printStackTrace();
+      } finally {
+        try {
+          if (br != null) br.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
       }
 
+    }
+
+  }
+
+  public static void checkForUpdate(Context context, File path, String assetZip) {
+    if (assetZip != null) {
+      writeTmpFromAsset(context, path, assetZip);
+
+      File configFileOld = new File(ConfigHelper.getBaseDir(context), "/brouter/segments4/" + mServerConfigName);
+      File configFileNew = new File(ConfigHelper.getBaseDir(context), "/brouter/segments4/" + mServerConfigName + ".tmp");
+      if (configFileOld.length() != configFileNew.length()) {
+        ServerConfig serverConfigOld = new ServerConfig(context, configFileOld);
+        ServerConfig serverConfigNew = new ServerConfig(context, configFileNew);
+        if (serverConfigOld.getSegmentUrl().equals(serverConfigNew.getSegmentUrl()) &&
+          serverConfigOld.getProfilesUrl().equals(serverConfigNew.getProfilesUrl()) &&
+          serverConfigOld.getLookupUrl().equals(serverConfigNew.getLookupUrl())
+        ) {
+          // replace when servers wasn't changed
+          configFileOld.delete();
+          configFileNew.renameTo(configFileOld);
+        }
+      } else {
+        configFileNew.delete();
+      }
+    }
+  }
+
+  private static void writeTmpFromAsset(Context context, File path, String assetZip) {
+    InputStream is = null;
+    try {
+      AssetManager assetManager = context.getAssets();
+      is = assetManager.open(assetZip);
+      ZipInputStream zis = new ZipInputStream(is);
+      byte[] data = new byte[1024];
+      for (; ; ) {
+        ZipEntry ze = zis.getNextEntry();
+        if (ze == null)
+          break;
+        if (ze.isDirectory()) {
+          continue;
+        }
+        String name = ze.getName();
+        if (name.equals(mServerConfigName)) {
+          File outfile = new File(path, name + ".tmp");
+          if (!outfile.exists() && outfile.getParentFile() != null) {
+            outfile.getParentFile().mkdirs();
+            FileOutputStream fos = new FileOutputStream(outfile);
+
+            for (; ; ) {
+              int len = zis.read(data, 0, 1024);
+              if (len < 0)
+                break;
+              fos.write(data, 0, len);
+            }
+            fos.close();
+          }
+        }
+        zis.closeEntry();
+      }
+      zis.close();
+    } catch (IOException io) {
+      throw new RuntimeException("error expanding " + assetZip + ": " + io);
+    } finally {
+      try {
+        if (is != null) is.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 


### PR DESCRIPTION
The file 'serverconfig.txt' holds the url and profile list for online updates.
This should be  overridden when the list of profiles changes.

When the server urls are different nothing is replaced. E.g. when a user has its own tile server.