### PR TITLE
optimizing constant expressions in profile parsing

### DIFF
--- a/brouter-core/src/main/java/btools/router/ProfileCache.java
+++ b/brouter-core/src/main/java/btools/router/ProfileCache.java
@@ -91,8 +91,8 @@ public final class ProfileCache {
 
     meta.readMetaData(new File(profileDir, "lookups.dat"));
 
-    rc.expctxWay.parseFile(profileFile, "global");
-    rc.expctxNode.parseFile(profileFile, "global");
+    rc.expctxWay.parseFile(profileFile, "global", rc.keyValues);
+    rc.expctxNode.parseFile(profileFile, "global", rc.keyValues);
 
     rc.readGlobalConfig();
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -108,16 +108,6 @@ public final class RoutingContext {
 
   public void readGlobalConfig() {
     BExpressionContext expctxGlobal = expctxWay; // just one of them...
-
-    if (keyValues != null) {
-      // add parameter to context
-      for (Map.Entry<String, String> e : keyValues.entrySet()) {
-        float f = Float.parseFloat(e.getValue());
-        expctxWay.setVariableValue(e.getKey(), f, true);
-        expctxNode.setVariableValue(e.getKey(), f, true);
-      }
-    }
-
     setModel(expctxGlobal._modelClass);
 
     carMode = 0.f != expctxGlobal.getVariableValue("validForCars", 0.f);

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -52,6 +52,9 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
 
   private Map<String, Integer> variableNumbers = new HashMap<>();
 
+  List<BExpression> lastAssignedExpression = new ArrayList<>();
+  Map<String, String> keyValues;
+
   private float[] variableData;
 
 
@@ -768,6 +771,12 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
     }
     return foreignContext.getOutputVariableIndex(name, true);
   }
+  
+  public void parseFile(File file, String readOnlyContext, Map<String, String> keyValues) {
+    this.keyValues = keyValues;
+    parseFile(file, readOnlyContext);
+    this.keyValues = null;
+  }
 
   public void parseFile(File file, String readOnlyContext) {
     if (!file.exists()) {
@@ -785,8 +794,8 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
       }
       linenr = 1;
       minWriteIdx = variableData == null ? 0 : variableData.length;
-
       expressionList = _parseFile(file);
+      lastAssignedExpression = null;
 
       // determine the build-in variable indices
       String[] varNames = getBuildInVariableNames();
@@ -857,6 +866,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
       if (create) {
         num = variableNumbers.size();
         variableNumbers.put(name, num);
+        lastAssignedExpression.add(null);
       } else {
         return -1;
       }

--- a/brouter-expressions/src/main/java/btools/expressions/ProfileComparator.java
+++ b/brouter-expressions/src/main/java/btools/expressions/ProfileComparator.java
@@ -25,10 +25,20 @@ public final class ProfileComparator {
     BExpressionMetaData meta2 = new BExpressionMetaData();
     BExpressionContext expctx1 = nodeContext ? new BExpressionContextNode(meta1) : new BExpressionContextWay(meta1);
     BExpressionContext expctx2 = nodeContext ? new BExpressionContextNode(meta2) : new BExpressionContextWay(meta2);
+
+    // if same profiles, compare different optimization levels
+    if (profile1File.getName().equals(profile2File.getName())) {
+      expctx2.skipConstantExpressionOptimizations = true;
+    }
+
     meta1.readMetaData(lookupFile);
     meta2.readMetaData(lookupFile);
     expctx1.parseFile(profile1File, "global");
+    System.out.println("usedTags1=" +  expctx1.usedTagList());
     expctx2.parseFile(profile2File, "global");
+    System.out.println("usedTags2=" +  expctx2.usedTagList());
+
+    System.out.println("nodeContext=" + nodeContext + " nodeCount1=" + expctx1.expressionNodeCount + " nodeCount2=" + expctx2.expressionNodeCount);
 
     Random rnd = new Random();
     for (int i = 0; i < nsamples; i++) {

--- a/brouter-expressions/src/test/java/btools/expressions/ConstantOptimizerTest.java
+++ b/brouter-expressions/src/test/java/btools/expressions/ConstantOptimizerTest.java
@@ -1,0 +1,50 @@
+package btools.expressions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Random;
+import java.util.Map;
+import java.util.HashMap;
+
+public class ConstantOptimizerTest {
+  @Test
+  public void compareOptimizerModesTest() {
+
+    File lookupFile = new File(getClass().getResource("/lookups_test.dat").getPath());
+    File profileFile = new File(getClass().getResource("/profile_test.brf").getPath());
+
+    BExpressionMetaData meta1 = new BExpressionMetaData();
+    BExpressionMetaData meta2 = new BExpressionMetaData();
+    BExpressionContext expctx1 = new BExpressionContextWay(meta1);
+    BExpressionContext expctx2 = new BExpressionContextWay(meta2);
+    expctx2.skipConstantExpressionOptimizations = true;
+
+    Map<String, String> keyValue = new HashMap<>();
+    keyValue.put("global_inject1", "5");
+    keyValue.put("global_inject2", "6");
+    keyValue.put("global_inject3", "7");
+
+    meta1.readMetaData(lookupFile);
+    meta2.readMetaData(lookupFile);
+    expctx1.parseFile(profileFile, "global", keyValue);
+    expctx2.parseFile(profileFile, "global", keyValue);
+
+    float d = 0.0001f;
+    Assert.assertEquals(5f, expctx1.getVariableValue("global_inject1", 0f), d);
+    Assert.assertEquals(9f, expctx1.getVariableValue("global_inject2", 0f), d); // should be modified in 2. assign!
+    Assert.assertEquals(7f, expctx1.getVariableValue("global_inject3", 0f), d);
+    Assert.assertEquals(3f, expctx1.getVariableValue("global_inject4", 3f), d); // un-assigned
+
+    Assert.assertTrue("expected far less exporessions nodes if optimized",  expctx2.expressionNodeCount - expctx1.expressionNodeCount >= 311-144);
+
+    Random rnd = new Random(17464); // fixed seed for unit test...
+    for (int i = 0; i < 10000; i++) {
+      int[] data = expctx1.generateRandomValues(rnd);
+      expctx1.evaluate(data);
+      expctx2.evaluate(data);
+      expctx1.assertAllVariablesEqual(expctx2);
+    }
+  }
+}

--- a/brouter-expressions/src/test/resources/profile_test.brf
+++ b/brouter-expressions/src/test/resources/profile_test.brf
@@ -1,0 +1,88 @@
+---context:global   # following code refers to global config
+
+assign   global_false = false
+assign   global_true = true
+assign   global_and = and false global_true
+
+assign   global_inject1 = 5
+assign   global_inject2 = 13
+assign   global_inject2 = add global_inject2 3
+
+assign global_or = or ( or global_true global_false ) ( or global_false global_true )
+assign global_and = and ( and global_true true ) false
+
+---context:way   # following code refers to way-tags
+
+assign v = highway=primary
+assign w = surface=asphalt
+
+# test constant or/and
+assign costfactor =
+  add multiply 1 or 1 1
+  add multiply 2 or 1 0
+  add multiply 4 or 0 1
+  add multiply 8 or 0 0
+  add multiply 16 and 1 1
+  add multiply 32 and 1 1
+  add multiply 64 and 1 1
+      multiply 128 and 1 1
+  
+# test variable or
+assign turncost =
+  add multiply 1 or v 1
+  add multiply 2 or v 0
+  add multiply 4 or 0 v
+  add multiply 8 or 1 v
+      multiply 16 or v w
+
+# test variable and
+assign uphillcostfactor =
+  add multiply 1 and v 1
+  add multiply 2 and v 0
+  add multiply 4 and 0 v
+  add multiply 8 and 1 v
+      multiply 16 and v w
+
+# test add
+assign downhillcostfactor =
+  add multiply 1 add 1 1
+  add multiply 2 add 1 0
+  add multiply 4 add 0 1
+  add multiply 8 add 0 0
+  add multiply 16 add v 1
+  add multiply 32 add v 0
+  add multiply 64 add 1 v
+      multiply 128 add 0 v
+
+# test max
+assign initialcost =
+  add multiply 1 max 1 2
+  add multiply 2 max multiply 2 v 1
+  add multiply 4 max 1 multiply 2 v
+      multiply 8 max multiply 2 v v
+
+# test switch
+assign initialclassifier =
+  add multiply 1 switch 1 1 0
+  add multiply 2 switch 0 1 0
+  add multiply 4 switch 1 0 1
+  add multiply 8 switch 0 0 1
+  add multiply 16 switch v 1 1
+  add multiply 32 switch v 0 1
+  add multiply 64 switch v 1 0
+  add multiply 128 switch v 0 1
+      multiply 256 switch 1 v w
+
+# test global calcs
+assign priorityclassifier =
+  add multiply 1 global_false
+  add multiply 2 global_true
+  add multiply 4 global_and
+  add multiply 8 global_inject1
+  add multiply 16 global_inject2
+  add multiply 32 global_or
+      multiply 64 global_and
+
+---context:node  # following code refers to node tags
+
+assign initialcost = 1


### PR DESCRIPTION
This is the patch for the corresponding issue https://github.com/abrensch/brouter/issues/566

It improves the handling of constant expressions in the profile compiler

Visible effect should be that tags that are unused by configuration (e.g. estimated_forest_class) do not appear in the table if process_unused_tags=false

Tested so far via the unit tests only.

Unit tests had found a problem with injected key-values so I had to change the handling of these. An Injected value is now injected as a Number-Expression-Operand of the assign-expression that assigns the variable.

