### PR TITLE
App update: Show only updatable tiles

### DIFF
--- a/brouter-routing-app/src/main/AndroidManifest.xml
+++ b/brouter-routing-app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:preserveLegacyExternalStorage="true"
+        android:hasFragileUserData="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/Theme.App">
         <activity

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -162,8 +162,10 @@ public class BInstallerActivity extends AppCompatActivity {
 
   private void updateDownloadButton() {
     final ArrayList<Integer> selectedTilesDownload = mBInstallerView.getSelectedTiles(MASK_SELECTED_RD5);
+    final ArrayList<Integer> selectedTilesLastUpdate = mBInstallerView.getSelectedTiles(MASK_CURRENT_RD5);
     final ArrayList<Integer> selectedTilesUpdate = mBInstallerView.getSelectedTiles(MASK_INSTALLED_RD5);
     final ArrayList<Integer> selectedTilesDelete = mBInstallerView.getSelectedTiles(MASK_DELETED_RD5);
+    selectedTilesUpdate.removeAll(selectedTilesLastUpdate);
     mSummaryInfo.setText("");
 
     if (selectedTilesDelete.size() > 0) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
@@ -9,7 +9,6 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.Rect;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
@@ -258,6 +257,8 @@ public class BRouterView extends View {
       ConfigMigration.tryMigrateStorageConfig(
         new File(basedir + "/brouter/segments3/storageconfig.txt"),
         new File(basedir + "/brouter/segments4/storageconfig.txt"));
+    } else {
+      ServerConfig.checkForUpdate(getContext(), segmentDir, "segments4.zip");
     }
     profileDir = new File(basedir, "brouter/profiles2");
     assertDirectoryExists("profile directory", profileDir, "profiles2.zip", version);
@@ -582,6 +583,7 @@ public class BRouterView extends View {
 
       }
     }
+
     if (!path.exists() || !path.isDirectory())
       throw new IllegalArgumentException(message + ": " + path + " cannot be created");
     return false;


### PR DESCRIPTION
The updatable tiles are displayed in grey color. When you have downloaded/updated a tile it is displayed in blue. But the 'update all' button shows al installed tiles.

New flag in manifest to keep the local data when app is deleted. 
New installed app then uses direct the 'old' data in ./Android/media/btools.routingapp/...

