### PR TITLE
Fixed error in single download

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
@@ -275,7 +275,8 @@ public class DownloadWorker extends Worker {
             errorCode = "Version error";
             return false;
           }
-        } else if (changed) {
+        }
+        if (changed) {
           lookupFile.delete();
           tmplookupFile.renameTo(lookupFile);
           versionChanged = changed;


### PR DESCRIPTION
The update (same major version) for the lookups.dat is not replaced, when there is only a partly tiles download. Issue #580 
