### PR TITLE
Fix bug in exclusion of small water bodies

### DIFF
--- a/misc/scripts/mapcreation/brouter.sql
+++ b/misc/scripts/mapcreation/brouter.sql
@@ -77,7 +77,7 @@ FROM
     polygons p
 WHERE
     -- do not consider small surfaces
-    st_area (p.way) > 1000
+    st_area (st_transform (p.way, 4326)::geography) > 1000
     AND p.natural IN ('water')
     OR (p.landuse IN ('forest', 'allotments', 'flowerbed', 'orchard', 'vineyard', 'recreation_ground', 'village_green')
         OR p.leisure IN ('garden', 'park', 'nature_reserve'));
@@ -93,7 +93,7 @@ FROM
     polygons p
 WHERE
     -- do not consider small surfaces
-    st_area (p.way) > 1000
+    st_area (st_transform (p.way, 4326)::geography) > 1000
     AND p.natural IN ('water')
     OR (p.landuse IN ('forest', 'allotments', 'flowerbed', 'orchard', 'vineyard', 'recreation_ground', 'village_green')
         OR p.leisure IN ('garden', 'park', 'nature_reserve'));


### PR DESCRIPTION
This [little pond](https://www.openstreetmap.org/way/124106504) was causing `estimated_river_class=2` on the [Hackländerstraße](https://www.openstreetmap.org/way/302539343):

![estimated_river_class](https://github.com/abrensch/brouter/assets/122357328/076f875d-1165-4a0a-9aa9-3e0129776a0c)

---

It would probably also be worth discussing whether it would not make sense to raise the threshold back to something near the original value of around 8000 square meter:
https://github.com/abrensch/brouter/blob/e66468b091506833eb5890656a0ef3a538397ab2/misc/scripts/mapcreation/brouter.sql#L475