### PR TITLE
Add "DIVIDE" command and new "maxslope" and "maxslopecost" parameters

### DIFF
--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -121,10 +121,10 @@ final class StdPath extends OsmPath {
       ehbd -= reduce;
       int elevationCost = 0;
       if (downhillcostdiv > 0) {
-        elevationCost = Math.min(reduce, dist * rc.elevationbufferreduce) / downhillcostdiv;
+        elevationCost += Math.min(reduce, dist * rc.elevationbufferreduce) / downhillcostdiv;
       }
       if (downhillmaxbuffercostdiv > 0) {
-        elevationCost = Math.max(0, reduce - dist * rc.elevationbufferreduce) / downhillmaxbuffercostdiv;
+        elevationCost += Math.max(0, reduce - dist * rc.elevationbufferreduce) / downhillmaxbuffercostdiv;
       }
       if (elevationCost > 0) {
         sectionCost += elevationCost;
@@ -153,10 +153,10 @@ final class StdPath extends OsmPath {
       ehbu -= reduce;
       int elevationCost = 0;
       if (uphillcostdiv > 0) {
-        elevationCost = Math.min(reduce, dist * rc.elevationbufferreduce) / uphillcostdiv;
+        elevationCost += Math.min(reduce, dist * rc.elevationbufferreduce) / uphillcostdiv;
       }
       if (uphillmaxbuffercostdiv > 0) {
-        elevationCost = Math.max(0, reduce - dist * rc.elevationbufferreduce) / uphillmaxbuffercostdiv;
+        elevationCost += Math.max(0, reduce - dist * rc.elevationbufferreduce) / uphillmaxbuffercostdiv;
       }
       if (elevationCost > 0) {
         sectionCost += elevationCost;

--- a/brouter-core/src/main/java/btools/router/StdPath.java
+++ b/brouter-core/src/main/java/btools/router/StdPath.java
@@ -17,9 +17,7 @@ final class StdPath extends OsmPath {
   private float elevation_buffer; // just another elevation buffer (for travel time)
 
   private int uphillcostdiv;
-  private int uphillmaxbuffercostdiv;
   private int downhillcostdiv;
-  private int downhillmaxbuffercostdiv;
 
   // Gravitational constant, g
   private static final double GRAVITY = 9.81;  // in meters per second^(-2)
@@ -41,9 +39,7 @@ final class StdPath extends OsmPath {
     totalTime = 0.f;
     totalEnergy = 0.f;
     uphillcostdiv = 0;
-    uphillmaxbuffercostdiv = 0;
     downhillcostdiv = 0;
-    downhillmaxbuffercostdiv = 0;
     elevation_buffer = 0.f;
   }
 
@@ -53,6 +49,8 @@ final class StdPath extends OsmPath {
     float turncostbase = rc.expctxWay.getTurncost();
     float uphillcutoff = rc.expctxWay.getUphillcutoff() * 10000;
     float downhillcutoff = rc.expctxWay.getDownhillcutoff() * 10000;
+    float uphillmaxslope = rc.expctxWay.getUphillmaxslope() * 10000;
+    float downhillmaxslope = rc.expctxWay.getDownhillmaxslope() * 10000;
     float cfup = rc.expctxWay.getUphillCostfactor();
     float cfdown = rc.expctxWay.getDownhillCostfactor();
     float cf = rc.expctxWay.getCostfactor();
@@ -64,12 +62,12 @@ final class StdPath extends OsmPath {
       downhillcostdiv = 1000000 / downhillcostdiv;
     }
 
-    downhillmaxbuffercostdiv = (int) rc.expctxWay.getDownhillmaxbuffercost();
-    if (downhillmaxbuffercostdiv > 0) {
-      downhillmaxbuffercostdiv = 1000000 / downhillmaxbuffercostdiv;
+    int downhillmaxslopecostdiv = (int) rc.expctxWay.getDownhillmaxslopecost();
+    if (downhillmaxslopecostdiv > 0) {
+      downhillmaxslopecostdiv = 1000000 / downhillmaxslopecostdiv;
     } else {
       // if not given, use legacy behavior
-      downhillmaxbuffercostdiv = downhillcostdiv;
+      downhillmaxslopecostdiv = downhillcostdiv;
     }
 
     uphillcostdiv = (int) rc.expctxWay.getUphillcost();
@@ -77,12 +75,12 @@ final class StdPath extends OsmPath {
       uphillcostdiv = 1000000 / uphillcostdiv;
     }
 
-    uphillmaxbuffercostdiv = (int) rc.expctxWay.getUphillmaxbuffercost();
-    if (uphillmaxbuffercostdiv > 0) {
-      uphillmaxbuffercostdiv = 1000000 / uphillmaxbuffercostdiv;
+    int uphillmaxslopecostdiv = (int) rc.expctxWay.getUphillmaxslopecost();
+    if (uphillmaxslopecostdiv > 0) {
+      uphillmaxslopecostdiv = 1000000 / uphillmaxslopecostdiv;
     } else {
       // if not given, use legacy behavior
-      uphillmaxbuffercostdiv = uphillcostdiv;
+      uphillmaxslopecostdiv = uphillcostdiv;
     }
 
     int dist = (int) distance; // legacy arithmetics needs int
@@ -119,12 +117,12 @@ final class StdPath extends OsmPath {
         reduce = excess;
       }
       ehbd -= reduce;
-      int elevationCost = 0;
+      float elevationCost = 0.f;
       if (downhillcostdiv > 0) {
-        elevationCost += Math.min(reduce, dist * rc.elevationbufferreduce) / downhillcostdiv;
+        elevationCost += Math.min(reduce, dist * downhillmaxslope) / downhillcostdiv;
       }
-      if (downhillmaxbuffercostdiv > 0) {
-        elevationCost += Math.max(0, reduce - dist * rc.elevationbufferreduce) / downhillmaxbuffercostdiv;
+      if (downhillmaxslopecostdiv > 0) {
+        elevationCost += Math.max(0, reduce - dist * downhillmaxslope) / downhillmaxslopecostdiv;
       }
       if (elevationCost > 0) {
         sectionCost += elevationCost;
@@ -151,12 +149,12 @@ final class StdPath extends OsmPath {
         reduce = excess;
       }
       ehbu -= reduce;
-      int elevationCost = 0;
+      float elevationCost = 0.f;
       if (uphillcostdiv > 0) {
-        elevationCost += Math.min(reduce, dist * rc.elevationbufferreduce) / uphillcostdiv;
+        elevationCost += Math.min(reduce, dist * uphillmaxslope) / uphillcostdiv;
       }
-      if (uphillmaxbuffercostdiv > 0) {
-        elevationCost += Math.max(0, reduce - dist * rc.elevationbufferreduce) / uphillmaxbuffercostdiv;
+      if (uphillmaxslopecostdiv > 0) {
+        elevationCost += Math.max(0, reduce - dist * uphillmaxslope) / uphillmaxslopecostdiv;
       }
       if (elevationCost > 0) {
         sectionCost += elevationCost;

--- a/brouter-expressions/src/main/java/btools/expressions/BExpression.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpression.java
@@ -9,7 +9,7 @@ final class BExpression {
 
   private static final int ADD_EXP = 20;
   private static final int MULTIPLY_EXP = 21;
-  private static final int DIV_EXP = 22;
+  private static final int DIVIDE_EXP = 22;
   private static final int MAX_EXP = 23;
   private static final int EQUAL_EXP = 24;
   private static final int GREATER_EXP = 25;
@@ -145,8 +145,8 @@ final class BExpression {
         exp.typ = AND_EXP;
       } else if ("multiply".equals(operator)) {
         exp.typ = MULTIPLY_EXP;
-      } else if ("div".equals(operator)) {
-        exp.typ = DIV_EXP;
+      } else if ("divide".equals(operator)) {
+        exp.typ = DIVIDE_EXP;
       } else if ("add".equals(operator)) {
         exp.typ = ADD_EXP;
       } else if ("max".equals(operator)) {
@@ -280,8 +280,8 @@ final class BExpression {
         return op1.evaluate(ctx) - op2.evaluate(ctx);
       case MULTIPLY_EXP:
         return op1.evaluate(ctx) * op2.evaluate(ctx);
-      case DIV_EXP:
-        return div(op1.evaluate(ctx), op2.evaluate(ctx));
+      case DIVIDE_EXP:
+        return divide(op1.evaluate(ctx), op2.evaluate(ctx));
       case MAX_EXP:
         return max(op1.evaluate(ctx), op2.evaluate(ctx));
       case MIN_EXP:
@@ -365,7 +365,7 @@ final class BExpression {
     return v1 < v2 ? v1 : v2;
   }
 
-  private float div(float v1, float v2) {
+  private float divide(float v1, float v2) {
     if (v2 == 0f) throw new IllegalArgumentException("div by zero");
     return v1 / v2;
   }

--- a/brouter-expressions/src/main/java/btools/expressions/BExpression.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpression.java
@@ -9,14 +9,15 @@ final class BExpression {
 
   private static final int ADD_EXP = 20;
   private static final int MULTIPLY_EXP = 21;
-  private static final int MAX_EXP = 22;
-  private static final int EQUAL_EXP = 23;
-  private static final int GREATER_EXP = 24;
-  private static final int MIN_EXP = 25;
+  private static final int DIV_EXP = 22;
+  private static final int MAX_EXP = 23;
+  private static final int EQUAL_EXP = 24;
+  private static final int GREATER_EXP = 25;
+  private static final int MIN_EXP = 26;
 
-  private static final int SUB_EXP = 26;
-  private static final int LESSER_EXP = 27;
-  private static final int XOR_EXP = 28;
+  private static final int SUB_EXP = 27;
+  private static final int LESSER_EXP = 28;
+  private static final int XOR_EXP = 29;
 
   private static final int SWITCH_EXP = 30;
   private static final int ASSIGN_EXP = 31;
@@ -144,6 +145,8 @@ final class BExpression {
         exp.typ = AND_EXP;
       } else if ("multiply".equals(operator)) {
         exp.typ = MULTIPLY_EXP;
+      } else if ("div".equals(operator)) {
+        exp.typ = DIV_EXP;
       } else if ("add".equals(operator)) {
         exp.typ = ADD_EXP;
       } else if ("max".equals(operator)) {
@@ -277,6 +280,8 @@ final class BExpression {
         return op1.evaluate(ctx) - op2.evaluate(ctx);
       case MULTIPLY_EXP:
         return op1.evaluate(ctx) * op2.evaluate(ctx);
+      case DIV_EXP:
+        return op1.evaluate(ctx) / op2.evaluate(ctx);
       case MAX_EXP:
         return max(op1.evaluate(ctx), op2.evaluate(ctx));
       case MIN_EXP:

--- a/brouter-expressions/src/main/java/btools/expressions/BExpression.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpression.java
@@ -281,7 +281,7 @@ final class BExpression {
       case MULTIPLY_EXP:
         return op1.evaluate(ctx) * op2.evaluate(ctx);
       case DIV_EXP:
-        return op1.evaluate(ctx) / op2.evaluate(ctx);
+        return div(op1.evaluate(ctx), op2.evaluate(ctx));
       case MAX_EXP:
         return max(op1.evaluate(ctx), op2.evaluate(ctx));
       case MIN_EXP:
@@ -363,6 +363,11 @@ final class BExpression {
 
   private float min(float v1, float v2) {
     return v1 < v2 ? v1 : v2;
+  }
+
+  private float div(float v1, float v2) {
+    if (v2 == 0f) throw new IllegalArgumentException("div by zero");
+    return v1 / v2;
   }
 
   @Override

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
@@ -12,7 +12,7 @@ public final class BExpressionContextWay extends BExpressionContext implements T
   private boolean decodeForbidden = true;
 
   private static String[] buildInVariables =
-    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff", "uphillmaxbuffercost", "downhillmaxbuffercost"};
+    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff", "uphillmaxslope", "downhillmaxslope", "uphillmaxslopecost", "downhillmaxslopecost"};
 
   protected String[] getBuildInVariableNames() {
     return buildInVariables;
@@ -82,12 +82,20 @@ public final class BExpressionContextWay extends BExpressionContext implements T
     return getBuildInVariable(15);
   }
 
-  public float getUphillmaxbuffercost() {
+  public float getUphillmaxslope() {
     return getBuildInVariable(16);
   }
 
-  public float getDownhillmaxbuffercost() {
+  public float getDownhillmaxslope() {
     return getBuildInVariable(17);
+  }
+
+  public float getUphillmaxslopecost() {
+    return getBuildInVariable(18);
+  }
+
+  public float getDownhillmaxslopecost() {
+    return getBuildInVariable(19);
   }
 
   public BExpressionContextWay(BExpressionMetaData meta) {

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
@@ -12,7 +12,7 @@ public final class BExpressionContextWay extends BExpressionContext implements T
   private boolean decodeForbidden = true;
 
   private static String[] buildInVariables =
-    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff"};
+    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff", "uphillmaxbuffercost", "downhillmaxbuffercost"};
 
   protected String[] getBuildInVariableNames() {
     return buildInVariables;
@@ -80,6 +80,14 @@ public final class BExpressionContextWay extends BExpressionContext implements T
 
   public float getDownhillcutoff() {
     return getBuildInVariable(15);
+  }
+
+  public float getUphillmaxbuffercost() {
+    return getBuildInVariable(16);
+  }
+
+  public float getDownhillmaxbuffercost() {
+    return getBuildInVariable(17);
   }
 
   public BExpressionContextWay(BExpressionMetaData meta) {

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -72,14 +72,16 @@ Some variable names are pre-defined and accessed by the routing engine:
 
 - for the global section these are:
 
-  - 7 elevation configuration parameters:
+  - 11 elevation configuration parameters:
 
     - `downhillcost`
     - `downhillcutoff`
-    - `downhillmaxbuffercost`
+    - `downhillmaxslope`
+    - `downhillmaxslopecost`
     - `uphillcost`
     - `uphillcutoff`
-    - `uphillmaxbuffercost`
+    - `uphillmaxslope`
+    - `uphillmaxslopecost`
     - `elevationpenaltybuffer`
     - `elevationmaxbuffer`
     - `elevationbufferreduce`
@@ -279,33 +281,35 @@ it climbed only 10 m on those 500 m, all 10 m would be *swallowed* by cutoff,
 together with up to 5 m from the buffer, if there were any.
 
 When elevation does not fit the buffer of size `elevationmaxbuffer`, it is
-converted by `uphillcost`/`downhillcost` ratio to Elevationcost portion of Equivalentlength.
-`uphillcostfactors`/`downhillcostfactors` are used, if defined, otherwise costfactor is used.
+converted by `up/downhill[maxslope]cost` ratio to Elevationcost portion of Equivalentlength.
+`up/downhillcostfactors` are used, if defined, otherwise `costfactor` is used.
 
 - `elevationpenaltybuffer` - default 5(m).
 
   The variable value is used for 2 purposes
 
   - with `buffer content > elevationpenaltybuffer`, it starts partially convert
-    the buffered elevation to ElevationCost by `uphillcost`/`downhillcost`
+    the buffered elevation to ElevationCost by `up/downhillcost`
 
   - with `elevation taken = MIN (buffer content - elevationpenaltybuffer, WayLength[km] * elevationbufferreduce*10`
-    Up/downhillcost factor takes place instead of costfactor at the percentage
+    The `up/downhillcostfactor` takes place instead of `costfactor` at the percentage
     of how much is `WayLength[km] * elevationbufferreduce*10` is saturated by
     the buffer content above elevationpenaltybuffer.
 
 - `elevationmaxbuffer` - default 10(m)
 
   is the size of the buffer, above which all elevation is converted to
-  Elevationcost by `uphillmaxbuffercost`/`downhillmaxbuffercost` parameter or, if those are not defined, by `uphillcost`/`downhillcost` parameter.
-  Additionally, when reaching `elevationmaxbuffer`, `uphillcostfactor`/ `downhillcostfactor` fully replaces `costfactor` in way cost calculation if those cost factors are defined.
+  Elevationcost by `up/downhill[maxslope]cost` ratio, and - if defined -
+  `up/downhillcostfactor` fully replaces `costfactor` in way cost calculation.
 
 - `elevationbufferreduce` - default 0(slope%)
 
   is rate of conversion of the buffer content above elevationpenaltybuffer to
   ElevationCost. For a way of length L, the amount of converted elevation is
   L[km] * elevationbufferreduce[%] * 10. The elevation to Elevationcost
-  conversion ratio is given by Up/downhillcost.
+  conversion ratio is given by `up/downhill[maxslope]cost`.
+
+Whether `up/downhillmaxslope` or `up/downhillmaxslopecost` is used as conversion ratio depends on whether the elevation was accumulated below or above the slope thresholds set in `up/downhillmaxslope`.
 
 Example:   Let's examine steady slopes with `elevationmaxbuffer=10`,
 `elevationpenaltybuffer=5`, `elevationbufferreduce=0.5`, `cutoffs=1.5`,
@@ -316,7 +320,7 @@ All slopes within 0 .. 1.5% are swallowed by the cutoff.
 - For slope 1.75%, there will remain 0.25%.
 
   That saturates the elevationbufferreduce 0.5% by 50%. That gives Way cost to
-  be calculated 50% from costfactor and 50% from Up/downhillcostfactor.
+  be calculated 50% from `costfactor` and 50% from `up/downhillcostfactor`.
   Additionally, 0.25% gives 2.5m per 1km, converted to 2.5*60 = 150m of
   Elevationcost.
 

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -309,7 +309,9 @@ converted by `up/downhill[maxslope]cost` ratio to Elevationcost portion of Equiv
   L[km] * elevationbufferreduce[%] * 10. The elevation to Elevationcost
   conversion ratio is given by `up/downhill[maxslope]cost`.
 
-Whether `up/downhillmaxslope` or `up/downhillmaxslopecost` is used as conversion ratio depends on whether the elevation was accumulated below or above the slope thresholds set in `up/downhillmaxslope`.
+Whether `up/downhillmaxslope` or `up/downhillmaxslopecost` is used as conversion
+ratio depends on whether the elevation was accumulated below or above the slope
+threshold values defined in `up/downhillmaxslope`.
 
 Example:   Let's examine steady slopes with `elevationmaxbuffer=10`,
 `elevationpenaltybuffer=5`, `elevationbufferreduce=0.5`, `cutoffs=1.5`,

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -76,8 +76,10 @@ Some variable names are pre-defined and accessed by the routing engine:
 
     - `downhillcost`
     - `downhillcutoff`
+    - `downhillmaxbuffercost`
     - `uphillcost`
     - `uphillcutoff`
+    - `uphillmaxbuffercost`
     - `elevationpenaltybuffer`
     - `elevationmaxbuffer`
     - `elevationbufferreduce`
@@ -172,6 +174,7 @@ All expressions have one of the following basic forms:
   - `and      <boolean expression 1> <boolean expression 2>`
   - `xor      <boolean expression 1> <boolean expression 2>`
   - `multiply <numeric expression 1> <numeric expression 2>`
+  - `div      <numeric expression 1> <numeric expression 2>`
   - `add      <numeric expression 1> <numeric expression 2>`
   - `sub      <numeric expression 1> <numeric expression 2>`
   - `max      <numeric expression 1> <numeric expression 2>`
@@ -276,15 +279,15 @@ it climbed only 10 m on those 500 m, all 10 m would be *swallowed* by cutoff,
 together with up to 5 m from the buffer, if there were any.
 
 When elevation does not fit the buffer of size `elevationmaxbuffer`, it is
-converted by up/downhillcost ratio to Elevationcost portion of Equivalentlength.
-Up/downhillcostfactors are used, if defined, otherwise costfactor is used.
+converted by `uphillcost`/`downhillcost` ratio to Elevationcost portion of Equivalentlength.
+`uphillcostfactors`/`downhillcostfactors` are used, if defined, otherwise costfactor is used.
 
 - `elevationpenaltybuffer` - default 5(m).
 
   The variable value is used for 2 purposes
 
   - with `buffer content > elevationpenaltybuffer`, it starts partially convert
-    the buffered elevation to ElevationCost by Up/downhillcost
+    the buffered elevation to ElevationCost by `uphillcost`/`downhillcost`
 
   - with `elevation taken = MIN (buffer content - elevationpenaltybuffer, WayLength[km] * elevationbufferreduce*10`
     Up/downhillcost factor takes place instead of costfactor at the percentage
@@ -294,8 +297,8 @@ Up/downhillcostfactors are used, if defined, otherwise costfactor is used.
 - `elevationmaxbuffer` - default 10(m)
 
   is the size of the buffer, above which all elevation is converted to
-  Elevationcost by Up/Downhillcost ratio, and - if defined -
-  Up/downhillcostfactor fully replaces costfactor in way cost calculation.
+  Elevationcost by `uphillmaxbuffercost`/`downhillmaxbuffercost` parameter or, if those are not defined, by `uphillcost`/`downhillcost` parameter.
+  Additionally, when reaching `elevationmaxbuffer`, `uphillcostfactor`/ `downhillcostfactor` fully replaces `costfactor` in way cost calculation if those cost factors are defined.
 
 - `elevationbufferreduce` - default 0(slope%)
 


### PR DESCRIPTION
To extend the functionality an additional "DIV" command and two additional parameters are defined. An example instance can be tested under [Brouter-Web Dev Instance](https://brouter.densborn.ddnss.de/) with [fastbike-longdistance.brf](https://github.com/simdens/brouter_profile) profile. 

### Reasoning
"DIV" command:
The profile can compute constants within the global context based on physical values like systemweight or nominal power.

"downhillmaxbuffercost" and "uphillmaxbuffercost"
These parameters allow to increase the uphill or downhill penalty if the buffer exceeds the maximum buffer value. This makes it possible to increase the penalty for very step hills. i.e. for uphills which are too steep for the given gear ratio. See the [fastbike-longdistance.brf](https://github.com/simdens/brouter_profile) profile for reference.