### PR TITLE
Add portrait mode to app

### DIFF
--- a/brouter-routing-app/src/main/AndroidManifest.xml
+++ b/brouter-routing-app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
             android:name=".BInstallerActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:screenOrientation="landscape" />
+            android:screenOrientation="locked" />
         <activity
             android:name=".BImportActivity"
             android:exported="true"

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -83,8 +83,6 @@ public class BInstallerActivity extends AppCompatActivity {
 
     boolean running = isDownloadRunning(DownloadWorker.class);
 
-    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-
     setContentView(R.layout.activity_binstaller);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -63,7 +63,8 @@ public class BInstallerView extends View {
     if (currentScale() * ratio >= 1) {
       mat.postScale(ratio, ratio, focusX, focusY);
       fitBounds();
-      tilesVisible = currentScale() >= SCALE_GRID_VISIBLE;
+      boolean landscape = getWidth() > getHeight();
+      tilesVisible = currentScale() >= (landscape ? SCALE_GRID_VISIBLE: SCALE_GRID_VISIBLE-1);
 
       invalidate();
     }
@@ -149,7 +150,9 @@ public class BInstallerView extends View {
 
     viewscale = Math.max(scaleX, scaleY);
 
-    mat.postScale(viewscale, viewscale);
+    mat.preScale(viewscale, viewscale, bmp.getWidth() /2f, 0);
+    setRatio(1f, bmp.getWidth() /2f, bmp.getHeight() /2f);
+
     tilesVisible = false;
   }
 
@@ -285,7 +288,7 @@ public class BInstallerView extends View {
     @Override
     public boolean onDoubleTap(MotionEvent e) {
       if (!tilesVisible) {
-        setScale(5, e.getX(), e.getY());
+        setScale(4, e.getX(), e.getY());
       } else {
         setScale(1, e.getX(), e.getY());
       }


### PR DESCRIPTION
Based on issue #551, the download view can now also be loaded in portrait mode.
This is only possible once at the beginning. Cannot switch while in use.