### PR TITLE
Fix wpt and nogo handling

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -304,9 +304,10 @@ public final class RoutingContext {
 
   public void checkMatchedWaypointAgainstNogos(List<MatchedWaypoint> matchedWaypoints) {
     if (nogopoints == null) return;
-    List<MatchedWaypoint> newMatchedWaypoints = new ArrayList<>();
     int theSize = matchedWaypoints.size();
+    if (theSize<2) return;
     int removed = 0;
+    List<MatchedWaypoint> newMatchedWaypoints = new ArrayList<>();
     MatchedWaypoint prevMwp = null;
     boolean prevMwpIsInside = false;
     for (int i = 0; i < theSize; i++) {
@@ -314,7 +315,8 @@ public final class RoutingContext {
       boolean isInsideNogo = false;
       OsmNode wp = mwp.crosspoint;
       for (OsmNodeNamed nogo : nogopoints) {
-        if (wp.calcDistance(nogo) < nogo.radius
+        if (Double.isNaN(nogo.nogoWeight)
+          && wp.calcDistance(nogo) < nogo.radius
           && (!(nogo instanceof OsmNogoPolygon)
           || (((OsmNogoPolygon) nogo).isClosed
           ? ((OsmNogoPolygon) nogo).isWithin(wp.ilon, wp.ilat)


### PR DESCRIPTION
A route should not enter a strict nogo area. So when a via point is inside a nogo it is ignore for routing.
But if the nogo area is not strict it can be used to mark the prefered way. 
Do not remove wpt in weighted nogos.

[sample](https://brouter.de/brouter-web/#map=15/48.1869/11.5579/standard&lonlats=11.568968,48.191611;11.565835,48.187405;11.57019,48.179681&nogos=11.566286,48.18704,100;11.57264,48.187377,100,1) Please play with the values in url e.g nogos=11.566286,48.18704,100,2;11.57264,48.187377,100,1