### PR TITLE
No needless dropping of 'estimated_town_class'

### DIFF
--- a/misc/scripts/mapcreation/brouter.sql
+++ b/misc/scripts/mapcreation/brouter.sql
@@ -675,15 +675,6 @@ WHERE losmid IN (
         WHERE
             forest_class NOT IN ('1'));
 
-DELETE FROM town_tags
-WHERE losmid IN (
-        SELECT
-            losmid
-        FROM
-            river_tags
-        WHERE
-            river_class NOT IN ('1'));
-
 SELECT
     count(*)
 FROM


### PR DESCRIPTION
To enable the crossing of a city along rivers, only one line of code in the profile text needs to be adjusted:
```
switch estimated_town_class= 0
```
->
```
switch or estimated_town_class= ( not estimated_river_class= )  0
```

---

This significantly improves the usability of the `estimated_town_class` pseudo tag.