### PR TITLE
Fix fastbike options

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -155,6 +155,8 @@ assign hascycleway = not
   and ( or cycleway= cycleway=no|none ) and ( or cycleway:left= cycleway:left=no ) ( or cycleway:right= cycleway:right=no )
 
 assign trafficpenalty0 =
+  if consider_traffic then
+  (
     if highway=primary|primary_link then
     (
       if      estimated_traffic_class=4 then 0.2
@@ -179,6 +181,8 @@ assign trafficpenalty0 =
       else 0
     )
     else 0
+  )
+  else 0
 
 assign trafficpenalty =
   if consider_traffic then

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -253,8 +253,8 @@ assign costfactor
   switch or highway=tertiary highway=tertiary_link    1.0
   switch    highway=unclassified                      switch isunpaved 10 1.1
   switch    highway=pedestrian                        10
-  switch    highway=steps                             1000
-  switch    route=ferry                               5.67
+  switch    highway=steps                             switch allow_steps 1000 10000
+  switch    route=ferry                               switch allow_ferries 5.67 10000
   switch    highway=bridleway                         5
   switch    highway=cycleway                          1.3
   switch    isresidentialorliving                     switch isunpaved 10 1.2

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -22,8 +22,6 @@ assign validForBikes = true
 assign allow_steps           = true   # %allow_steps% | Set to false to disallow steps | boolean
 assign allow_ferries         = true   # %allow_ferries% | set to false to disallow ferries | boolean
 assign allow_motorways       = false  # %allow_motorways% | Set to true to allow motorways (useful in Asia / Oceania for example) | boolean
-assign ignore_cycleroutes    = false  # %ignore_cycleroutes% | Set to true for better elevation results | boolean
-assign stick_to_cycleroutes  = false  # %stick_to_cycleroutes% | Set to true to just follow cycleroutes | boolean
 
 assign consider_traffic      = false  # %consider_traffic% | Activate to avoid traffic | boolean
 assign consider_noise        = false  # %consider_noise% | Activate to prefer a low-noise route | boolean


### PR DESCRIPTION
This takes the [suggestion](https://github.com/abrensch/brouter/issues/479#issuecomment-1315848943)  from @tbsmark86 and implements both `allow_steps` and `allow_ferries` in `fastbike.brf`.

This also utilizes the new [Profile-Compiler: constant expressions optimizations](https://github.com/abrensch/brouter/issues/566).

Related with: https://github.com/abrensch/brouter/issues/561