### PR TITLE
Add jdbc import

### DIFF
--- a/brouter-map-creator/src/main/java/btools/mapcreator/ConvertLidarTile.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/ConvertLidarTile.java
@@ -165,7 +165,7 @@ public class ConvertLidarTile {
     String s = "E";
     if (lon < 0) {
       lon = -lon;
-      s = "E";
+      s = "W";
     }
     String n = "000" + lon;
     return s + n.substring(n.length() - 3);

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
@@ -40,6 +40,9 @@ public class OsmCutter extends MapCreatorBase {
 
 
   Connection conn = null;
+  // PreparedStatement psNoise = null;
+  // PreparedStatement psRiver = null;
+  // PreparedStatement psForest = null;
   PreparedStatement psAllTags = null;
 
   ResultSet rsBrouter = null;
@@ -209,11 +212,13 @@ public class OsmCutter extends MapCreatorBase {
         System.err.println("OsmCutter connect to the database ok........");
 
       } catch (SQLException g) {
-        System.err.format("Osm Cutter SQL State: %s\n%s", g.getSQLState(), g.getMessage());
-        System.exit(0);
+        System.err.format("Osm Cutter SQL State: %s\n%s\n", g.getSQLState(), g.getMessage());
+        System.exit(1);
+        return;
       } catch (Exception f) {
         f.printStackTrace();
-        System.exit(0);
+        System.exit(1);
+        return;
       }
     }
 
@@ -261,11 +266,11 @@ public class OsmCutter extends MapCreatorBase {
           }
 
         } catch (SQLException g) {
-          System.err.format(" OsmCutter execute sql .. SQL State: %s\n%s", g.getSQLState(), g.getMessage());
-          System.exit(0);
+          System.err.format(" OsmCutter execute sql .. SQL State: %s\n%s\n", g.getSQLState(), g.getMessage());
+          System.exit(1);
         } catch (Exception f) {
           f.printStackTrace();
-          System.exit(0);
+          System.exit(1);
         }
 
         return;

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
@@ -191,7 +191,7 @@ public class OsmCutter extends MapCreatorBase {
     }
   }
 
