### PR TITLE
Fix regression in fastbike profile

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -261,8 +261,7 @@ assign costfactor
   switch    highway=cycleway                          1.3
   switch    isresidentialorliving                     switch isunpaved 10 1.2
   switch    highway=service                           switch isunpaved 10 1.2
-  switch    highway=path                              switch avoid_path 2.1 1.1
-  switch or highway=track or highway=road highway=footway
+  switch or highway=track or highway=road or highway=path highway=footway
    switch tracktype=grade1 switch isunpaved 3 1.2
    switch tracktype=grade2 switch isunpaved 10 3
    switch tracktype=grade3 10.0


### PR DESCRIPTION
https://github.com/abrensch/brouter/pull/579 broke the logic that handled `highway=path` trying to add the missing `avoid_path` logic.

Example: [http://brouter.de/brouter-web/#map=15/51.3734/7.0430/...&profile=fastbike](http://brouter.de/brouter-web/#map=15/51.3734/7.0430/standard&lonlats=7.035675,51.375211;7.049965,51.371661&profile=fastbike)

See: https://github.com/nrenner/brouter-web/issues/756

---

Both `avoid_unsafe` and `avoid_path` dysfunctional. We should either remove these options or implement them properly.