### PR TITLE
Find matching points in areas with longer distance between way points

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1328,7 +1328,8 @@ public class RoutingEngine extends Thread {
         }
 
         // recheck cutoff before doing expensive stuff
-        if (path.cost + path.airdistance > maxTotalCost + 100) {
+        int addDiff = 300;
+        if (path.cost + path.airdistance > maxTotalCost + addDiff) {
           path.unregisterUpTree(routingContext);
           continue;
         }
@@ -1426,7 +1427,7 @@ public class RoutingEngine extends Thread {
 
             boolean inRadius = boundary == null || boundary.isInBoundary(nextNode, bestPath.cost);
 
-            if (inRadius && (isFinalLink || bestPath.cost + bestPath.airdistance <= maxTotalCost + 100)) {
+            if (inRadius && (isFinalLink || bestPath.cost + bestPath.airdistance <= maxTotalCost + addDiff)) {
               // add only if this may beat an existing path for that link
               OsmLinkHolder dominator = link.getFirstLinkHolder(currentNode);
               while (!trafficSim && dominator != null) {

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -64,6 +64,8 @@ public class RoutingEngine extends Thread {
   protected RoutingContext routingContext;
 
   public double airDistanceCostFactor;
+  public double lastAirDistanceCostFactor;
+
   private OsmTrack guideTrack;
 
   private OsmPathElement matchPath;
@@ -933,6 +935,7 @@ public class RoutingEngine extends Thread {
 
     if (track == null) {
       for (int cfi = 0; cfi < airDistanceCostFactors.length; cfi++) {
+        if (cfi > 0) lastAirDistanceCostFactor = airDistanceCostFactors[cfi-1];
         airDistanceCostFactor = airDistanceCostFactors[cfi];
 
         if (airDistanceCostFactor < 0.) {
@@ -986,6 +989,7 @@ public class RoutingEngine extends Thread {
 
     // final run for verbose log info and detail nodes
     airDistanceCostFactor = 0.;
+    lastAirDistanceCostFactor = 0.;
     guideTrack = track;
     startTime = System.currentTimeMillis(); // reset timeout...
     try {
@@ -1328,7 +1332,7 @@ public class RoutingEngine extends Thread {
         }
 
         // recheck cutoff before doing expensive stuff
-        int addDiff = 300;
+        int addDiff = 100;
         if (path.cost + path.airdistance > maxTotalCost + addDiff) {
           path.unregisterUpTree(routingContext);
           continue;
@@ -1427,7 +1431,7 @@ public class RoutingEngine extends Thread {
 
             boolean inRadius = boundary == null || boundary.isInBoundary(nextNode, bestPath.cost);
 
-            if (inRadius && (isFinalLink || bestPath.cost + bestPath.airdistance <= maxTotalCost + addDiff)) {
+            if (inRadius && (isFinalLink || bestPath.cost + bestPath.airdistance <= (lastAirDistanceCostFactor != 0. ? maxTotalCost*lastAirDistanceCostFactor : maxTotalCost) + addDiff)) {
               // add only if this may beat an existing path for that link
               OsmLinkHolder dominator = link.getFirstLinkHolder(currentNode);
               while (!trafficSim && dominator != null) {

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
@@ -285,7 +285,13 @@ public final class NodesCache {
   public void matchWaypointsToNodes(List<MatchedWaypoint> unmatchedWaypoints, double maxDistance, OsmNodePairSet islandNodePairs) {
     waypointMatcher = new WaypointMatcherImpl(unmatchedWaypoints, maxDistance, islandNodePairs);
     for (MatchedWaypoint mwp : unmatchedWaypoints) {
-      preloadPosition(mwp.waypoint);
+      int cellsize = 12500;
+      preloadPosition(mwp.waypoint, cellsize);
+      // get a second chance
+      if (mwp.crosspoint == null) {
+        cellsize = 1000000 / 32;
+        preloadPosition(mwp.waypoint, cellsize);
+      }
     }
 
     if (first_file_access_failed) {
@@ -309,8 +315,7 @@ public final class NodesCache {
     }
   }
 
-  private void preloadPosition(OsmNode n) {
-    int d = 12500;
+  private void preloadPosition(OsmNode n, int d) {
     first_file_access_failed = false;
     first_file_access_name = null;
     loadSegmentFor(n.ilon, n.ilat);


### PR DESCRIPTION
According to issue #568 two changes for get better results on long distances around searching points.

1. Do a second round when a way point is not found to get all square around the search square
2. Add a greater difference value for a finishing check (rc.waypointCatchingRange wasn't enough)

A 3rd idea is drop for now - tile generation: add pseudo points when no points in an areas.