-  private void generateSpecialTags(long osm_id, Map<String, String> map) {
+  private void generateTagsFromDatabase(long osm_id, Map<String, String> map) {
 
     if (jdbcurl == null) return;
 
@@ -284,7 +284,7 @@ public class OsmCutter extends MapCreatorBase {
     // encode tags
     if (w.getTagsOrNull() == null) return;
 
-    generateSpecialTags(w.wid, w.getTagsOrNull());
+    generateTagsFromDatabase(w.wid, w.getTagsOrNull());
 
     generatePseudoTags(w.getTagsOrNull());
 

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmCutter.java
@@ -191,9 +191,6 @@ public class OsmCutter extends MapCreatorBase {
     }
   }
 
-
-// Ess Bee : NEW function to add the new tags (estimated_noise_class , river, forest...)
-
   private void generateSpecialTags(long osm_id, Map<String, String> map) {
 
     if (jdbcurl == null) return;
@@ -203,16 +200,16 @@ public class OsmCutter extends MapCreatorBase {
 
       String sql_all_tags = "SELECT *  from all_tags where losmid = ?";
 
-      System.err.println("OsmCutter start connection to the database........" + jdbcurl);
+      System.out.println("OsmCutter start connection to the database........" + jdbcurl);
 
       try {
         conn = DriverManager.getConnection(jdbcurl);
         psAllTags = conn.prepareStatement(sql_all_tags);
 
-        System.err.println("OsmCutter connect to the database ok........");
+        System.out.println("OsmCutter connect to the database ok........");
 
       } catch (SQLException g) {
-        System.err.format("Osm Cutter SQL State: %s\n%s\n", g.getSQLState(), g.getMessage());
+        System.out.format("Osm Cutter SQL State: %s\n%s\n", g.getSQLState(), g.getMessage());
         System.exit(1);
         return;
       } catch (Exception f) {

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmFastCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmFastCutter.java
@@ -13,7 +13,7 @@ public class OsmFastCutter extends MapCreatorBase {
   public static void main(String[] args) throws Exception {
     System.out.println("*** OsmFastCutter: cut an osm map in node-tiles + way-tiles");
     if (args.length != 11 && args.length != 12 && args.length != 13) {
-      String common = "java OsmFastCutter <lookup-file> <node-dir> <way-dir> <node55-dir> <way55-dir> <border-file> <out-rel-file> <out-res-file> <filter-profile> <report-profile> <check-profile> <map-file> <jdbc-url>";
+      String common = "java OsmFastCutter <lookup-file> <node-dir> <way-dir> <node55-dir> <way55-dir> <border-file> <out-rel-file> <out-res-file> <filter-profile> <report-profile> <check-profile> <map-file> [jdbc-url]";
 
       System.out.println("usage: bzip2 -dc <map> | " + common);
       System.out.println("or   : " + common + " <inputfile> ");

--- a/brouter-map-creator/src/main/java/btools/mapcreator/OsmFastCutter.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/OsmFastCutter.java
@@ -12,8 +12,8 @@ import java.io.File;
 public class OsmFastCutter extends MapCreatorBase {
   public static void main(String[] args) throws Exception {
     System.out.println("*** OsmFastCutter: cut an osm map in node-tiles + way-tiles");
-    if (args.length != 11 && args.length != 12) {
-      String common = "java OsmFastCutter <lookup-file> <node-dir> <way-dir> <node55-dir> <way55-dir> <border-file> <out-rel-file> <out-res-file> <filter-profile> <report-profile> <check-profile>";
+    if (args.length != 11 && args.length != 12 && args.length != 13) {
+      String common = "java OsmFastCutter <lookup-file> <node-dir> <way-dir> <node55-dir> <way55-dir> <border-file> <out-rel-file> <out-res-file> <filter-profile> <report-profile> <check-profile> <map-file> <jdbc-url>";
 
       System.out.println("usage: bzip2 -dc <map> | " + common);
       System.out.println("or   : " + common + " <inputfile> ");
@@ -33,12 +33,14 @@ public class OsmFastCutter extends MapCreatorBase {
       , new File(args[9])
       , new File(args[10])
       , args.length > 11 ? new File(args[11]) : null
+      , args.length > 12 ? args[12] : null
     );
   }
 
-  public static void doCut(File lookupFile, File nodeDir, File wayDir, File node55Dir, File way55Dir, File borderFile, File relFile, File resFile, File profileAll, File profileReport, File profileCheck, File mapFile) throws Exception {
+  public static void doCut(File lookupFile, File nodeDir, File wayDir, File node55Dir, File way55Dir, File borderFile, File relFile, File resFile, File profileAll, File profileReport, File profileCheck, File mapFile, String jdbcurl) throws Exception {
     // **** run OsmCutter ****
     OsmCutter cutter = new OsmCutter();
+    if (jdbcurl != null) cutter.setJdbcUrl(jdbcurl);
 
     // ... inject WayCutter
     cutter.wayCutter = new WayCutter();

--- a/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
@@ -214,22 +214,23 @@ public class PosUnifier extends MapCreatorBase {
     double lat = (ilat - 90000000) / 1000000.;
 
     String filename = buildHgtFilename(lat, lon);
-    lastSrtmRaster = srtmmap.get(filename);
-    if (lastSrtmRaster == null) {
+    // don't block lastSrtmRaster
+    SrtmRaster srtm = srtmmap.get(filename);
+    if (srtm == null) {
       File f = new File(new File(srtmdir), filename + ".hgt");
       if (f.exists()) {
-        lastSrtmRaster = new ConvertLidarTile().getRaster(f, lon, lat);
-        srtmmap.put(filename, lastSrtmRaster);
-        return lastSrtmRaster;
+        srtm = new ConvertLidarTile().getRaster(f, lon, lat);
+        srtmmap.put(filename, srtm);
+        return srtm;
       }
       f = new File(new File(srtmdir), filename + ".zip");
       if (f.exists()) {
-        lastSrtmRaster = new ConvertLidarTile().getRaster(f, lon, lat);
-        srtmmap.put(filename, lastSrtmRaster);
-        return lastSrtmRaster;
+        srtm = new ConvertLidarTile().getRaster(f, lon, lat);
+        srtmmap.put(filename, srtm);
+        return srtm;
       }
     }
-    return lastSrtmRaster;
+    return srtm;
   }
 
   private String buildHgtFilename(double llat, double llon) {

--- a/brouter-map-creator/src/test/java/btools/mapcreator/MapcreatorTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/MapcreatorTest.java
@@ -35,7 +35,7 @@ public class MapcreatorTest {
     File profileCheck = new File(profileDir, "softaccess.brf");
     File borderFile = new File(tmpdir, "bordernids.dat");
 
-    new OsmFastCutter().doCut(lookupFile, nodes, ways, nodes55, ways55, borderFile, relFile, resFile, profileAll, profileReport, profileCheck, mapFile);
+    new OsmFastCutter().doCut(lookupFile, nodes, ways, nodes55, ways55, borderFile, relFile, resFile, profileAll, profileReport, profileCheck, mapFile, null);
 
 
     // run PosUnifier

--- a/misc/scripts/mapcreation/brouter.sql
+++ b/misc/scripts/mapcreation/brouter.sql
@@ -1,0 +1,649 @@
+--  calculation of new tags (estimated_noise_class, estimated_river_class,estimated_forest_class, estimated_town_class, estimated_traffic_class)
+--  Ess Bee version 08/05/2023
+
+set client_encoding to UTF8;
+select now();
+
+-- create new tables for tuning
+SELECT  osm_id :: bigint , highway, waterway, width, maxspeed,
+case 
+when maxspeed is null              then 0  
+when not (maxspeed ~ '^[0-9\.]+$') then 0  
+when maxspeed :: numeric > '105'   then 1
+when maxspeed :: numeric > '75'    then 2
+else                                    3
+end as maxspeed_class
+, ST_Buffer(way,50) as way
+into table osm_line_buf_50
+from lines where highway is not null or waterway in ('river','canal');
+
+select now();
+
+-- modify "way" by large waterways !!" (example Rhein ==> width = 400 ....) enlarge a bit the "50 meter" buffer
+UPDATE
+    osm_line_buf_50
+SET
+    way = st_buffer(way, (width :: numeric / 10))
+WHERE
+    waterway = 'river' and width is not null and (width ~ '^[0-9\.]+$') and width :: numeric > 15;
+
+
+
+SELECT  osm_id :: bigint,   leisure, landuse, p.natural, p.water, ST_Buffer(way,50) as way
+into table osm_poly_buf_50
+from polygons p where 
+-- do not consider small surfaces
+st_area(p.way) > 1000
+and p.natural in ('water') or (p.landuse in ('forest','allotments','flowerbed','orchard','vineyard','recreation_ground','village_green')  
+     or p.leisure in ( 'park','nature_reserve'));
+
+SELECT  osm_id :: bigint,   leisure, landuse, p.natural, p.water, ST_Buffer(way,70) as way
+into table osm_poly_buf_120
+from osm_poly_buf_50 p ;
+
+select now();
+
+-- create indexes
+CREATE INDEX osm_line_buf_50_idx ON public.osm_line_buf_50 USING gist (way) WITH (fillfactor='100');
+ANALYZE;
+
+
+select
+ osm_id, highway, way, 
+ST_Expand(way, 15000) way2,
+ST_Centroid(way) way0
+into table primsecter15k
+from lines
+where  highway in ('primary','primary_link', 'secondary','secondary_link', 'tertiary');
+
+
+CREATE INDEX primsecter15k_idx2 ON public.primsecter15k USING gist (way2) WITH (fillfactor='100');
+
+CREATE INDEX primsecter15k_idx1 ON public.primsecter15k USING gist (way) WITH (fillfactor='100');
+CREATE INDEX primsecter15k_idx0 ON public.primsecter15k USING gist (way0) WITH (fillfactor='100');
+
+select now();
+
+
+
+-- create a new "town" table based on cities_rel (with a valid/numeric population) AND fetch by need the population from the cities table)  
+
+-- clean the cities table (when population is null or population is not numeric or unusable)
+select 
+a.name,  
+REPLACE(a.population, '.', '') :: bigint population,
+a.way  
+into cities_ok 
+from cities a where a.population is not null and (a.population ~ '^[0-9\.]+$')
+and a.place in ('town', 'city', 'municipality'); 
+
+-- clean the cities_rel table (when population is not numeric or unusable)
+select 
+a.name as name,
+a.admin_level, 
+case
+when a.population is not null and (a.population ~ '^[0-9\.]+$') then REPLACE(a.population, '.', '') :: bigint
+else null
+end as population,
+a.way
+into cities_rel_ok
+from cities_rel a;
+
+-- select town + population + way starting with cities_rel_ok .... 
+select 
+a.name as name, 
+case
+when a.population is not null then a.population
+when b.population is not null then b.population
+else null
+end as population,
+a.way
+into cities_intermed1
+from cities_rel_ok a
+left outer join cities_ok b on a.name = b.name  
+where  a.admin_level = '8'
+order by a.name;
+
+-- select town + population + way starting with cities_ok .... (to catch specials cases as ex. "Berlin" which is tagged with "admin_level=4")
+
+select 
+a.name as name, 
+a.population,
+case
+when b.way is not null then b.way
+-- stupid case (ex. "Ebingen": no relation available, so no administrattive surface ... create a dummy area with 2000 m radius !
+else st_buffer(a.way, 2000)
+end as way
+into cities_intermed2
+from cities_ok a
+left outer join cities_rel_ok b on a.name = b.name
+and b.way is not null
+and b.admin_level = '8'
+order by name;
+
+select name,
+max (population) as population,
+way,
+st_centroid(way) as way0
+into cities_all
+from ((select * from cities_intermed1 where population is not null) union (select * from cities_intermed2)) a 
+where population is not null
+-- and population > 20000
+group by name, way
+order by population;
+select now();
+
+
+-- create tags for noise 
+
+-- create raw data
+--     when several highways-segments are producing noise, aggregate the noises using the "ST_Union" of the segments!
+--     (better as using "sum" or "max" that do not deliver good factors) 
+
+SELECT
+    m.osm_id losmid, m.highway lhighway, q.highway as qhighway, q.maxspeed_class,
+    case 
+    when q.highway in ('motorway', 'motorway_link','trunk','trunk_link') and q.maxspeed_class < 1.1 then
+     	st_area(st_intersection(m.way, ST_Union( q.way)))      / st_area(m.way)
+    when q.highway in ('motorway', 'motorway_link','trunk','trunk_link')  then
+     	st_area(st_intersection(m.way, ST_Union( q.way)))   	 / (1.5 * st_area(m.way))
+
+    when q.highway in ('primary','primary_link')                        and q.maxspeed_class < 2.1  then
+	st_area(st_intersection(m.way, ST_Union( q.way)))    	/ (2 * st_area(m.way))
+    when q.highway in ('primary','primary_link')      then
+	st_area(st_intersection(m.way, ST_Union( q.way)))     / (3 * st_area(m.way))
+
+    when q.highway in ('secondary')                                    and q.maxspeed_class < 2.1 then
+	st_area(st_intersection(m.way, ST_Union( q.way)))    	/ (3 * st_area(m.way))
+    when q.highway in ('secondary') then 
+	st_area(st_intersection(m.way, ST_Union( q.way)))    	/ (5 * st_area(m.way))
+    end
+as noise_factor
+into table noise_tmp
+FROM osm_line_buf_50 AS m
+INNER JOIN osm_line_buf_50 AS q ON ST_Intersects(m.way, q.way) 
+WHERE m.highway is not null
+and q.highway in ('motorway', 'motorway_link','trunk','trunk_link','primary','primary_link','secondary')
+GROUP BY losmid, lhighway, m.way, q.highway, q.maxspeed_class
+order by noise_factor desc;
+
+select now();
+
+
+-- aggregate data: 
+-- on "maxspeed_class take the sum of several highways (having different maxspeed-class) union is then not done, but not very frequent 
+-- on "phighway"      take the sum of several highways (as probably several highways are producing noise at the point!
+
+select losmid, lhighway, sum(noise_factor) as sum_noise_factor
+into table noise_tmp2 
+from noise_tmp 
+group by losmid, lhighway
+order by sum_noise_factor desc;
+
+
+-- create the noise classes
+SELECT    losmid, 
+case
+  when y.sum_noise_factor < 0.1  then '1'
+  when y.sum_noise_factor < 0.25 then '2'
+  when y.sum_noise_factor < 0.4  then '3'
+  when y.sum_noise_factor < 0.55 then '4'
+  when y.sum_noise_factor < 0.8  then '5'
+  else '6' 
+end as noise_class
+into table noise_tags
+from noise_tmp2 y 
+where y.sum_noise_factor > 0.01;
+
+select count(*) from noise_tags;
+select noise_class, count(*) from noise_tags group by noise_class order by noise_class;
+
+drop table noise_tmp2;
+select now();
+
+
+
+-- create tags for river
+
+
+
+select xid , sum(water_river_see) as river_see 
+into table river_tmp
+from (
+SELECT     m.osm_id  as xid,
+  st_area(st_intersection(m.way, ST_Union( q.way))) / st_area(m.way)
+  as water_river_see
+FROM osm_line_buf_50 AS m
+INNER JOIN osm_poly_buf_120 AS q ON ST_Intersects(m.way, q.way) 
+WHERE  m.highway is not null
+-- and st_area(q.way) > 90746  !!! filter on very small surfaces was set above !!!!!!!!!
+and q.natural in ('water') and (q.water is null or q.water not in ('wastewater'))
+GROUP BY m.osm_id, m.way
+union
+SELECT    m.osm_id as xid, 
+    st_area(st_intersection(m.way, ST_Union( q.way))) / st_area(m.way)
+     as water_river_see
+FROM osm_line_buf_50 AS m
+INNER JOIN osm_line_buf_50 AS q ON ST_Intersects(m.way, q.way) 
+WHERE m.highway is not null
+and
+q.waterway in ('river','canal') 
+GROUP BY m.osm_id, m.way
+) as abcd
+GROUP BY xid
+order by river_see desc;
+
+
+SELECT     y.xid losmid, 
+case
+  when y.river_see < 0.17  then '1'
+  when y.river_see < 0.35  then '2'
+  when y.river_see < 0.57  then '3'
+  when y.river_see < 0.85  then '4'
+  when y.river_see < 1   then '5'
+  else '6' 
+end as river_class
+into table river_tags
+from river_tmp y where y.river_see > 0.05;
+
+select count(*) from river_tags;
+select river_class, count(*) from river_tags group by river_class order by river_class;
+
+select now();
+
+
+
+-- create tags for forest
+
+
+
+SELECT
+    m.osm_id, m.highway,
+    st_area(st_intersection(m.way, ST_Union( q.way))) / st_area(m.way)    
+ as green_factor
+into table forest_tmp
+FROM osm_line_buf_50 AS m
+INNER JOIN osm_poly_buf_50 AS q ON ST_Intersects(m.way, q.way) 
+WHERE m.highway is not null
+ and 
+((q.landuse in ('forest','allotments','flowerbed','orchard','vineyard','recreation_ground','village_green') ) 
+     or q.leisure in ( 'garden','park','nature_reserve'))
+GROUP BY m.osm_id, m.highway, m.way
+order by green_factor desc;
+
+--
+SELECT  y.osm_id losmid, 
+case
+  when y.green_factor < 0.1  then null
+  when y.green_factor < 0.3  then '1'
+  when y.green_factor < 0.6  then '2'
+  when y.green_factor < 0.9    then '3'
+  when y.green_factor < 1  then '4'
+  when y.green_factor < 1.3   then '5'
+  else '6' 
+end as forest_class
+into table forest_tags
+from forest_tmp y where y.green_factor  > 0.1;
+
+select count(*) from forest_tags;
+select forest_class, count(*) from forest_tags group by forest_class order by forest_class;
+
+select now();
+
+--  create "town" tags
+ 
+-- get the highways which intersect the town
+
+SELECT
+    m.osm_id losmid, m.highway lhighway,
+    case 
+    when q.population :: decimal > '2000000'    then  1
+    when q.population :: decimal > '1000000'    then  0.8
+    when q.population :: decimal > '400000'    then  0.6
+    when q.population :: decimal > '150000'    then  0.4
+    when q.population :: decimal > '80000'    then  0.2
+    else 0.1  
+    end  as town_factor
+into table town_tmp
+FROM osm_line_buf_50 AS m
+INNER JOIN cities_all AS q ON ST_Intersects(m.way, q.way) 
+WHERE m.highway is not null 
+and q.population  > '50000' 
+order by town_factor desc;
+
+--
+
+SELECT    losmid, 
+case
+  when y.town_factor =  0.1  then '1'
+  when y.town_factor =  0.2  then '2'
+  when y.town_factor =  0.4  then '3'
+  when y.town_factor =  0.6  then '4'
+  when y.town_factor =  0.8  then '5'
+  else '6' 
+end as town_class
+into table town_tags
+from 
+(SELECT    losmid, max (town_factor) as town_factor
+from town_tmp y
+group by losmid) y;
+
+select count(*) from town_tags;
+select town_class, count(*) from town_tags group by town_class order by town_class;
+
+
+--
+--  substract the ways from town with a green tag (because administrative surface are some times too large)
+--
+delete from town_tags
+where losmid in 
+(SELECT losmid     FROM forest_tags);
+
+delete from town_tags
+where losmid in 
+(SELECT losmid     FROM river_tags);
+
+
+select count(*) from town_tags;
+select town_class, count(*) from town_tags group by town_class order by town_class;
+
+select now();
+
+
+
+-------------------------------------------
+-- create tags for  TRAFFIC
+-----------------------------------------
+-- OSM data used to calculate/estimate the traffic: 
+--    population of towns (+ distance from position to the towns)
+--    industrial areas (landuse=industrial)  (+ surface of the areas and distance from position) 
+--    motorway density (traffic on motorways decreases traffic on primary/secondary/tertiary)         calculated on grid
+--    highway density  (traffic decreases when more primary/secondary/tertiary highways are available) calculated on grid
+--    exceptions: near junctions between motorways and primary/secondary/tertiary the traffic increases on the primary/secondary/tertiary..
+--    mountain-ranges  (high peaks)  traffic is generally on highways in such regions higher as only generated by local population or industrial areas
+
+
+-- calculate traffic from the population (for each segment of type primary secondary tertiary)
+
+-- SUM of (population of each town < 100 km) / ( town-radius + 2500 + dist(segment-position to the town) ** 2 )
+--  town-radius is calculated as sqrt(population)
+
+select now();
+SELECT
+    m.osm_id losmid, m.highway lhighway,
+case
+  when m.highway = 'tertiary' then
+sum ( 10000 * q.population :: numeric /
+    power( ((8 * sqrt(q.population :: numeric))  + 500 + ST_Distance(m.way0, q.way0) ) , 2)  * 0.4 )
+  when m.highway in ('secondary', 'secondary_link') then
+sum ( 10000 * q.population :: numeric /
+    power( ((8 * sqrt(q.population :: numeric))  + 500 + ST_Distance(m.way0, q.way0) ) , 2)  * 0.6 )
+  else
+sum ( 10000 * q.population :: numeric /
+    power( ((8 * sqrt(q.population :: numeric))  + 500 + ST_Distance(m.way0, q.way0) ) , 2)  )
+  end
+as populate_factor
+into table traffic_tmp
+FROM primsecter15k AS m
+INNER JOIN cities_all AS q ON ST_DWithin(m.way0, q.way0, (5000 + (100000 * q.population / (q.population +  10000) )))
+WHERE m.highway is not null
+--and m.highway in ('primary','primary_link','secondary', 'secondary_link', 'tertiary')
+and q.population > 200
+GROUP BY m.osm_id, m.highway, m.way
+order by populate_factor;
+select now();
+
+-- prepare some special tables 
+--  the intersections motorway_link with primary/secondary/tertiary deliver the motorway acccesses....
+
+SELECT
+    m.osm_id losmid, 
+ m.highway,
+m.way,
+ST_Expand(m.way, 1000) way2,
+ST_Expand(m.way, 2000) way3
+into table motorway_access
+FROM lines AS m
+INNER JOIN lines AS q ON ST_Intersects(m.way, q.way) 
+WHERE q.highway  in ('motorway_link','trunk_link')
+and m.highway in ('primary', 'secondary', 'tertiary')
+group by m.osm_id, m.highway, m.way;
+
+CREATE INDEX motorway_access_idx ON public.motorway_access USING gist (way2) WITH (fillfactor='100');
+select now();
+
+
+
+-- find out all the primary/secondary/tertiary within 1000 m and 2000 m from a motorway access
+select now();
+
+SELECT
+    m.osm_id losmid, 
+sum ( st_length(q.way) / (10000 )  )  motorway_factor
+into table motorway_access_1000
+FROM lines AS m
+inner JOIN motorway_access AS q ON ST_Intersects(m.way, q.way2) 
+WHERE m.highway in ('primary', 'primary_link', 'secondary','secondary_link', 'tertiary')
+GROUP BY m.osm_id, m.way 
+order by motorway_factor;
+select now();
+
+SELECT
+    m.osm_id losmid, 
+sum ( st_length(q.way) / (10000 )  )  motorway_factor
+into table motorway_access_2000
+FROM lines AS m
+inner JOIN motorway_access AS q ON ST_Intersects(m.way, q.way3) 
+WHERE m.highway in ('primary', 'primary_link', 'secondary','secondary_link', 'tertiary')
+GROUP BY m.osm_id, m.way 
+order by motorway_factor;
+select now();
+
+
+
+--
+--  special regions: mountain_range with "peaks" ==> few highways ==> higher traffic !!! 
+--  calculate the "peak_density"
+
+select now();
+SELECT
+    m.osm_id losmid, 
+count(  q.*) as peak_cnt,
+sum (q.ele :: decimal) peak_sum_ele
+into table peak_density
+FROM primsecter15k AS m
+INNER JOIN peak AS q ON ST_Intersects(m.way2, q.way) 
+where (q.ele ~ '^[0-9\.]+$') and q.ele :: decimal > 400
+GROUP BY m.osm_id, m.way 
+order by peak_cnt desc;
+select now();
+
+--
+-- traffic due to industrial parcs ...
+--
+select now();
+
+select 
+name, 
+way, 
+ST_Centroid(way) way0,
+st_area(way) area,  
+sqrt(st_area(way)) sqrt_area 
+into industri
+from polygons 
+WHERE landuse = 'industrial'
+and st_area(way) > 20000;
+
+select now();
+SELECT
+    m.osm_id losmid, m.highway lhighway,
+case
+  when m.highway = 'tertiary' then 
+sum ( area  / 
+    power( ( sqrt_area  + 500 + ST_Distance(m.way0, q.way0) ) , 2)  * 0.6 )
+  when m.highway in ('secondary', 'secondary_link') then 
+sum ( area  / 
+    power( ( sqrt_area  + 500 + ST_Distance(m.way0, q.way0) ) , 2)  * 0.8 )
+  else 
+sum ( area  / 
+    power( ( sqrt_area  + 500 + ST_Distance(m.way0, q.way0) ) , 2)   )
+  end 
+as industrial_factor
+into industri_tmp
+FROM primsecter15k AS m
+INNER JOIN industri AS q ON ST_dwithin(m.way0, q.way0, 20000) 
+GROUP BY m.osm_id, m.highway, m.way 
+order by industrial_factor;
+
+select now();
+
+-- create a grid to allow a fast calculation for highway_density and motorway_density
+
+CREATE OR replace FUNCTION generate_grid(bound_polygon geometry, grid_step integer, srid integer default 2180)
+RETURNS table(id bigint, geom geometry)
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+Xmin int;
+Xmax int;
+Ymax int;
+Ymin int;
+query_text text;
+BEGIN
+Xmin := floor(ST_XMin(bound_polygon));
+Xmax := ceil(ST_XMax(bound_polygon));
+Ymin := floor(ST_YMin(bound_polygon));
+Ymax := ceil(ST_YMax(bound_polygon));
+   
+  query_text := 'select row_number() over() id, st_makeenvelope(s1, s2, s1+$5, s2+$5, $6) geom
+   from generate_series($1, $2+$5, $5) s1, generate_series ($3, $4+$5, $5) s2';
+
+RETURN QUERY EXECUTE query_text using Xmin, Xmax, Ymin, Ymax, grid_step, srid;
+END;
+$function$
+;
+
+create table grid1 as select id, geom from generate_grid((ST_GeomFromText('POLYGON((0 9000000, 18000000 9000000, 18000000 -9000000, 0 -9000000, 0  9000000))')),10000,3857);
+create table grid2 as select id, geom from generate_grid((ST_GeomFromText('POLYGON((0 9000000, -18000000 9000000, -18000000 -9000000, 0 -9000000, 0  9000000))')),10000,3857);
+
+select geom into table grid from ((select  geom from grid1) union (select  geom from grid2)) a;
+
+-- GRID  HIGHWAY_DENSITY
+select now();
+SELECT
+sum ( st_length(q.way) / (10000 )  )  highway_factor,
+m.geom way
+into table grid_highway_density
+FROM lines AS q
+INNER JOIN grid AS m ON ST_Intersects(q.way, m.geom) 
+where q.highway in ('primary','primary_link','secondary', 'secondary_link', 'tertiary')
+GROUP BY  m.geom
+order by highway_factor;
+select now();
+
+-- GRID MOTORWAY_DENSITY
+
+select now();
+SELECT
+sum ( st_length(q.way) / (10000 )  )  motorway_factor,
+m.geom way
+into table grid_motorway_density
+FROM lines AS q
+INNER JOIN grid AS m ON ST_Intersects(q.way, m.geom) 
+where q.highway in ('motorway', 'motorway_link','trunk','trunk_link')
+GROUP BY  m.geom
+order by motorway_factor;
+select now();
+
+-- CREATE INDEX grid_idx ON public.grid USING gist (geom) WITH (fillfactor='100');
+CREATE INDEX grid_hwd_idx ON public.grid_highway_density USING gist (way) WITH (fillfactor='100');
+CREATE INDEX grid_mwd_idx ON public.grid_motorway_density USING gist (way) WITH (fillfactor='100');
+
+
+-- collect all exceptions on 1 table
+select now();
+SELECT    y.osm_id losmid,
+  case when q.motorway_factor is null then 0
+   else q.motorway_factor
+   end as motorway_factor,
+  case when x.peak_sum_ele is null then 0
+       when x.peak_sum_ele > 500000 then 4
+   else x.peak_sum_ele / 125000
+    end as peak_sum_ele,
+  case when z.highway_factor is null then 0
+     else z.highway_factor
+    end as highway_factor,
+  case when w.industrial_factor is null then 0
+       when w.industrial_factor > 1 then (1500 * 50)
+       else (w.industrial_factor * 1500 * 50) 
+    end as industrial_factor
+ into table except_all_tmp
+ from lines y
+ left outer JOIN grid_motorway_density AS q ON st_dwithin(q.way, y.way, 5500)
+ left outer JOIN peak_density AS x ON y.osm_id = x.losmid
+ left outer JOIN industri_tmp AS w ON y.osm_id = w.losmid
+ left outer JOIN grid_highway_density AS z ON st_dwithin(z.way, y.way, 5500)
+ where y.highway in ('primary','primary_link','secondary','secondary_link', 'tertiary');
+ select now();
+
+select losmid, peak_sum_ele, avg(highway_factor) highway_factor, avg(motorway_factor) motorway_factor, industrial_factor 
+into table except_all
+from except_all_tmp
+group by  losmid, peak_sum_ele, industrial_factor;
+
+select now();
+
+--  Do not apply the positiv effect of "motorway density" in proximity of motorway accesses!!!! 
+UPDATE except_all
+SET motorway_factor = 0
+where losmid in (select losmid from motorway_access_2000);
+
+-- quite direct at motorway accesses set a negativ effect !!!! 
+UPDATE except_all
+SET motorway_factor = -15
+where losmid in (select losmid from motorway_access_1000);
+
+
+select now();
+
+-- class calculation with modifications using peaks, motorway_density and highway_density... 
+-- 
+
+SELECT    y.losmid :: bigint, 
+case
+  when ((y.populate_factor * 1200 * (1 + q.peak_sum_ele)) + q.industrial_factor) / ((30 + q.motorway_factor ) * (50 + q.highway_factor))  < 6  then '1'
+  when ((y.populate_factor * 1200 * (1 + q.peak_sum_ele)) + q.industrial_factor) / ((30 + q.motorway_factor ) * (50 + q.highway_factor))  < 10 then '2'
+  when ((y.populate_factor * 1200 * (1 + q.peak_sum_ele)) + q.industrial_factor) / ((30 + q.motorway_factor ) * (50 + q.highway_factor))  < 19  then '3'
+  when ((y.populate_factor * 1200 * (1 + q.peak_sum_ele)) + q.industrial_factor) / ((30 + q.motorway_factor ) * (50 + q.highway_factor))  < 35 then '4'
+  when ((y.populate_factor * 1200 * (1 + q.peak_sum_ele)) + q.industrial_factor) / ((30 + q.motorway_factor ) * (50 + q.highway_factor))  < 70 then '5'
+  else '6' 
+end as traffic_class
+into table traffic_tags
+from traffic_tmp y 
+left outer JOIN except_all AS q ON y.losmid = q.losmid
+order by traffic_class desc;
+
+select now();
+
+--statistics 
+select traffic_class , count(losmid) cnt from traffic_tags group by traffic_class order by traffic_class;
+
+
+--
+--  put all tags together in 1 table (1 "direct" access per way in mapcreator)
+--
+
+
+select losmid :: bigint as losmid, noise_class, river_class, forest_class, town_class, traffic_class  
+into table all_tags 
+from river_tags 
+natural full outer join noise_tags 
+natural full outer join forest_tags 
+natural full outer join town_tags 
+natural full outer join traffic_tags 
+order by losmid;
+
+create index all_tags_ind on all_tags(losmid, noise_class, river_class, forest_class, town_class, traffic_class) WITH (fillfactor='100');
+analyse;
+
+select now();

--- a/misc/scripts/mapcreation/brouter_cfg.lua
+++ b/misc/scripts/mapcreation/brouter_cfg.lua
@@ -1,0 +1,170 @@
+-- special config to calcule pseudo-tags /  "Brouter project"
+-- EssBee version 08/05/2023
+
+local srid = 3857
+
+-- 3857 SHOULD BE USED here for distance calculation ... (not srid = 4326 !)
+--  https://gis.stackexchange.com/questions/48949/epsg-3857-or-4326-for-web-mapping  
+
+local tables = {}
+
+tables.lines = osm2pgsql.define_way_table('lines', {
+    { column = 'name', type = 'text' },
+    { column = 'osm_id', type = 'text' },
+    { column = 'highway', type = 'text' },
+    { column = 'maxspeed', type = 'text' },
+    { column = 'waterway', type = 'text' },
+    { column = 'width', type = 'text' },
+    { column = 'way', type = 'linestring', projection = srid, not_null = true },
+})
+
+tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'osm_id', type = 'text' },
+    { column = 'type', type = 'text' },
+    { column = 'boundary', type = 'text' },
+    { column = 'name', type = 'text' },
+    { column = 'place', type = 'text' },
+    { column = 'population', type = 'text' },
+    { column = 'landuse', type = 'text' },
+    { column = 'leisure', type = 'text' },
+    { column = 'natural', type = 'text' },
+    { column = 'water', type = 'text' },
+    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+})
+
+
+tables.cities = osm2pgsql.define_node_table('cities', {
+    { column = 'name', type = 'text' },
+    { column = 'place', type = 'text' },
+    { column = 'admin_level', type = 'text' },
+    { column = 'osm_id', type = 'text' },
+    { column = 'population', type = 'text' },
+    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+})
+
+-- create a table for cities from special relation 
+tables.cities_rel = osm2pgsql.define_relation_table('cities_rel', {
+    { column = 'reltype', type = 'text' },
+    { column = 'admin_level', type = 'text' },
+    { column = 'boundary', type = 'text' },
+    { column = 'name', type = 'text' },
+    { column = 'place', type = 'text' },
+    { column = 'osm_id', type = 'text' },
+    { column = 'population', type = 'text' },
+    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+})
+
+-- create a table for peaks from nodes 
+tables.peak = osm2pgsql.define_node_table('peak', {
+    { column = 'name', type = 'text' },
+    { column = 'natural', type = 'text' },
+    { column = 'osm_id', type = 'text' },
+    { column = 'ele', type = 'text' },
+    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+})
+
+-- Helper function that looks at the tags and decides if this is possibly
+-- an area.
+function has_area_tags(tags)
+    if tags.area == 'yes' then
+        return true
+    end
+    if tags.area == 'no' then
+        return false
+    end
+
+    return tags.place
+        or tags.population
+        end
+
+function osm2pgsql.process_node(object)
+
+if (object.tags.place == 'city' or object.tags.place == 'town' or object.tags.place == 'municipality') and has_area_tags(object.tags)  then
+    tables.cities:insert({
+        osm_id = object.id,
+        name = object.tags.name,
+        place = object.tags.place,
+        admin_level = object.tags.admin_level,
+        population = object.tags.population,
+        way   = object:as_point()
+    })
+
+    end
+
+ if (object.tags.natural == 'peak')   then
+          tables.peak:insert({
+            natural = object.tags.natural,
+            name     = object.tags.name,
+            ele = object.tags.ele,
+            osm_id = object.id,
+            way = object:as_point()
+        })
+
+    end
+        
+end
+
+function osm2pgsql.process_way(object)
+local way_type = object:grab_tag('type')
+    
+    if  ( object.tags.natural == 'water') or (object.tags.landuse ~= nil ) or (object.tags.leisure ~= nil ) then
+        tables.polygons:insert({
+            name     = object.tags.name,
+            osm_id    = object.id,
+            type  = way_type,
+            landuse = object.tags.landuse,
+            leisure     = object.tags.leisure,
+            natural    = object.tags.natural,
+            water = object.tags.water,
+            way = object:as_polygon()
+   })
+    end
+
+   if ( object.tags.highway ~= nil) or  ( object.tags.waterway ~= nil) then
+        tables.lines:insert({
+            name = object.tags.name,
+            osm_id =  object.id,
+            highway = object.tags.highway,
+            waterway = object.tags.waterway,
+            width = object.tags.width,
+            maxspeed = object.tags.maxspeed,
+            way = object:as_linestring()
+        })
+  end
+
+  
+end
+
+function osm2pgsql.process_relation(object)
+    local relation_type = object:grab_tag('type')
+
+
+        tables.polygons:insert({
+            osm_id    = object.id,
+            type  = relation_type,
+            boundary  = object.tags.boundary,
+            name     = object.tags.name,
+            place    = object.tags.place,
+            population = object.tags.population,
+            landuse = object.tags.landuse,
+            leisure     = object.tags.leisure,
+            natural    = object.tags.natural,
+            water = object.tags.water,
+            way = object:as_multipolygon()
+        })
+
+--   if (relation_type == 'boundary') and has_area_tags(object.tags)  then
+   if (relation_type == 'boundary')   then
+          tables.cities_rel:insert({
+            reltype    = object.tags.relation_type,
+            boundary = object.tags.boundary,
+            admin_level = object.tags.admin_level,
+            name     = object.tags.name,
+            place    = object.tags.place,
+            population = object.tags.population,
+            osm_id = object.id,
+            way = object:as_multipolygon()
+        })
+     end
+
+end

--- a/misc/scripts/mapcreation/brouter_cfg.lua
+++ b/misc/scripts/mapcreation/brouter_cfg.lua
@@ -1,170 +1,169 @@
 -- special config to calcule pseudo-tags /  "Brouter project"
--- EssBee version 08/05/2023
 
 local srid = 3857
 
 -- 3857 SHOULD BE USED here for distance calculation ... (not srid = 4326 !)
---  https://gis.stackexchange.com/questions/48949/epsg-3857-or-4326-for-web-mapping  
+--  https://gis.stackexchange.com/questions/48949/epsg-3857-or-4326-for-web-mapping
 
 local tables = {}
 
 tables.lines = osm2pgsql.define_way_table('lines', {
-    { column = 'name', type = 'text' },
-    { column = 'osm_id', type = 'text' },
-    { column = 'highway', type = 'text' },
-    { column = 'maxspeed', type = 'text' },
-    { column = 'waterway', type = 'text' },
-    { column = 'width', type = 'text' },
-    { column = 'way', type = 'linestring', projection = srid, not_null = true },
+   { column = 'name', type = 'text' },
+   { column = 'osm_id', type = 'text' },
+   { column = 'highway', type = 'text' },
+   { column = 'maxspeed', type = 'text' },
+   { column = 'waterway', type = 'text' },
+   { column = 'width', type = 'text' },
+   { column = 'way', type = 'linestring', projection = srid, not_null = true },
 })
 
 tables.polygons = osm2pgsql.define_area_table('polygons', {
-    { column = 'osm_id', type = 'text' },
-    { column = 'type', type = 'text' },
-    { column = 'boundary', type = 'text' },
-    { column = 'name', type = 'text' },
-    { column = 'place', type = 'text' },
-    { column = 'population', type = 'text' },
-    { column = 'landuse', type = 'text' },
-    { column = 'leisure', type = 'text' },
-    { column = 'natural', type = 'text' },
-    { column = 'water', type = 'text' },
-    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+   { column = 'osm_id', type = 'text' },
+   { column = 'type', type = 'text' },
+   { column = 'boundary', type = 'text' },
+   { column = 'name', type = 'text' },
+   { column = 'place', type = 'text' },
+   { column = 'population', type = 'text' },
+   { column = 'landuse', type = 'text' },
+   { column = 'leisure', type = 'text' },
+   { column = 'natural', type = 'text' },
+   { column = 'water', type = 'text' },
+   { column = 'way', type = 'geometry', projection = srid, not_null = true },
 })
 
 
 tables.cities = osm2pgsql.define_node_table('cities', {
-    { column = 'name', type = 'text' },
-    { column = 'place', type = 'text' },
-    { column = 'admin_level', type = 'text' },
-    { column = 'osm_id', type = 'text' },
-    { column = 'population', type = 'text' },
-    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+   { column = 'name', type = 'text' },
+   { column = 'place', type = 'text' },
+   { column = 'admin_level', type = 'text' },
+   { column = 'osm_id', type = 'text' },
+   { column = 'population', type = 'text' },
+   { column = 'way', type = 'geometry', projection = srid, not_null = true },
 })
 
--- create a table for cities from special relation 
+-- create a table for cities from special relation
 tables.cities_rel = osm2pgsql.define_relation_table('cities_rel', {
-    { column = 'reltype', type = 'text' },
-    { column = 'admin_level', type = 'text' },
-    { column = 'boundary', type = 'text' },
-    { column = 'name', type = 'text' },
-    { column = 'place', type = 'text' },
-    { column = 'osm_id', type = 'text' },
-    { column = 'population', type = 'text' },
-    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+   { column = 'reltype', type = 'text' },
+   { column = 'admin_level', type = 'text' },
+   { column = 'boundary', type = 'text' },
+   { column = 'name', type = 'text' },
+   { column = 'place', type = 'text' },
+   { column = 'osm_id', type = 'text' },
+   { column = 'population', type = 'text' },
+   { column = 'way', type = 'geometry', projection = srid, not_null = true },
 })
 
--- create a table for peaks from nodes 
+-- create a table for peaks from nodes
 tables.peak = osm2pgsql.define_node_table('peak', {
-    { column = 'name', type = 'text' },
-    { column = 'natural', type = 'text' },
-    { column = 'osm_id', type = 'text' },
-    { column = 'ele', type = 'text' },
-    { column = 'way', type = 'geometry', projection = srid, not_null = true },
+   { column = 'name', type = 'text' },
+   { column = 'natural', type = 'text' },
+   { column = 'osm_id', type = 'text' },
+   { column = 'ele', type = 'text' },
+   { column = 'way', type = 'geometry', projection = srid, not_null = true },
 })
 
 -- Helper function that looks at the tags and decides if this is possibly
 -- an area.
 function has_area_tags(tags)
-    if tags.area == 'yes' then
-        return true
-    end
-    if tags.area == 'no' then
-        return false
-    end
+   if tags.area == 'yes' then
+      return true
+   end
+   if tags.area == 'no' then
+      return false
+   end
 
-    return tags.place
-        or tags.population
-        end
+   return tags.place
+   or tags.population
+end
 
 function osm2pgsql.process_node(object)
 
-if (object.tags.place == 'city' or object.tags.place == 'town' or object.tags.place == 'municipality') and has_area_tags(object.tags)  then
-    tables.cities:insert({
-        osm_id = object.id,
-        name = object.tags.name,
-        place = object.tags.place,
-        admin_level = object.tags.admin_level,
-        population = object.tags.population,
-        way   = object:as_point()
-    })
+   if (object.tags.place == 'city' or object.tags.place == 'town' or object.tags.place == 'municipality') and has_area_tags(object.tags)  then
+      tables.cities:insert({
+         osm_id = object.id,
+         name = object.tags.name,
+         place = object.tags.place,
+         admin_level = object.tags.admin_level,
+         population = object.tags.population,
+         way   = object:as_point()
+      })
 
-    end
+   end
 
- if (object.tags.natural == 'peak')   then
-          tables.peak:insert({
-            natural = object.tags.natural,
-            name     = object.tags.name,
-            ele = object.tags.ele,
-            osm_id = object.id,
-            way = object:as_point()
-        })
+   if (object.tags.natural == 'peak')   then
+      tables.peak:insert({
+         natural = object.tags.natural,
+         name     = object.tags.name,
+         ele = object.tags.ele,
+         osm_id = object.id,
+         way = object:as_point()
+      })
 
-    end
-        
+   end
+
 end
 
 function osm2pgsql.process_way(object)
-local way_type = object:grab_tag('type')
-    
-    if  ( object.tags.natural == 'water') or (object.tags.landuse ~= nil ) or (object.tags.leisure ~= nil ) then
-        tables.polygons:insert({
-            name     = object.tags.name,
-            osm_id    = object.id,
-            type  = way_type,
-            landuse = object.tags.landuse,
-            leisure     = object.tags.leisure,
-            natural    = object.tags.natural,
-            water = object.tags.water,
-            way = object:as_polygon()
-   })
-    end
+   local way_type = object:grab_tag('type')
+
+   if  ( object.tags.natural == 'water') or (object.tags.landuse ~= nil ) or (object.tags.leisure ~= nil ) then
+      tables.polygons:insert({
+         name     = object.tags.name,
+         osm_id    = object.id,
+         type  = way_type,
+         landuse = object.tags.landuse,
+         leisure     = object.tags.leisure,
+         natural    = object.tags.natural,
+         water = object.tags.water,
+         way = object:as_polygon()
+      })
+   end
 
    if ( object.tags.highway ~= nil) or  ( object.tags.waterway ~= nil) then
-        tables.lines:insert({
-            name = object.tags.name,
-            osm_id =  object.id,
-            highway = object.tags.highway,
-            waterway = object.tags.waterway,
-            width = object.tags.width,
-            maxspeed = object.tags.maxspeed,
-            way = object:as_linestring()
-        })
-  end
+      tables.lines:insert({
+         name = object.tags.name,
+         osm_id =  object.id,
+         highway = object.tags.highway,
+         waterway = object.tags.waterway,
+         width = object.tags.width,
+         maxspeed = object.tags.maxspeed,
+         way = object:as_linestring()
+      })
+   end
 
-  
+
 end
 
 function osm2pgsql.process_relation(object)
-    local relation_type = object:grab_tag('type')
+   local relation_type = object:grab_tag('type')
 
 
-        tables.polygons:insert({
-            osm_id    = object.id,
-            type  = relation_type,
-            boundary  = object.tags.boundary,
-            name     = object.tags.name,
-            place    = object.tags.place,
-            population = object.tags.population,
-            landuse = object.tags.landuse,
-            leisure     = object.tags.leisure,
-            natural    = object.tags.natural,
-            water = object.tags.water,
-            way = object:as_multipolygon()
-        })
+   tables.polygons:insert({
+      osm_id    = object.id,
+      type  = relation_type,
+      boundary  = object.tags.boundary,
+      name     = object.tags.name,
+      place    = object.tags.place,
+      population = object.tags.population,
+      landuse = object.tags.landuse,
+      leisure     = object.tags.leisure,
+      natural    = object.tags.natural,
+      water = object.tags.water,
+      way = object:as_multipolygon()
+   })
 
---   if (relation_type == 'boundary') and has_area_tags(object.tags)  then
+   --   if (relation_type == 'boundary') and has_area_tags(object.tags)  then
    if (relation_type == 'boundary')   then
-          tables.cities_rel:insert({
-            reltype    = object.tags.relation_type,
-            boundary = object.tags.boundary,
-            admin_level = object.tags.admin_level,
-            name     = object.tags.name,
-            place    = object.tags.place,
-            population = object.tags.population,
-            osm_id = object.id,
-            way = object:as_multipolygon()
-        })
-     end
+      tables.cities_rel:insert({
+         reltype    = object.tags.relation_type,
+         boundary = object.tags.boundary,
+         admin_level = object.tags.admin_level,
+         name     = object.tags.name,
+         place    = object.tags.place,
+         population = object.tags.population,
+         osm_id = object.id,
+         way = object:as_multipolygon()
+      })
+   end
 
 end

--- a/misc/scripts/mapcreation/lookups_db.dat
+++ b/misc/scripts/mapcreation/lookups_db.dat
@@ -1,5 +1,5 @@
 ---lookupversion:10
----minorversion:13
+---minorversion:14
 
 ---context:way
 

--- a/misc/scripts/mapcreation/lookups_db.dat
+++ b/misc/scripts/mapcreation/lookups_db.dat
@@ -1,0 +1,967 @@
+---lookupversion:10
+---minorversion:13
+
+---context:way
+
+highway;0029035962 residential
+highway;0010319731 service
+highway;0007688809 track
+highway;0007656124 unclassified
+highway;0004141444 footway
+highway;0003493551 tertiary
+highway;0002852601 path
+highway;0002185240 secondary
+highway;0001447719 primary
+highway;0000699577 cycleway
+highway;0000608469 trunk
+highway;0000568118 living_street
+highway;0000515044 motorway
+highway;0000451760 motorway_link
+highway;0000442502 steps
+highway;0000360177 road
+highway;0000318426 pedestrian
+highway;0000210535 trunk_link
+highway;0000192461 primary_link
+highway;0000120758 secondary_link
+highway;0000079637 tertiary_link
+highway;0000070238 construction
+highway;0000058257 bridleway
+highway;0000039003 platform
+highway;0000037192 proposed planned virtual
+highway;0000010307 raceway
+highway;0000003152 rest_area
+highway;0000002942 abandoned disused razed demolished dismantled
+highway;0000002631 services
+highway;0000002133 corridor
+highway;0000002093 crossing
+highway;0000001440 bus_stop
+highway;0000001274 yes
+highway;0000000679 unsurfaced
+highway;0000000108 byway
+highway;0000000037 driveway
+highway;0000000021 mini_roundabout
+highway;0000000020 turning_loop
+
+tracktype;0000887965 grade2
+tracktype;0000868414 grade3
+tracktype;0000595882 grade1
+tracktype;0000568372 grade4
+tracktype;0000405959 grade5
+
+surface;0002497676 asphalt
+surface;0001568957 paved
+surface;0001562253 unpaved
+surface;0000727427 gravel
+surface;0000560191 ground
+surface;0000350378 dirt
+surface;0000237226 grass
+surface;0000212587 concrete concrete:plates concrete:lanes
+surface;0000188743 paving_stones paving_stones:30 paving_stones:20
+surface;0000113800 cobblestone cobblestone:flattened
+surface;0000093164 compacted
+surface;0000091171 sand dirt/sand
+surface;0000023293 wood
+surface;0000019915 pebblestone
+surface;0000012866 fine_gravel
+surface;0000010681 earth
+surface;0000007331 sett
+surface;0000005778 mud
+surface;0000004549 grass_paver
+surface;0000004398 clay
+surface;0000003760 metal
+
+maxspeed;0001058313 50 30_mph 30mph
+maxspeed;0000860780 30 20_mph 20mph
+maxspeed;0000025232 10 5 7 15
+maxspeed;0000083989 20 10_mph 10mph 15_mph 15mph
+maxspeed;0000195097 40 45 25_mph 25mph
+maxspeed;0000204646 60 35_mph 35mph 40_mph 40mph
+maxspeed;0000130108 70 45_mph 45mph
+maxspeed;0000225071 80 50_mph 50mph
+maxspeed;0000106719 90 55_mph 55mph
+maxspeed;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed;0000025242 110 70_mph 70mph
+maxspeed;0000038763 120 75_mph 75mph
+maxspeed;0000026953 130
+maxspeed;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+service;0001433919 parking_aisle
+service;0001305879 driveway
+service;0000382788 alley
+service;0000018777 drive-through drive_through
+service;0000008290 emergency_access
+service;0000003138 bus
+service;0000001250 parking
+service;0000001159 logging
+
+lit;0000809223 yes
+
+lanes;0002838405 2
+lanes;0000718138 1
+lanes;0000259502 3
+lanes;0000141651 4
+lanes;0000018473 -1
+lanes;0000017934 5
+lanes;0000008241 6
+lanes;0000003643 1.5
+lanes;0000001087 7
+
+access;0002688349 private
+access;0000319927 yes
+access;0000144799 no
+access;0000140215 permissive
+access;0000108802 destination
+access;0000099899 agricultural forestry
+access;0000039934 designated official
+access;0000011813 customers
+access;0000004007 delivery
+access;0000000100 psv
+access;0000000100 hov
+
+foot;0001659694 yes allowed Yes
+foot;0000424847 designated official
+foot;0000202364 no
+foot;0000053031 permissive
+foot;0000011661 destination
+foot;0000007289 private
+foot;0000000167 use_sidepath sidewalk
+
+bicycle;0001245560 yes allowed
+bicycle;0000452059 no
+bicycle;0000324902 designated official
+bicycle;0000025707 dismount
+bicycle;0000020440 permissive
+bicycle;0000008286 private
+bicycle;0000001553 destination
+bicycle;0000000719 use_sidepath use_cycleway
+bicycle;0000000385 mtb
+bicycle;0000000117 opposite
+
+motorcar;0000135124 no
+motorcar;0000045407 yes
+motorcar;0000021494 agricultural forestry
+motorcar;0000012090 destination
+motorcar;0000008733 private
+motorcar;0000005757 designated official
+motorcar;0000004116 permissive
+motorcar;0000000979 restricted
+motorcar;0000000100 psv
+motorcar;0000000100 hov
+
+motor_vehicle;0000212692 no
+motor_vehicle;0000184982 yes
+motor_vehicle;0000045128 private
+motor_vehicle;0000032622 agricultural forestry agricultural;forestry agricultural,forestry
+motor_vehicle;0000025396 designated official
+motor_vehicle;0000025092 destination
+motor_vehicle;0000010895 permissive
+motor_vehicle;0000000175 emergency Emergency
+motor_vehicle;0000000100 psv
+motor_vehicle;0000000100 hov
+
+motorcycle;0000092079 no
+motorcycle;0000027978 yes
+motorcycle;0000014652 agricultural forestry
+motorcycle;0000008862 destination
+motorcycle;0000004877 designated official
+motorcycle;0000003936 private
+motorcycle;0000002209 permissive
+motorcycle;0000000100 psv
+motorcycle;0000000100 hov
+
+vehicle;0000030218 no
+vehicle;0000013333 destination
+vehicle;0000011692 yes
+vehicle;0000007147 agricultural forestry agricultural;forestry
+vehicle;0000006305 private
+vehicle;0000001294 permissive
+vehicle;0000000105 designated
+vehicle;0000000100 psv
+vehicle;0000000100 hov
+
+horse;0000227398 no
+horse;0000144432 yes
+horse;0000014566 designated
+horse;0000007223 permissive
+horse;0000004755 private
+horse;0000000983 official
+horse;0000000968 unknown
+horse;0000000205 destination
+
+wheelchair;0000036603 no
+wheelchair;0000028451 yes
+wheelchair;0000002713 limited
+wheelchair;0000001043 unknown
+wheelchair;0000000439 designated official
+wheelchair;0000000184 destination
+
+hgv;0000206836 designated
+hgv;0000071222 yes
+hgv;0000043783 no
+hgv;0000019115 destination
+hgv;0000005273 delivery
+hgv;0000003055 local
+hgv;0000001088 agricultural forestry
+hgv;0000000461 private
+hgv;0000000320 unsuitable
+hgv;0000000306 permissive
+
+cycleway;0000137526 no
+cycleway;0000124777 lane
+cycleway;0000106948 track
+cycleway;0000044652 opposite
+cycleway;0000011237 shared
+cycleway;0000007312 opposite_lane
+cycleway;0000005737 shared_lane
+cycleway;0000002533 yes
+cycleway;0000002356 opposite_track
+cycleway;0000001945 share_busway
+cycleway;0000001883 none
+cycleway;0000001705 crossing
+cycleway;0000001560 unmarked_lane
+cycleway;0000001542 right
+cycleway;0000001291 segregated
+cycleway;0000001065 both
+cycleway;0000000892 left
+cycleway;0000000399 street
+cycleway;0000000344 shoulder
+cycleway;0000000326 designated
+cycleway;0000000247 proposed planned virtual
+cycleway;0000000224 cyclestreet
+cycleway;0000000172 path
+cycleway;0000000154 sidewalk
+
+footway;0000104998 sidewalk
+footway;0000065943 crossing
+footway;0000012342 both
+footway;0000008363 none
+footway;0000005903 right
+footway;0000004159 left
+footway;0000003966 no
+footway;0000001093 yes
+footway;0000000558 separate
+
+segregated;0000224960 no
+segregated;0000051124 yes
+
+sidewalk;0000194579 none
+sidewalk;0000111468 both
+sidewalk;0000052950 right
+sidewalk;0000024489 left
+sidewalk;0000012916 no
+sidewalk;0000005725 separate
+sidewalk;0000001950 yes
+
+mtb:scale;0000114272 0
+mtb:scale;0000068284 1
+mtb:scale;0000027311 2
+mtb:scale;0000011529 3
+mtb:scale;0000003666 4
+mtb:scale;0000001957 0+
+mtb:scale;0000001472 5
+mtb:scale;0000000498 1+
+mtb:scale;0000000478 1-
+mtb:scale;0000000268 0-
+mtb:scale;0000000177 2-
+mtb:scale;0000000131 2+
+mtb:scale;0000000115 6
+
+sac_scale;0000150704 hiking
+sac_scale;0000070463 mountain_hiking
+sac_scale;0000010993 demanding_mountain_hiking
+sac_scale;0000004549 alpine_hiking
+sac_scale;0000001620 demanding_alpine_hiking
+sac_scale;0000000831 yes
+sac_scale;0000000712 difficult_alpine_hiking
+sac_scale;0000000265 T1-hiking
+
+noexit;0000118665 yes
+
+motorroad;0000056844 yes
+
+oneway;0005387257 yes
+oneway;0001455407 no
+oneway;0000139188 -1
+oneway;0000000892 reversible
+oneway;0000000756 1
+oneway;0000000481 true
+
+junction;0000321066 roundabout
+junction;0000002828 spui
+junction;0000002134 jughandle
+junction;0000001493 approach
+junction;0000000100 circular
+
+bridge;0001842517 yes viaduct true suspension
+
+tunnel;0000247305 yes
+tunnel;0000016890 building_passage
+tunnel;0000004237 no
+tunnel;0000000265 passage
+tunnel;0000000241 culvert
+tunnel;0000000122 avalanche_protector
+tunnel;0000000114 covered
+
+lcn;0000073956 yes
+lcn;0000002631 proposed
+
+oneway:bicycle;0000012034 no
+oneway:bicycle;0000005217 yes
+oneway:bicycle;0000000161 opposite
+
+cycleway:right;0000012522 lane Lane
+cycleway:right;0000006644 track
+cycleway:right;0000000971 share_busway
+cycleway:right;0000000686 sidepath
+cycleway:right;0000000410 shared_lane
+cycleway:right;0000000104 opposite_lane
+cycleway:right;0000000058 opposite_track
+cycleway:right;0000000045 no none
+cycleway:right;0000000037 yes
+cycleway:right;0000000004 opposite
+
+cycleway:left;0000005134 lane Lane
+cycleway:left;0000003169 track
+cycleway:left;0000000656 share_busway
+cycleway:left;0000000608 opposite_lane
+cycleway:left;0000000475 sidepath
+cycleway:left;0000000257 shared_lane
+cycleway:left;0000000246 no none
+cycleway:left;0000000130 opposite_track
+cycleway:left;0000000053 opposite
+cycleway:left;0000000014 yes
+
+incline;0000052784 up
+incline;0000035413 down
+incline;0000001628 yes
+incline;0000000779 steep
+incline;0000000861 3% 0 1 2 3 0% 1% 2% 3%
+incline;0000000724 5% 4 5 4%
+incline;0000000530 8% 6 7 8 6% 7%
+incline;0000003109 10% 9 10 9% 10°
+incline;0000001297 15% 11 12 13 14 15 11% 12% 13% 14%
+incline;0000000997 20% 16 17 18 19 20 16% 17% 18% 19%
+incline;0000000409 25% 21 22 23 24 25 21% 22% 23% 24%
+incline;0000000263 30% 30 40 50 40% 50%
+incline;0000000861 -3% -1 -2 -3 -1% -2% -3%
+incline;0000000724 -5% -4 -5 -4%
+incline;0000000530 -8% -6 -7 -8 -6% -7%
+incline;0000001515 -10% -9 -10 -9% -10°
+incline;0000001297 -15% -11 -12 -13 -14 -15 -11% -12% -13% -14%
+incline;0000000997 -20% -16 -17 -18 -19 -20 -16% -17% -18% -19%
+incline;0000000409 -25% -21 -22 -23 -24 -25 -21% -22% -23% -24%
+incline;0000000172 -30% -30 -40 -50 -40% -50%
+
+toll;0000090536 yes true
+
+railway;0000157547 rail
+railway;0000019316 abandoned
+railway;0000016982 tram
+railway;0000014387 platform
+railway;0000011143 disused
+railway;0000004623 light_rail
+railway;0000002982 subway
+railway;0000002422 narrow_gauge
+railway;0000001960 razed
+railway;0000001859 preserved
+
+seamark:type;0001564 recommended_track
+seamark:type;0000522 fairway
+
+waterway;0000016046 river
+waterway;0000009496 canal
+waterway;0000007876 riverbank
+waterway;0000002202 weir
+waterway;0000001364 dam
+waterway;0000000386 lock
+waterway;0000000321 tidal_flat_slough
+waterway;0000000179 wadi
+waterway;0000000126 dock
+waterway;0000000113 fish_pass
+waterway;0000000086 boatyard
+waterway;0000000071 fairway
+waterway;0000000059 lock_gate
+
+boat;0000019888 no
+boat;0000002718 yes
+boat;0000000232 private
+boat;0000000064 permissive
+boat;0000000045 designated
+
+motorboat;0000001077 yes
+motorboat;0000000808 no
+motorboat;0000000025 private privat
+
+route;0000000850 ferry
+route;0000000539 hiking
+route;0000000505 bicycle
+route;0000000454 ski
+route;0000000413 mtb
+route;0000000194 canoe
+route;0000000151 road
+route;0000000104 bus
+
+smoothness;0000068136 good
+smoothness;0000042124 bad Bad
+smoothness;0000040763 intermediate
+smoothness;0000033941 excellent
+smoothness;0000012683 very_bad
+smoothness;0000009837 horrible terrible
+smoothness;0000003515 very_horrible
+smoothness;0000000919 impassable
+smoothness;0000000251 robust_wheels
+smoothness;0000000221 high_clearance
+smoothness;0000000132 very_good
+smoothness;0000000083 off_road_wheels
+smoothness;0000000057 medium Medium average
+smoothness;0000000048 poor
+smoothness;0000000039 rough
+
+rcn;0000014518 yes
+rcn;0000002862 proposed
+
+ncn;0000002941 yes
+ncn;0000001036 proposed
+
+ford;0000020552 yes
+ford;0000000289 stepping_stones
+
+trail_visibility;0000067438 good
+trail_visibility;0000041280 intermediate
+trail_visibility;0000039801 excellent
+trail_visibility;0000023482 bad
+trail_visibility;0000005853 horrible
+trail_visibility;0000002222 no
+
+class:bicycle:mtb;0000002079 1 +1
+class:bicycle:mtb;0000001191 0
+class:bicycle:mtb;0000001089 2 +2
+class:bicycle:mtb;0000000703 -1
+class:bicycle:mtb;0000000234 -2
+class:bicycle:mtb;0000000140 3 +3
+class:bicycle:mtb;0000000068 -3
+
+class:bicycle;0000002842 1 +1
+class:bicycle;0000000595 -1
+class:bicycle;0000000533 2 +2
+class:bicycle;0000000516 -2
+class:bicycle;0000000245 -3
+class:bicycle;0000000170 0
+class:bicycle;0000000108 3 +3
+
+route_bicycle_icn;0000088753 yes
+route_bicycle_icn;0000000001 proposed
+route_bicycle_ncn;0000268180 yes
+route_bicycle_ncn;00000000001 proposed
+route_bicycle_rcn;0000718163 yes
+route_bicycle_rcn;00000000001 proposed
+route_bicycle_lcn;0000469215 yes
+route_bicycle_lcn;00000000001 proposed
+
+route_bicycle_;0000024662 yes
+route_bicycle_radweit;0000004604 yes
+
+route_hiking_iwn;0000056005 yes
+route_hiking_nwn;0000315813 yes
+route_hiking_rwn;0000343219 yes
+route_hiking_lwn;0000359332 yes
+route_hiking_;0000103733 yes
+
+route_foot_nwn;0000047923 yes
+route_foot_lwn;0000135371 yes
+route_foot_rwn;0000115325 yes
+route_foot_;0000070583 yes
+
+route_mtb_;0000066263 yes
+route_mtb_lcn;0000023718 yes
+route_mtb_ncn;0000004853 yes
+route_mtb_rcn;0000013321 yes
+route_mtb_mtb;0000006853 yes
+route_bicycle_mtb;0000002240 yes
+
+brouter_route_placeholder_dummy_01;0000000001 dummy
+brouter_route_placeholder_dummy_02;0000000001 dummy
+brouter_route_placeholder_dummy_03;0000000001 dummy
+brouter_route_placeholder_dummy_04;0000000001 dummy
+brouter_route_placeholder_dummy_05;0000000001 dummy
+brouter_route_placeholder_dummy_06;0000000001 dummy
+brouter_route_placeholder_dummy_07;0000000001 dummy
+brouter_route_placeholder_dummy_08;0000000001 dummy
+brouter_route_placeholder_dummy_09;0000000001 dummy
+brouter_route_placeholder_dummy_10;0000000001 dummy
+brouter_route_placeholder_dummy_11;0000000001 dummy
+brouter_route_placeholder_dummy_12;0000000001 dummy
+brouter_route_placeholder_dummy_13;0000000001 dummy
+brouter_route_placeholder_dummy_14;0000000001 dummy
+brouter_route_placeholder_dummy_15;0000000001 dummy
+brouter_route_placeholder_dummy_16;0000000001 dummy
+brouter_route_placeholder_dummy_17;0000000001 dummy
+brouter_route_placeholder_dummy_18;0000000001 dummy
+brouter_route_placeholder_dummy_19;0000000001 dummy
+brouter_route_placeholder_dummy_20;0000000001 dummy
+brouter_route_placeholder_dummy_21;0000000001 dummy
+
+ramp:bicycle;0000001305 yes both permissive right left
+ramp:bicycle;0000000385 no
+
+ramp:stroller;0000001099 yes
+ramp:stroller;0000000326 no
+
+ramp:wheelchair;0000000610 yes
+ramp:wheelchair;0000000439 no
+
+ramp:luggage;0000000162 no
+ramp:luggage;0000000054 yes automatic manual
+
+estimated_traffic_class;0000000001 1
+estimated_traffic_class;0000000001 2
+estimated_traffic_class;0000000001 3
+estimated_traffic_class;0000000001 4
+estimated_traffic_class;0000000001 5
+estimated_traffic_class;0000000001 6
+estimated_traffic_class;0000000001 7
+
+mtb:scale:uphill;0000018869 0 0+ 0-
+mtb:scale:uphill;0000015578 1 1+ 1-
+mtb:scale:uphill;0000012338 2 2+ 2-
+mtb:scale:uphill;0000009099 3 3+ 3-
+mtb:scale:uphill;0000005825 4 4+ 4-
+mtb:scale:uphill;0000004628 5 5+ 5-
+
+crossing;0000101049 zebra
+crossing;0000017509 unmarked
+crossing;0000013817 traffic_signals
+crossing;0000011062 uncontrolled
+crossing;0000001722 yes
+crossing;0000001678 island
+crossing;0000000457 marked
+crossing;0000000131 pedestrian_signals
+crossing;0000000122 no
+
+informal;0000002424 yes
+
+indoor;0000058418 yes
+indoor;0000025038 room
+indoor;0000005295 wall
+indoor;0000004322 corridor
+indoor;0000002410 area
+indoor;0000000816 column
+indoor;0000000568 no
+indoor;0000000129 shop
+indoor;0000000099 steps
+
+4wd_only;0000008129 yes Yes
+4wd_only;0000000487 recommended
+4wd_only;0000000041 no
+
+concrete;0000000043 plates
+concrete;0000000013 lanes
+
+bus;0001178365 yes
+bus;0000006419 designated
+bus;0000005602 no
+bus;0000001424 urban
+
+psv;0000072077 yes
+psv;0000007456 no
+psv;0000007428 designated official
+
+hov;0000006684 lane
+hov;0000003258 designated
+hov;0000002162 no
+hov;0000001512 yes
+
+busway;0000000000 opposite opposite_lane opposite_track
+busway:left;0000000000 opposite opposite_lane opposite_track
+busway:right;0000000000 opposite opposite_lane opposite_track
+
+cycleway:left:oneway;0000000769 yes
+cycleway:left:oneway;0000001595 no
+cycleway:left:oneway;0000000927 -1
+
+cycleway:right:oneway;0000003084 yes
+cycleway:right:oneway;0000002499 no
+cycleway:right:oneway;0000000017 -1
+
+zone:maxspeed;0000001616 20 DE:20 FR:20
+zone:maxspeed;0000063721 30 DE:30 FR:30 BE:30 HU:30 NO:30 AT:30 ES:30 NL:30
+
+cycleway:surface;0000002609 asphalt
+cycleway:surface;0000000150 paved
+cycleway:surface;0000000012 unpaved
+cycleway:surface;0000000010 gravel
+cycleway:surface;0000000157 concrete concrete:plates concrete:lanes
+cycleway:surface;0000002239 paving_stones paving_stones:30 paving_stones:20
+cycleway:surface;0000000011 cobblestone cobblestone:flattened
+cycleway:surface;0000000013 compacted
+cycleway:surface;0000000006 fine_gravel
+cycleway:surface;0000000011 sett
+
+maxspeed:backward;0001058313 50 30_mph 30mph
+maxspeed:backward;0000860780 30 20_mph 20mph
+maxspeed:backward;0000025232 10 5 7 15
+maxspeed:backward;0000083989 20 10_mph 10mph 15_mph 15mph
+maxspeed:backward;0000195097 40 45 25_mph 25mph
+maxspeed:backward;0000204646 60 35_mph 35mph 40_mph 40mph
+maxspeed:backward;0000130108 70 45_mph 45mph
+maxspeed:backward;0000225071 80 50_mph 50mph
+maxspeed:backward;0000106719 90 55_mph 55mph
+maxspeed:backward;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed:backward;0000025242 110 70_mph 70mph
+maxspeed:backward;0000038763 120 75_mph 75mph
+maxspeed:backward;0000026953 130
+maxspeed:backward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed:backward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+maxspeed:forward;0001058313 50 30_mph 30mph
+maxspeed:forward;0000860780 30 20_mph 20mph
+maxspeed:forward;0000025232 10 5 7 15
+maxspeed:forward;0000083989 20 10_mph 10mph 15_mph 15mph
+maxspeed:forward;0000195097 40 45 25_mph 25mph
+maxspeed:forward;0000204646 60 35_mph 35mph 40_mph 40mph
+maxspeed:forward;0000130108 70 45_mph 45mph
+maxspeed:forward;0000225071 80 50_mph 50mph
+maxspeed:forward;0000106719 90 55_mph 55mph
+maxspeed:forward;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed:forward;0000025242 110 70_mph 70mph
+maxspeed:forward;0000038763 120 75_mph 75mph
+maxspeed:forward;0000026953 130
+maxspeed:forward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed:forward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+embedded_rails;0000000928 tram
+embedded_rails;0000000007 yes
+embedded_rails;0000000003 rail
+
+living_street;0000000404 yes
+
+sidewalk:bicycle;0000000439 yes designated
+sidewalk:left:bicycle;0000001722 yes designated
+sidewalk:right:bicycle;0000002667 yes designated
+
+bicycle_road;0000006521 yes designated
+
+construction;0000144871 yes
+construction;0000008214 minor
+construction;0029035962 residential
+construction;0010319731 service
+construction;0007688809 track
+construction;0007656124 unclassified
+construction;0004141444 footway
+construction;0003493551 tertiary
+construction;0002852601 path
+construction;0002185240 secondary
+construction;0001447719 primary
+construction;0000699577 cycleway
+construction;0000608469 trunk
+construction;0000568118 living_street
+construction;0000515044 motorway
+construction;0000451760 motorway_link
+construction;0000442502 steps
+construction;0000360177 road
+construction;0000318426 pedestrian
+construction;0000210535 trunk_link
+construction;0000192461 primary_link
+construction;0000120758 secondary_link
+construction;0000079637 tertiary_link
+construction;0000070238 construction
+construction;0000058257 bridleway
+construction;0000039003 platform
+construction;0000037192 proposed
+construction;0000010307 raceway
+construction;0000003152 rest_area
+construction;0000002942 abandoned
+construction;0000002631 services
+construction;0000002133 corridor
+construction;0000002093 crossing
+construction;0000001440 bus_stop
+construction;0000001274 yes
+construction;0000000679 unsurfaced
+construction;0000000108 byway
+construction;0000000037 driveway
+construction;0000000021 mini_roundabout
+construction;0000000020 turning_loop
+
+estimated_forest_class;0000000001 1
+estimated_forest_class;0000000001 2
+estimated_forest_class;0000000001 3
+estimated_forest_class;0000000001 4
+estimated_forest_class;0000000001 5
+estimated_forest_class;0000000001 6
+
+estimated_noise_class;0000000001 1
+estimated_noise_class;0000000001 2
+estimated_noise_class;0000000001 3
+estimated_noise_class;0000000001 4
+estimated_noise_class;0000000001 5
+estimated_noise_class;0000000001 6
+
+estimated_river_class;0000000001 1
+estimated_river_class;0000000001 2
+estimated_river_class;0000000001 3
+estimated_river_class;0000000001 4
+estimated_river_class;0000000001 5
+estimated_river_class;0000000001 6
+
+estimated_town_class;0000000001 1
+estimated_town_class;0000000001 2
+estimated_town_class;0000000001 3
+estimated_town_class;0000000001 4
+estimated_town_class;0000000001 5
+estimated_town_class;0000000001 6
+
+
+ ---context:node
+
+highway;0001314954 bus_stop
+highway;0001130090 crossing
+highway;0001031274 turning_circle
+highway;0000609262 traffic_signals
+highway;0000306900 street_lamp
+highway;0000136339 stop
+highway;0000105097 motorway_junction
+highway;0000058076 give_way
+highway;0000049111 mini_roundabout
+highway;0000030072 milestone
+highway;0000017567 speed_camera
+highway;0000013806 emergency_access_point
+highway;0000009721 platform
+highway;0000007369 passing_place
+highway;0000005939 ford
+highway;0000004831 rest_area
+highway;0000003535 elevator
+highway;0000002572 turning_loop
+highway;0000002540 steps
+highway;0000002493 services
+highway;0000002133 emergency_bay
+highway;0000001372 residential
+highway;0000001324 street_light
+highway;0000001147 incline_steep
+highway;0000001101 stile
+highway;0000000904 incline
+highway;0000000819 service
+highway;0000000817 traffic_calming
+highway;0000000662 path
+highway;0000000603 footway
+highway;0000000438 track
+highway;0000000436 no
+highway;0000000353 door
+highway;0000000283 level_crossing
+highway;0000000267 yes
+highway;0000000262 road
+highway;0000000244 construction
+highway;0000000214 unclassified
+highway;0000000213 proposed
+highway;0000000197 junction
+highway;0000000176 distance_marker
+highway;0000000158 noexit
+highway;0000000155 unknown
+highway;0000000134 traffic_sign
+highway;0000000123 tertiary
+highway;0000000115 trailhead
+highway;0000000113 priority_to_right
+highway;0000000113 culvert
+highway;0000000100 <residential>
+highway;0000000046 toll_bridge
+highway;0000000037 city_entry
+highway;0000002967 traffic_mirror
+highway;0000001724 priority
+
+barrier;0000606512 gate
+barrier;0000164120 bollard
+barrier;0000112184 lift_gate
+barrier;0000046779 stile
+barrier;0000046255 cycle_barrier
+barrier;0000038597 entrance
+barrier;0000027579 block
+barrier;0000023074 toll_booth
+barrier;0000016782 cattle_grid
+barrier;0000016154 kissing_gate
+barrier;0000003182 turnstile
+barrier;0000003160 fence
+barrier;0000002701 border_control
+barrier;0000002536 sally_port
+barrier;0000002504 chain
+barrier;0000002470 door
+barrier;0000002089 swing_gate
+barrier;0000001912 bump_gate
+barrier;0000001856 yes
+barrier;0000001683 hampshire_gate
+barrier;0000000445 wall
+barrier;0000000440 bus_trap
+barrier;0000000435 ditch
+barrier;0000000420 debris
+barrier;0000000381 log
+barrier;0000000336 chicane
+barrier;0000000316 kerb
+barrier;0000000270 sump_buster
+barrier;0000000268 obstacle
+barrier;0000000223 no
+barrier;0000000213 horse_stile
+barrier;0000000210 full-height_turnstile
+barrier;0000000176 windfall
+barrier;0000000168 spikes
+barrier;0000000168 checkpoint
+barrier;0000000166 hedge
+barrier;0000000164 footgate
+barrier;0000000141 tree
+barrier;0000000133 guard_rail
+barrier;0000000129 bar
+barrier;0000000124 fallen_tree
+barrier;0000000118 jersey_barrier
+barrier;0000000114 motorcycle_barrier
+barrier;0000000114 barrier
+barrier;0000000108 rope
+barrier;0000000095 stone
+barrier;0000000069 traffic_crossing_pole
+
+
+access;0000078544 private
+access;0000014933 yes public
+access;0000014456 no
+access;0000008670 permissive
+access;0000006316 destination customers
+access;0000000973 agricultural forestry
+access;0000000942 designated official
+
+foot;0000272169 yes
+foot;0000036271 no
+foot;0000001118 designated official
+foot;0000000960 private
+foot;0000000833 permissive
+foot;0000000127 destination
+
+bicycle;0000267569 yes
+bicycle;0000067796 no
+bicycle;0000004075 designated official
+bicycle;0000002596 dismount
+bicycle;0000000498 permissive
+bicycle;0000000359 private
+bicycle;0000000075 destination
+
+motorcar;0000038901 yes
+motorcar;0000009323 no
+motorcar;0000000895 private
+motorcar;0000000216 destination
+motorcar;0000000214 permissive
+motorcar;0000000093 agricultural forestry
+motorcar;0000000084 designated official
+
+motor_vehicle;0000000066 yes
+motor_vehicle;0000000001 permissive
+motor_vehicle;0000000000 designated official
+motor_vehicle;0000000030 destination
+motor_vehicle;0000000073 agricultural forestry
+motor_vehicle;0000000136 private
+motor_vehicle;0000000469 no
+
+motorcycle;0000028697 yes
+motorcycle;0000007061 no
+motorcycle;0000000243 private
+motorcycle;0000000237 designated
+motorcycle;0000000117 destination
+motorcycle;0000000080 permissive
+motorcycle;0000000029 agricultural forestry
+
+vehicle;0000002176 no
+vehicle;0000000576 yes
+vehicle;0000000556 private
+vehicle;0000000262 destination
+vehicle;0000000138 agricultural forestry
+vehicle;0000000105 permissive
+vehicle;0000000003 designated official
+
+horse;0000021837 yes
+horse;0000010811 no
+horse;0000000105 private
+horse;0000000065 permissive
+horse;0000000053 designated official
+horse;0000000009 critical
+horse;0000000007 destination
+
+wheelchair;0000203478 yes true
+wheelchair;0000100082 no false
+wheelchair;0000080430 limited
+wheelchair;0000002769 designated official
+wheelchair;0000000005 private
+wheelchair;0000000005 permissive
+wheelchair;0000000139 bad
+wheelchair;0000000031 half
+wheelchair;0000000005 partial
+
+hgv;0000001141 no
+hgv;0000000359 yes true
+hgv;0000000111 destination
+hgv;0000000108 designated official
+hgv;0000000065 private
+hgv;0000000053 delivery
+hgv;0000000016 agricultural forestry
+hgv;0000000010 permissive
+
+crossing;0000251032 uncontrolled
+crossing;0000200387 traffic_signals
+crossing;0000029717 unmarked
+crossing;0000022119 island
+crossing;0000006981 zebra
+crossing;0000003897 no
+crossing;0000002166 yes
+
+railway;0000312710 level_crossing
+railway;0000078746 station
+railway;0000067876 buffer_stop
+railway;0000056184 switch
+railway;0000049600 crossing
+railway;0000037871 tram_stop
+railway;0000024038 halt
+railway;0000014285 subway_entrance
+railway;0000010890 signal
+
+waterway;0000004698 weir
+waterway;0000001647 lock_gate
+waterway;0000000425 waterfall
+waterway;0000000337 take_right_side
+waterway;0000000332 take_left_side
+waterway;0000000219 milestone
+waterway;0000000187 depth
+waterway;0000000170 lock
+
+noexit;0000195286 yes
+
+entrance;0000301732 yes
+entrance;0000159853 main
+entrance;0000025621 staircase
+entrance;0000006666 home
+entrance;0000005428 service
+entrance;0000001853 emergency
+entrance;0000001144 exit
+entrance;0000000953 residence
+entrance;0000000620 garage
+entrance;0000000558 entrance
+entrance;0000000504 main_entrance
+entrance;0000000439 secondary_entrance
+entrance;0000000285 shop
+entrance;0000000258 private
+
+traffic_calming;0000045987 bump bump;choker
+traffic_calming;0000040022 hump hump;choker
+traffic_calming;0000012499 table table;choker
+traffic_calming;0000006808 yes *
+traffic_calming;0000005754 cushion cushion;choker
+traffic_calming;0000005466 choker choker;cushion choker;hump choker;table choker;bump
+traffic_calming;0000005305 island
+traffic_calming;0000004686 chicane
+traffic_calming;0000004032 rumble_strip
+traffic_calming;0000000847 speed_bump
+traffic_calming;0000000186 dip
+
+ford;0000037927 yes
+ford;0000000310 stepping_stones
+
+direction;0000274642 forward
+direction;0000249637 backward
+direction;0000021634 both
+
+traffic_signals:direction;0000062645 forward
+traffic_signals:direction;0000033961 backward
+traffic_signals:direction;0000007309 both

--- a/misc/scripts/mapcreation/readme_database.md
+++ b/misc/scripts/mapcreation/readme_database.md
@@ -1,0 +1,51 @@
+Import new tags for noise, green and water feature
+
+
+- A PostgreSQL and a osm2pgsql installation is needed
+  see https://www.postgresql.org/
+  and https://osm2pgsql.org/
+
+- and a jdbc driver
+  see https://jdbc.postgresql.org/download/
+
+
+- prepare database
+
+```
+# postgres createdb --encoding=UTF8  -U postgres osm
+
+# postgres psql  -U postgres osm --command='CREATE EXTENSION postgis;'
+```
+
+- import to database and create
+
+```
+# osm2pgsql  -c -s -d osm -U postgres -W -H localhost -P 5432 -O flex  -S brouter_cfg.lua /path/to/file.pbf
+```
+
+
+- generate new tags inside the database
+
+```
+# psql -d osm -U postgres  -H localhost -P 5432  -f brouter.sql
+```
+
+- prepare generation of pbf
+
+  - when using database and new tagging an other lookups.dat is needed, use lookups_db.dat and rename
+
+  - script needs a jdbc in the classpath
+
+    `... -cp ../postgresql-42.6.0.jar;../brouter_fc.jar ...`
+
+  - script needs a call with jdbc parameter
+
+    define the database parameter
+
+    `JDBC="jdbc:postgresql://localhost/osm?user=postgres&password=xyz&ssl=false"`
+
+    call it with OsmFastCutter as last parameter (behind pbf file)
+
+    `... btools.mapcreator.OsmFastCutter ... ../planet-new.osm.pbf $(JDBC)`
+
+


### PR DESCRIPTION
This is according to discussion #486 and adds tags via database call to the way generation.
New is 
forest to find nice ways in or near forest
river to file ways along water
noise to avoid bigger streets
town to avoid bigger citys
traffic was used before but is now generated by database call

The classpath in generation needs a jdbc driver
and the OsmFastCutter a call with some database parameter
Please see readme.

There is also a new lookups.dat that contains the new tags - before the node context. This should be neutral to older versions. 
In the next generation lookups.dat (#458) I would prefer these new tags more moved up to get smaller rd5 files.

This needs also an update for the profiles to make use of the new tags. 