### PR TITLE
Unify brackets for opening blocks with comments

### DIFF
--- a/brouter-codec/src/main/java/btools/codec/MicroCache.java
+++ b/brouter-codec/src/main/java/btools/codec/MicroCache.java
@@ -318,8 +318,7 @@ public class MicroCache extends ByteDataWriter {
     while (idx1 < mc1.size || idx2 < mc2.size) {
       int id1 = idx1 < mc1.size ? mc1.faid[idx1] : Integer.MAX_VALUE;
       int id2 = idx2 < mc2.size ? mc2.faid[idx2] : Integer.MAX_VALUE;
-      if (id1 >= id2) // data from diff file wins
-      {
+      if (id1 >= id2) { // data from diff file wins
         int start2 = idx2 > 0 ? mc2.fapos[idx2 - 1] : 0;
         int len2 = mc2.fapos[idx2++] - start2;
         if (keepEmptyNodes || len2 > 0) {
@@ -327,8 +326,7 @@ public class MicroCache extends ByteDataWriter {
           fapos[size] = aboffset;
           faid[size++] = id2;
         }
-        if (id1 == id2) // // id exists in both caches
-        {
+        if (id1 == id2) { // // id exists in both caches
           idx1++;
         }
       } else // use data from base file

--- a/brouter-codec/src/main/java/btools/codec/MicroCache2.java
+++ b/brouter-codec/src/main/java/btools/codec/MicroCache2.java
@@ -75,8 +75,7 @@ public final class MicroCache2 extends MicroCache {
     LinkedListContainer reverseLinks = new LinkedListContainer(size, dataBuffers.ibuf1);
 
     int selev = 0;
-    for (int n = 0; n < size; n++) // loop over nodes
-    {
+    for (int n = 0; n < size; n++) { // loop over nodes
       int ilon = alon[n];
       int ilat = alat[n];
 
@@ -91,11 +90,9 @@ public final class MicroCache2 extends MicroCache {
       while (featureId != 0) {
         int bitsize = bc.decodeNoisyNumber(5);
 
-        if (featureId == 2) // exceptions to turn-restriction
-        {
+        if (featureId == 2) { // exceptions to turn-restriction
           trExceptions = (short) bc.decodeBounded(1023);
-        } else if (featureId == 1) // turn-restriction
-        {
+        } else if (featureId == 1) { // turn-restriction
           writeBoolean(true);
           writeShort(trExceptions); // exceptions from previous feature
           trExceptions = 0;
@@ -128,8 +125,7 @@ public final class MicroCache2 extends MicroCache {
         int dlat_remaining;
 
         boolean isReverse = false;
-        if (nodeIdx != n) // internal (forward-) link
-        {
+        if (nodeIdx != n) { // internal (forward-) link
           dlon_remaining = alon[nodeIdx] - ilon;
           dlat_remaining = alat[nodeIdx] - ilat;
         } else {
@@ -151,8 +147,7 @@ public final class MicroCache2 extends MicroCache {
           writeVarLengthSigned(dlat_remaining);
 
           validBits[n >> 5] |= 1 << n; // mark source-node valid
-          if (nodeIdx != n) // valid internal (forward-) link
-          {
+          if (nodeIdx != n) { // valid internal (forward-) link
             reverseLinks.addDataElement(nodeIdx, n); // register reverse link
             finaldatasize += 1 + aboffset - startPointer; // reserve place for reverse
             validBits[nodeIdx >> 5] |= 1 << nodeIdx; // mark target-node valid
@@ -160,8 +155,7 @@ public final class MicroCache2 extends MicroCache {
           writeModeAndDesc(isReverse, wayTags == null ? null : wayTags.data);
         }
 
-        if (!isReverse) // write geometry for forward links only
-        {
+        if (!isReverse) { // write geometry for forward links only
           WaypointMatcher matcher = wayTags == null || wayTags.accessType < 2 ? null : waypointMatcher;
           int ilontarget = ilon + dlon_remaining;
           int ilattarget = ilat + dlat_remaining;
@@ -294,8 +288,7 @@ public final class MicroCache2 extends MicroCache {
   @Override
   public int encodeMicroCache(byte[] buffer) {
     HashMap<Long, Integer> idMap = new HashMap<Long, Integer>();
-    for (int n = 0; n < size; n++) // loop over nodes
-    {
+    for (int n = 0; n < size; n++) { // loop over nodes
       idMap.put(Long.valueOf(expandId(faid[n])), Integer.valueOf(n));
     }
 
@@ -313,8 +306,7 @@ public final class MicroCache2 extends MicroCache {
 
     int netdatasize = 0;
 
-    for (int pass = 1; ; pass++) // 3 passes: counters, stat-collection, encoding
-    {
+    for (int pass = 1; ; pass++) { // 3 passes: counters, stat-collection, encoding
       boolean dostats = pass == 3;
       boolean dodebug = debug && pass == 3;
 
@@ -345,8 +337,7 @@ public final class MicroCache2 extends MicroCache {
       if (dodebug) System.out.println("*** encoding cache of size=" + size);
       int lastSelev = 0;
 
-      for (int n = 0; n < size; n++) // loop over nodes
-      {
+      for (int n = 0; n < size; n++) { // loop over nodes
         aboffset = startPos(n);
         aboffsetEnd = fapos[n];
         if (dodebug)
@@ -395,8 +386,7 @@ public final class MicroCache2 extends MicroCache {
         if (dostats) bc.assignBits("link-counts");
 
         nlinks = 0;
-        while (hasMoreData()) // loop over links
-        {
+        while (hasMoreData()) { // loop over links
           // read link data
           int startPointer = aboffset;
           int endPointer = getEndPointer();

--- a/brouter-codec/src/main/java/btools/codec/StatCoderContext.java
+++ b/brouter-codec/src/main/java/btools/codec/StatCoderContext.java
@@ -184,8 +184,7 @@ public final class StatCoderContext extends BitCoderContext {
    * @param mask    should be 0
    */
   public void encodeSortedArray(int[] values, int offset, int subsize, int nextbit, int mask) {
-    if (subsize == 1) // last-choice shortcut
-    {
+    if (subsize == 1) { // last-choice shortcut
       while (nextbit != 0) {
         encodeBit((values[offset] & nextbit) != 0);
         nextbit >>= 1;
@@ -227,8 +226,7 @@ public final class StatCoderContext extends BitCoderContext {
    * @see #encodeSortedArray
    */
   public void decodeSortedArray(int[] values, int offset, int subsize, int nextbitpos, int value) {
-    if (subsize == 1) // last-choice shortcut
-    {
+    if (subsize == 1) { // last-choice shortcut
       if (nextbitpos >= 0) {
         value |= decodeBitsReverse(nextbitpos + 1);
       }

--- a/brouter-core/src/main/java/btools/router/KinematicPath.java
+++ b/brouter-core/src/main/java/btools/router/KinematicPath.java
@@ -46,8 +46,7 @@ final class KinematicPath extends OsmPath {
     } else {
       double turnspeed = 999.; // just high
 
-      if (km.turnAngleDecayTime != 0.) // process turn-angle slowdown
-      {
+      if (km.turnAngleDecayTime != 0.) { // process turn-angle slowdown
         if (angle < 0) floatingAngleLeft -= (float) angle;
         else floatingAngleRight += (float) angle;
         float aa = Math.max(floatingAngleLeft, floatingAngleRight);
@@ -63,8 +62,7 @@ final class KinematicPath extends OsmPath {
         }
       }
 
-      if (nsection == 0) // process slowdown by crossing geometry
-      {
+      if (nsection == 0) { // process slowdown by crossing geometry
         double junctionspeed = 999.; // just high
 
         int classifiermask = (int) rc.expctxWay.getClassifierMask();
@@ -76,13 +74,11 @@ final class KinematicPath extends OsmPath {
         for (OsmPrePath prePath = rc.firstPrePath; prePath != null; prePath = prePath.next) {
           KinematicPrePath pp = (KinematicPrePath) prePath;
 
-          if (((pp.classifiermask ^ classifiermask) & 8) != 0) // exactly one is linktype
-          {
+          if (((pp.classifiermask ^ classifiermask) & 8) != 0) { // exactly one is linktype
             continue;
           }
 
-          if ((pp.classifiermask & 32) != 0) // touching a residential?
-          {
+          if ((pp.classifiermask & 32) != 0) { // touching a residential?
             hasResidential = true;
           }
 

--- a/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
+++ b/brouter-core/src/main/java/btools/router/OsmNogoPolygon.java
@@ -182,22 +182,17 @@ public class OsmNogoPolygon extends OsmNodeNamed {
     final double v12x = p1x - p0x;
     final double v12y = p1y - p0y;
 
-    if (v10x == 0) // P0->P1 vertical?
-    {
-      if (v10y == 0) // P0 == P1?
-      {
+    if (v10x == 0) { // P0->P1 vertical?
+      if (v10y == 0) { // P0 == P1?
         return true;
       }
-      if (v12x != 0) // P1->P2 not vertical?
-      {
+      if (v12x != 0) { // P1->P2 not vertical?
         return false;
       }
       return (v12y / v10y) >= 1; // P1->P2 at least as long as P1->P0?
     }
-    if (v10y == 0) // P0->P1 horizontal?
-    {
-      if (v12y != 0) // P1->P2 not horizontal?
-      {
+    if (v10y == 0) { // P0->P1 horizontal?
+      if (v12y != 0) { // P1->P2 not horizontal?
         return false;
       }
       // if ( P10x == 0 ) // P0 == P1? already tested
@@ -233,8 +228,7 @@ public class OsmNogoPolygon extends OsmNodeNamed {
     long p0x = p0.x; // need to use long to avoid overflow in products
     long p0y = p0.y;
 
-    for (int i = isClosed ? 0 : 1; i <= i_last; i++) // edge from v[i] to v[i+1]
-    {
+    for (int i = isClosed ? 0 : 1; i <= i_last; i++) { // edge from v[i] to v[i+1]
       final Point p1 = points.get(i);
 
       final long p1x = p1.x;
@@ -246,16 +240,13 @@ public class OsmNogoPolygon extends OsmNodeNamed {
 
       if (p0y <= py)  // start y <= p.y
       {
-        if (p1y > py) // an upward crossing
-        {             // p left of edge
+        if (p1y > py) { // an upward crossing, p left of edge
           if (((p1x - p0x) * (py - p0y) - (px - p0x) * (p1y - p0y)) > 0) {
             ++wn;     // have a valid up intersect
           }
         }
-      } else // start y > p.y (no test needed)
-      {
-        if (p1y <= py) // a downward crossing
-        {              // p right of edge
+      } else { // start y > p.y (no test needed)
+        if (p1y <= py) { // a downward crossing, p right of edge
           if (((p1x - p0x) * (py - p0y) - (px - p0x) * (p1y - p0y)) < 0) {
             --wn;      // have a valid down intersect
           }
@@ -380,8 +371,7 @@ public class OsmNogoPolygon extends OsmNodeNamed {
     final int sp0x = seg_p0.x;
     final int sp1x = seg_p1.x;
 
-    if (sp0x != sp1x) // S is not vertical
-    {
+    if (sp0x != sp1x) { // S is not vertical
       final int px = p.x;
       if (sp0x <= px && px <= sp1x) {
         return true;

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -433,8 +433,7 @@ public final class OsmTrack {
       }
     }
 
-    if (turnInstructionMode == 4) // comment style
-    {
+    if (turnInstructionMode == 4) { // comment style
       sb.append("<!-- $transport-mode$").append(voiceHints.getTransportMode()).append("$ -->\n");
       sb.append("<!--          cmd    idx        lon        lat d2next  geometry -->\n");
       sb.append("<!-- $turn-instruction-start$\n");
@@ -477,8 +476,7 @@ public final class OsmTrack {
       sb.append("  </extensions>\n");
       sb.append(" </metadata>\n");
     }
-    if (turnInstructionMode == 3 || turnInstructionMode == 8) // osmand style, cruiser
-    {
+    if (turnInstructionMode == 3 || turnInstructionMode == 8) { // osmand style, cruiser
       float lastRteTime = 0;
 
       sb.append(" <rte>\n");
@@ -490,8 +488,7 @@ public final class OsmTrack {
         first.append("  <rtept lat=\"").append(formatILat(nodes.get(0).getILat())).append("\" lon=\"")
           .append(formatILon(nodes.get(0).getILon())).append("\">\n")
           .append("   <desc>start</desc>\n   <extensions>\n");
-        if (rteTime != lastRteTime) // add timing only if available
-        {
+        if (rteTime != lastRteTime) { // add timing only if available
           double t = rteTime - lastRteTime;
           first.append("    <time>").append("" + (int) (t + 0.5)).append("</time>\n");
           lastRteTime = rteTime;
@@ -518,8 +515,7 @@ public final class OsmTrack {
 
         rteTime = getVoiceHintTime(i + 1);
 
-        if (rteTime != lastRteTime) // add timing only if available
-        {
+        if (rteTime != lastRteTime) { // add timing only if available
           double t = rteTime - lastRteTime;
           sb.append("    <time>").append("" + (int) (t + 0.5)).append("</time>\n");
           lastRteTime = rteTime;
@@ -538,8 +534,7 @@ public final class OsmTrack {
       sb.append("</rte>\n");
     }
 
-    if (turnInstructionMode == 7) // old locus style
-    {
+    if (turnInstructionMode == 7) { // old locus style
       float lastRteTime = getVoiceHintTime(0);
 
       for (int i = 0; i < voiceHints.list.size(); i++) {
@@ -550,8 +545,7 @@ public final class OsmTrack {
           .append("<name>").append(hint.getMessageString()).append("</name>")
           .append("<extensions><locus:rteDistance>").append("" + hint.distanceToNext).append("</locus:rteDistance>");
         float rteTime = getVoiceHintTime(i + 1);
-        if (rteTime != lastRteTime) // add timing only if available
-        {
+        if (rteTime != lastRteTime) { // add timing only if available
           double t = rteTime - lastRteTime;
           double speed = hint.distanceToNext / t;
           sb.append("<locus:rteTime>").append("" + t).append("</locus:rteTime>")
@@ -562,8 +556,7 @@ public final class OsmTrack {
           .append("</wpt>\n");
       }
     }
-    if (turnInstructionMode == 5) // gpsies style
-    {
+    if (turnInstructionMode == 5) { // gpsies style
       for (VoiceHint hint : voiceHints.list) {
         sb.append(" <wpt lon=\"").append(formatILon(hint.ilon)).append("\" lat=\"")
           .append(formatILat(hint.ilat)).append("\">")
@@ -574,8 +567,7 @@ public final class OsmTrack {
       }
     }
 
-    if (turnInstructionMode == 6) // orux style
-    {
+    if (turnInstructionMode == 6) { // orux style
       for (VoiceHint hint : voiceHints.list) {
         sb.append(" <wpt lat=\"").append(formatILat(hint.ilat)).append("\" lon=\"")
           .append(formatILon(hint.ilon)).append("\">")
@@ -971,8 +963,7 @@ public final class OsmTrack {
         sb.append(',').append((int) hint.angle);
 
         // not always include geometry because longer and only needed for comment style
-        if (turnInstructionMode == 4) // comment style
-        {
+        if (turnInstructionMode == 4) { // comment style
           sb.append(",\"").append(hint.formatGeometry()).append("\"");
         }
 
@@ -981,8 +972,7 @@ public final class OsmTrack {
       sb.deleteCharAt(sb.lastIndexOf(","));
       sb.append("        ],\n");
     }
-    if (showSpeedProfile) // set in profile
-    {
+    if (showSpeedProfile) { // set in profile
       List<String> sp = aggregateSpeedProfile();
       if (sp.size() > 0) {
         sb.append("        \"speedprofile\": [\n");
@@ -1033,8 +1023,7 @@ public final class OsmTrack {
     OsmPathElement nn = null;
     for (OsmPathElement n : nodes) {
       String sele = n.getSElev() == Short.MIN_VALUE ? "" : ", " + n.getElev();
-      if (showspeed) // hack: show speed instead of elevation
-      {
+      if (showspeed) { // hack: show speed instead of elevation
         double speed = 0;
         if (nn != null) {
           int dist = n.calcDistance(nn);

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -165,8 +165,7 @@ public final class RoutingContext {
     showTime = 0.f != expctxGlobal.getVariableValue("showtime", 0.f);
 
     int tiMode = (int) expctxGlobal.getVariableValue("turnInstructionMode", 0.f);
-    if (tiMode != 1) // automatic selection from coordinate source
-    {
+    if (tiMode != 1) { // automatic selection from coordinate source
       turnInstructionMode = tiMode;
     }
     turnInstructionCatchingRange = expctxGlobal.getVariableValue("turnInstructionCatchingRange", 40.f);
@@ -431,8 +430,7 @@ public final class RoutingContext {
         double r22 = x2 * x2 + y2 * y2;
         double radius = Math.abs(r12 < r22 ? y1 * dx - x1 * dy : y2 * dx - x2 * dy) / d;
 
-        if (radius < nogo.radius) // 20m
-        {
+        if (radius < nogo.radius) { // 20m
           double s1 = x1 * dx + y1 * dy;
           double s2 = x2 * dx + y2 * dy;
 

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -872,8 +872,7 @@ public class RoutingEngine extends Thread {
         try {
           t = findTrack(cfi == 0 ? "pass0" : "pass1", startWp, endWp, track, refTrack, false);
         } catch (IllegalArgumentException iae) {
-          if (!terminated && matchPath != null) // timeout, but eventually prepare a dirty ref track
-          {
+          if (!terminated && matchPath != null) { // timeout, but eventually prepare a dirty ref track
             logInfo("supplying dirty reference track after timeout");
             foundRawTrack = mergeTrack(matchPath, track);
             foundRawTrack.endPoint = endWp;
@@ -901,8 +900,7 @@ public class RoutingEngine extends Thread {
     OsmPathElement lastElement = null;
 
     boolean wasClean = nearbyTrack != null && !nearbyTrack.isDirty;
-    if (refTrack == null && !(wasClean && isDirty)) // do not overwrite a clean with a dirty track
-    {
+    if (refTrack == null && !(wasClean && isDirty)) { // do not overwrite a clean with a dirty track
       logInfo("supplying new reference track, dirty=" + isDirty);
       track.endPoint = endWp;
       track.nogoChecksums = routingContext.getNogoChecksums();
@@ -1175,8 +1173,7 @@ public class RoutingEngine extends Thread {
           }
         }
 
-        if (nodeLimit > 0) // check node-limit for target island search
-        {
+        if (nodeLimit > 0) { // check node-limit for target island search
           if (--nodeLimit == 0) {
             return null;
           }
@@ -1202,8 +1199,7 @@ public class RoutingEngine extends Thread {
         }
 
         if (path.treedepth != 1) {
-          if (path.treedepth == 0) // hack: sameSegment Paths marked treedepth=0 to pass above check
-          {
+          if (path.treedepth == 0) { // hack: sameSegment Paths marked treedepth=0 to pass above check
             path.treedepth = 1;
           }
 

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -214,8 +214,7 @@ public final class VoiceHintProcessor {
           hint.distanceToNext += dist;
           hint.angle += h2.angle;
           i--;
-          if (h2.isRoundabout()) // if we hit a roundabout, use that as the trigger
-          {
+          if (h2.isRoundabout()) { // if we hit a roundabout, use that as the trigger
             h2.angle = hint.angle;
             hint = h2;
             break;

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -134,8 +134,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
     // (skip first bit ("reversedirection") )
 
     // all others are generic
-    for (int inum = 1; inum < lookupValues.size(); inum++) // loop over lookup names
-    {
+    for (int inum = 1; inum < lookupValues.size(); inum++) { // loop over lookup names
       int d = ld[inum];
       if (d == 0) {
         skippedTags++;
@@ -162,8 +161,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
     // crosscheck: decode and compare
     int[] ld2 = new int[lookupValues.size()];
     decode(ld2, false, ab);
-    for (int inum = 1; inum < lookupValues.size(); inum++) // loop over lookup names (except reverse dir)
-    {
+    for (int inum = 1; inum < lookupValues.size(); inum++) { // loop over lookup names (except reverse dir)
       if (ld2[inum] != ld[inum])
         throw new RuntimeException("assertion failed encoding inum=" + inum + " val=" + ld[inum] + " " + getKeyValueDescription(false, ab));
     }
@@ -212,8 +210,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
   public String getKeyValueDescription(boolean inverseDirection, byte[] ab) {
     StringBuilder sb = new StringBuilder(200);
     decode(lookupData, inverseDirection, ab);
-    for (int inum = 0; inum < lookupValues.size(); inum++) // loop over lookup names
-    {
+    for (int inum = 0; inum < lookupValues.size(); inum++) { // loop over lookup names
       BExpressionLookupValue[] va = lookupValues.get(inum);
       int val = lookupData[inum];
       String value = (val >= 1000) ? Float.toString((val - 1000) / 100f) : va[val].toString();
@@ -228,8 +225,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
   public List<String> getKeyValueList(boolean inverseDirection, byte[] ab) {
     ArrayList<String> res = new ArrayList<String>();
     decode(lookupData, inverseDirection, ab);
-    for (int inum = 0; inum < lookupValues.size(); inum++) // loop over lookup names
-    {
+    for (int inum = 0; inum < lookupValues.size(); inum++) { // loop over lookup names
       BExpressionLookupValue[] va = lookupValues.get(inum);
       int val = lookupData[inum];
       // no negative values

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionMetaData.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionMetaData.java
@@ -57,8 +57,7 @@ public final class BExpressionMetaData {
           minAppVersion = Short.parseShort(line.substring(MIN_APP_VERSION_TAG.length()));
           continue;
         }
-        if (line.startsWith(VARLENGTH_TAG)) // tag removed...
-        {
+        if (line.startsWith(VARLENGTH_TAG)) { // tag removed...
           continue;
         }
         if (ctx != null) ctx.parseMetaLine(line);

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmNodeP.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmNodeP.java
@@ -221,8 +221,7 @@ public class OsmNodeP extends OsmLinkP {
       mc.writeVarLengthSigned(target.ilon - ilon);
       mc.writeVarLengthSigned(target.ilat - ilat);
       mc.writeModeAndDesc(isReverse, description);
-      if (!isReverse && linkNodes.size() > 2) // write geometry for forward links only
-      {
+      if (!isReverse && linkNodes.size() > 2) { // write geometry for forward links only
         DPFilter.doDPFilter(linkNodes);
         origin = this;
         for (int i = 1; i < linkNodes.size() - 1; i++) {

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/DirectWeaver.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/DirectWeaver.java
@@ -55,8 +55,7 @@ public final class DirectWeaver extends ByteDataWriter {
     aboffset = 0;
 
     int selev = 0;
-    for (int n = 0; n < size; n++) // loop over nodes
-    {
+    for (int n = 0; n < size; n++) { // loop over nodes
       OsmNode node = nodes[n];
       int ilon = node.ilon;
       int ilat = node.ilat;
@@ -68,11 +67,9 @@ public final class DirectWeaver extends ByteDataWriter {
         if (featureId == 0) break;
         int bitsize = bc.decodeNoisyNumber(5);
 
-        if (featureId == 2) // exceptions to turn-restriction
-        {
+        if (featureId == 2) { // exceptions to turn-restriction
           trExceptions = (short) bc.decodeBounded(1023);
-        } else if (featureId == 1) // turn-restriction
-        {
+        } else if (featureId == 1) { // turn-restriction
           TurnRestriction tr = new TurnRestriction();
           tr.exceptions = trExceptions;
           trExceptions = 0;
@@ -100,8 +97,7 @@ public final class DirectWeaver extends ByteDataWriter {
         int dlat_remaining;
 
         boolean isReverse = false;
-        if (nodeIdx != n) // internal (forward-) link
-        {
+        if (nodeIdx != n) { // internal (forward-) link
           dlon_remaining = nodes[nodeIdx].ilon - ilon;
           dlat_remaining = nodes[nodeIdx].ilat - ilat;
         } else {
@@ -115,8 +111,7 @@ public final class DirectWeaver extends ByteDataWriter {
         int linklon = ilon + dlon_remaining;
         int linklat = ilat + dlat_remaining;
         aboffset = 0;
-        if (!isReverse) // write geometry for forward links only
-        {
+        if (!isReverse) { // write geometry for forward links only
           WaypointMatcher matcher = wayTags == null || wayTags.accessType < 2 ? null : waypointMatcher;
           int ilontarget = ilon + dlon_remaining;
           int ilattarget = ilat + dlat_remaining;
@@ -154,8 +149,7 @@ public final class DirectWeaver extends ByteDataWriter {
             System.arraycopy(ab, 0, geometry, 0, aboffset);
           }
 
-          if (nodeIdx != n) // valid internal (forward-) link
-          {
+          if (nodeIdx != n) { // valid internal (forward-) link
             OsmNode node2 = nodes[nodeIdx];
             OsmLink link = node.isLinkUnused() ? node : (node2.isLinkUnused() ? node2 : null);
             if (link == null) {
@@ -164,8 +158,7 @@ public final class DirectWeaver extends ByteDataWriter {
             link.descriptionBitmap = wayTags.data;
             link.geometry = geometry;
             node.addLink(link, isReverse, node2);
-          } else // weave external link
-          {
+          } else { // weave external link
             node.addLink(linklon, linklat, wayTags.data, geometry, hollowNodes, isReverse);
             node.visitID = 1;
           }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/GeometryDecoder.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/GeometryDecoder.java
@@ -13,7 +13,7 @@ public final class GeometryDecoder {
   private OsmTransferNode[] cachedNodes;
   private int nCachedNodes = 128;
 
-  // result-cache  
+  // result-cache
   private OsmTransferNode firstTransferNode;
   private boolean lastReverse;
   private byte[] lastGeometry;
@@ -47,8 +47,7 @@ public final class GeometryDecoder {
       olon = trans.ilon;
       olat = trans.ilat;
       oselev = trans.selev;
-      if (reverseLink) // reverse chaining
-      {
+      if (reverseLink) { // reverse chaining
         trans.next = firstTransferNode;
         firstTransferNode = trans;
       } else {

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
@@ -220,8 +220,7 @@ public final class NodesCache {
       node.parseNodeBody(segment, nodesMap, expCtxWay);
     }
 
-    if (garbageCollectionEnabled) // garbage collection
-    {
+    if (garbageCollectionEnabled) { // garbage collection
       cacheSum -= segment.collect(segment.getSize() >> 1); // threshold = 1/2 of size is deleted
     }
 

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNode.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNode.java
@@ -171,11 +171,9 @@ public class OsmNode extends OsmLink implements OsmPos {
         }
       }
     }
-    if (tn == null) // .. not found, then check the hollow nodes
-    {
+    if (tn == null) { // .. not found, then check the hollow nodes
       tn = hollowNodes.get(linklon, linklat); // target node
-      if (tn == null) // node not yet known, create a new hollow proxy
-      {
+      if (tn == null) { // node not yet known, create a new hollow proxy
         tn = new OsmNode(linklon, linklat);
         tn.setHollow();
         hollowNodes.put(tn);
@@ -231,8 +229,7 @@ public class OsmNode extends OsmLink implements OsmPos {
     OsmLink l = firstlink;
     while (l != null) {
       // if ( l.isReverse( this ) )
-      if (l.n1 != this && l.n1 != null) // isReverse inline
-      {
+      if (l.n1 != this && l.n1 != null) { // isReverse inline
         OsmLink nl = l.previous;
         if (nl == link) {
           l.previous = n;

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNodesMap.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/OsmNodesMap.java
@@ -53,8 +53,7 @@ public final class OsmNodesMap {
 
   private void cleanupPeninsulas(OsmNode[] nodes) {
     baseID = lastVisitID++;
-    for (int i = 0; i < nodes.length; i++) // loop over nodes again just for housekeeping
-    {
+    for (int i = 0; i < nodes.length; i++) { // loop over nodes again just for housekeeping
       OsmNode n = nodes[i];
       if (n.firstlink != null) {
         if (n.visitID == 1) {
@@ -88,8 +87,7 @@ public final class OsmNodesMap {
       } else if (minIdSub == 0) {
         int nodesCreatedUntilHere = nodesCreated;
         minIdSub = minVisitIdInSubtree(n, t);
-        if (minIdSub > n.visitID) // peninsula ?
-        {
+        if (minIdSub > n.visitID) { // peninsula ?
           nodesCreated = nodesCreatedUntilHere;
           n.unlinkLink(l);
           t.unlinkLink(l);
@@ -227,9 +225,8 @@ public final class OsmNodesMap {
 
 
   public void remove(OsmNode node) {
-    if (node != endNode1 && node != endNode2) // keep endnodes in hollow-map even when loaded
-    {                                           // (needed for escape analysis)
-      hmap.remove(node);
+    if (node != endNode1 && node != endNode2) { // keep endnodes in hollow-map even when loaded
+      hmap.remove(node);                        // (needed for escape analysis)
     }
   }
 

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/PhysicalFile.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/PhysicalFile.java
@@ -69,10 +69,8 @@ final public class PhysicalFile {
       DataBuffers dataBuffers = new DataBuffers();
       pf = new PhysicalFile(f, dataBuffers, -1, -1);
       int div = pf.divisor;
-      for (int lonDegree = 0; lonDegree < 5; lonDegree++) // does'nt really matter..
-      {
-        for (int latDegree = 0; latDegree < 5; latDegree++) // ..where on earth we are
-        {
+      for (int lonDegree = 0; lonDegree < 5; lonDegree++) { // does'nt really matter..
+        for (int latDegree = 0; latDegree < 5; latDegree++) { // ..where on earth we are
           OsmFile osmf = new OsmFile(pf, lonDegree, latDegree, dataBuffers);
           if (osmf.hasData())
             for (int lonIdx = 0; lonIdx < div; lonIdx++)
@@ -115,8 +113,7 @@ final public class PhysicalFile {
 
     if (len == pos) return; // old format o.k.
 
-    if (len < pos + extraLen) // > is o.k. for future extensions!
-    {
+    if (len < pos + extraLen) { // > is o.k. for future extensions!
       throw new IOException("file of size " + len + " too short, should be " + (pos + extraLen));
     }
 

--- a/brouter-server/src/main/java/btools/server/BRouter.java
+++ b/brouter-server/src/main/java/btools/server/BRouter.java
@@ -16,8 +16,7 @@ import btools.router.SearchBoundary;
 
 public class BRouter {
   public static void main(String[] args) throws Exception {
-    if (args.length == 2) // cgi-input-mode
-    {
+    if (args.length == 2) { // cgi-input-mode
       try {
         String queryString = args[1];
         int sepIdx = queryString.indexOf('=');

--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -224,8 +224,7 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
         String headers = encodings == null || encodings.indexOf("gzip") < 0 ? null : "Content-Encoding: gzip\n";
         writeHttpHeader(bw, handler.getMimeType(), handler.getFileName(), headers, HTTP_STATUS_OK);
         if (track != null) {
-          if (headers != null) // compressed
-          {
+          if (headers != null) { // compressed
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             Writer w = new OutputStreamWriter(new GZIPOutputStream(baos), "UTF-8");
             w.write(handler.formatTrack(track));

--- a/brouter-server/src/main/java/btools/server/SuspectManager.java
+++ b/brouter-server/src/main/java/btools/server/SuspectManager.java
@@ -240,8 +240,7 @@ public class SuspectManager extends Thread {
     bw.write("<html><body>\n");
     bw.write("BRouter suspect manager. <a href=\"http://brouter.de/brouter/suspect_manager_help.html\">Help</a><br><br>\n");
 
-    if (filter == null) // generate country list
-    {
+    if (filter == null) { // generate country list
       bw.write("<table>\n");
       File countryParent = new File("worldpolys" + country);
       File[] files = countryParent.listFiles();

--- a/brouter-util/src/main/java/btools/util/BitCoderContext.java
+++ b/brouter-util/src/main/java/btools/util/BitCoderContext.java
@@ -128,8 +128,7 @@ public class BitCoderContext {
       bits -= len;
       return vl_values[b12]; // full value lookup
     }
-    if (len <= 23) // // only length lookup
-    {
+    if (len <= 23) { // // only length lookup
       int len2 = len >> 1;
       b >>>= (len2 + 1);
       int mask = 0xffffffff >>> (32 - len2);

--- a/brouter-util/src/main/java/btools/util/ByteDataWriter.java
+++ b/brouter-util/src/main/java/btools/util/ByteDataWriter.java
@@ -99,8 +99,7 @@ public class ByteDataWriter extends ByteDataReader {
       size++;
     }
     while (v != 0);
-    if (size > 1) // doesn't fit -> shift the data after the placeholder
-    {
+    if (size > 1) { // doesn't fit -> shift the data after the placeholder
       System.arraycopy(ab, sizeoffset + 1, ab, sizeoffset + size, datasize);
     }
     aboffset = sizeoffset;

--- a/brouter-util/src/main/java/btools/util/CompactLongMap.java
+++ b/brouter-util/src/main/java/btools/util/CompactLongMap.java
@@ -248,8 +248,7 @@ public class CompactLongMap<V> {
       pa[i] = 0;
     }
 
-    for (int ti = 0; ti < size; ti++) // target-index
-    {
+    for (int ti = 0; ti < size; ti++) { // target-index
       int bp = size; // treat size as bitpattern
       int minIdx = -1;
       long minId = 0;

--- a/brouter-util/src/main/java/btools/util/CompactLongSet.java
+++ b/brouter-util/src/main/java/btools/util/CompactLongSet.java
@@ -149,8 +149,7 @@ public class CompactLongSet {
       pa[i] = 0;
     }
 
-    for (int ti = 0; ti < size; ti++) // target-index
-    {
+    for (int ti = 0; ti < size; ti++) { // target-index
       int bp = size; // treat size as bitpattern
       int minIdx = -1;
       long minId = 0;

--- a/brouter-util/src/main/java/btools/util/MixCoderDataInputStream.java
+++ b/brouter-util/src/main/java/btools/util/MixCoderDataInputStream.java
@@ -84,8 +84,7 @@ public final class MixCoderDataInputStream extends DataInputStream {
       bits -= len;
       return vl_values[b12]; // full value lookup
     }
-    if (len <= 23) // // only length lookup
-    {
+    if (len <= 23) { // // only length lookup
       int len2 = len >> 1;
       b >>>= (len2 + 1);
       int mask = 0xffffffff >>> (32 - len2);

--- a/brouter-util/src/main/java/btools/util/SortedHeap.java
+++ b/brouter-util/src/main/java/btools/util/SortedHeap.java
@@ -209,8 +209,7 @@ public final class SortedHeap<V> {
   public void add(int key, V value) {
     size++;
 
-    if (first.lp == 0 && second.lp == 0) // both full ?
-    {
+    if (first.lp == 0 && second.lp == 0) { // both full ?
       sortUp();
     }
     if (first.lp > 0) {

--- a/misc/pbfparser/BPbfBlobDecoder.java
+++ b/misc/pbfparser/BPbfBlobDecoder.java
@@ -216,14 +216,12 @@ public class BPbfBlobDecoder {
 
       String role = fieldDecoder.decodeString(memberRoleIterator.next());
 
-      if (memberType == Osmformat.Relation.MemberType.WAY) // currently just waymembers
-      {
+      if (memberType == Osmformat.Relation.MemberType.WAY) { // currently just waymembers
         wayIds.add(refId);
         if ("from".equals(role)) fromWid = addLong(fromWid, refId);
         if ("to".equals(role)) toWid = addLong(toWid, refId);
       }
-      if (memberType == Osmformat.Relation.MemberType.NODE) // currently just waymembers
-      {
+      if (memberType == Osmformat.Relation.MemberType.NODE) { // currently just waymembers
         if ("via".equals(role)) viaNid = addLong(viaNid, refId);
       }
     }


### PR DESCRIPTION
Normally `BRouter` source formats opening blocks with having the curly bracket in the same line.
Somehow the reformat done between v1.6.3 and v1.7.0 did not work for opening lines having a line comment - for those blocks the opening curly bracket remained on a separate line.

This PR fixes / unifies this by moving the opening curly brackets into the blocks' opening lines.
