### PR TITLE
BRouter translations

### DIFF
--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -20,8 +20,6 @@ android {
         minSdkVersion 14
         targetSdkVersion 33
 
-        resConfigs "en"
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerActivity.java
@@ -171,7 +171,7 @@ public class BInstallerActivity extends AppCompatActivity {
       }
       mButtonDownload.setText(getString(R.string.action_download, getSegmentsPlural(selectedTilesDownload.size())));
       mButtonDownload.setEnabled(true);
-      mSummaryInfo.setText(getString(R.string.summary_segments, Formatter.formatFileSize(this, tileSize), Formatter.formatFileSize(this, getAvailableSpace(mBaseDir.getAbsolutePath()))));
+      mSummaryInfo.setText(String.format(getString(R.string.summary_segments), Formatter.formatFileSize(this, tileSize), Formatter.formatFileSize(this, getAvailableSpace(mBaseDir.getAbsolutePath()))));
     } else if (selectedTilesUpdate.size() > 0) {
       mButtonDownload.setText(getString(R.string.action_update, getSegmentsPlural(selectedTilesUpdate.size())));
       mButtonDownload.setEnabled(true);

--- a/brouter-routing-app/src/main/res/values-ar/strings.xml
+++ b/brouter-routing-app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d قطعة</item>
+        <item quantity="other">%d قطع</item>
+    </plurals>
+    <string name="cancel_download">إلغاء التنزيل</string>
+    <string name="import_profile">استيراد ملف تعريف</string>
+    <string name="action_download">تنزيل %s</string>
+    <string name="action_delete">حذف %s</string>
+    <string name="action_update">تحديث %s</string>
+    <string name="action_select">حدد القطع</string>
+    <string name="action_cancel">إيقاف التنزيل</string>
+    <string name="summary_segments">الحجم=%1$s\nالحجم المتوفر=%2$s</string>
+    <string name="notification_title">تحميل القطع</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-ca/strings.xml
+++ b/brouter-routing-app/src/main/res/values-ca/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segment</item>
+        <item quantity="other">%d segments</item>
+    </plurals>
+    <string name="cancel_download">Cancel·lar descàrrega</string>
+    <string name="import_profile">Importar perfil</string>
+    <string name="action_download">Descàrrega %s</string>
+    <string name="action_delete">Eliminar %s</string>
+    <string name="action_update">Actualitzar %s</string>
+    <string name="action_select">Seleccionar segments</string>
+    <string name="action_cancel">Aturar Descàrrega</string>
+    <string name="summary_segments">Espai=%1$s\nLliure=%2$s</string>
+    <string name="notification_title">Descarregar segments</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-de/strings.xml
+++ b/brouter-routing-app/src/main/res/values-de/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d Segment</item>
+        <item quantity="other">%d Segmente</item>
+    </plurals>
+    <string name="cancel_download">Download abbrechen</string>
+    <string name="import_profile">Profil importieren</string>
+    <string name="action_download">%s downloaden</string>
+    <string name="action_delete">%s löschen</string>
+    <string name="action_update">%s aktualisieren</string>
+    <string name="action_select">Segmente auswählen</string>
+    <string name="action_cancel">Download stoppen</string>
+    <string name="summary_segments">Größe=%1$s\nFrei=%2$s</string>
+    <string name="notification_title">Segmente herunterladen</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-el/strings.xml
+++ b/brouter-routing-app/src/main/res/values-el/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d τμήμα</item>
+        <item quantity="other">%d τμήματα</item>
+    </plurals>
+    <string name="cancel_download">Ακύρωση λήψης</string>
+    <string name="import_profile">Εισαγωγή προφίλ</string>
+    <string name="action_download">Λήψη %s</string>
+    <string name="action_delete">Διαγραφή %s</string>
+    <string name="action_update">Ενημέρωση %s</string>
+    <string name="action_select">Επιλογή τμημάτων</string>
+    <string name="action_cancel">Διακοπή λήψης</string>
+    <string name="summary_segments">Μέγεθος=%1$s\nΕλεύθερο=%2$s</string>
+    <string name="notification_title">Λήψη τμημάτων</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-es/strings.xml
+++ b/brouter-routing-app/src/main/res/values-es/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segmento</item>
+        <item quantity="other">%d segmentos</item>
+    </plurals>
+    <string name="cancel_download">Cancelar descarga</string>
+    <string name="import_profile">Importar perfil</string>
+    <string name="action_download">Descargar %s</string>
+    <string name="action_delete">Eliminar %s</string>
+    <string name="action_update">Actualizar %s</string>
+    <string name="action_select">Seleccionar segmentos</string>
+    <string name="action_cancel">Detener descarga</string>
+    <string name="summary_segments">Tamaño=%1$s\nGratis=%2$s</string>
+    <string name="notification_title">Descargar segmentos</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-fr/strings.xml
+++ b/brouter-routing-app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segment</item>
+        <item quantity="other">%d segments</item>
+    </plurals>
+    <string name="cancel_download">Annuler le téléchargement</string>
+    <string name="import_profile">Importer le profil</string>
+    <string name="action_download">Télécharger %s</string>
+    <string name="action_delete">Supprimer %s</string>
+    <string name="action_update">Mettre à jour %s</string>
+    <string name="action_select">Sélectionner les segments</string>
+    <string name="action_cancel">Arrêter le téléchargement</string>
+    <string name="summary_segments">Taille=%1$s\nGratuit=%2$s</string>
+    <string name="notification_title">Télécharger les segments</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-it/strings.xml
+++ b/brouter-routing-app/src/main/res/values-it/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segmento</item>
+        <item quantity="other">%d segmenti</item>
+    </plurals>
+    <string name="cancel_download">Annulla download</string>
+    <string name="import_profile">Importa profilo</string>
+    <string name="action_download">Scarica %s</string>
+    <string name="action_delete">Elimina %s</string>
+    <string name="action_update">Aggiorna %s</string>
+    <string name="action_select">Seleziona segmenti</string>
+    <string name="action_cancel">Interrompi download</string>
+    <string name="summary_segments">Taglia=%1$s\nGratis=%2$s</string>
+    <string name="notification_title">Scarica segmenti</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-nl/strings.xml
+++ b/brouter-routing-app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segment</item>
+        <item quantity="other">%d segmenten</item>
+    </plurals>
+    <string name="cancel_download">Download annuleren</string>
+    <string name="import_profile">Profiel importeren</string>
+    <string name="action_download">Downloaden %s</string>
+    <string name="action_delete">Verwijderen %s</string>
+    <string name="action_update">Bijwerken %s</string>
+    <string name="action_select">Segmenten selecteren</string>
+    <string name="action_cancel">Download stoppen</string>
+    <string name="summary_segments">Grootte=%1$s\nGratis=%2$s</string>
+    <string name="notification_title">Segmenten downloaden</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values-pl/strings.xml
+++ b/brouter-routing-app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
+        <item quantity="one">%d segment</item>
+        <item quantity="other">%d segmenty/ów</item>
+    </plurals>
+    <string name="cancel_download">Anuluj pobieranie</string>
+    <string name="import_profile">Importuj profil</string>
+    <string name="action_download">Pobierz %s</string>
+    <string name="action_delete">Usuń %s</string>
+    <string name="action_update">Zaktualizuj %s</string>
+    <string name="action_select">Wybierz segmenty</string>
+    <string name="action_cancel">Zatrzymaj pobieranie</string>
+    <string name="summary_segments">Rozmiar=%1$s\nDostępne=%2$s</string>
+    <string name="notification_title">Pobieranie segmentów</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values/donottranslate-strings.xml
+++ b/brouter-routing-app/src/main/res/values/donottranslate-strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">BRouter</string>
+    <string name="profile_filename_example">filename.brf</string>
+    <string name="notification_channel_id">brouter_download</string>
+    <string name="channel_name">Downloads</string>
+</resources>

--- a/brouter-routing-app/src/main/res/values/strings.xml
+++ b/brouter-routing-app/src/main/res/values/strings.xml
@@ -1,37 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010 The Android Open Source Project
-
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
--->
-
-<resources>
-    <plurals name="numberOfSegments">
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <plurals name="numberOfSegments" tools:ignore="MissingQuantity">
         <item quantity="one">%d segment</item>
         <item quantity="other">%d segments</item>
     </plurals>
-    <string name="app_name">BRouter</string>
-    <string name="cancel_download">Cancel Download</string>
-    <string name="import_profile">Import Profile</string>
-    <string name="profile_filename_example">filename.brf</string>
-    <string name="download_info_start">Starting download…</string>
-    <string name="download_info_cancel">Cancelling…</string>
+    <string name="cancel_download">Cancel download</string>
+    <string name="import_profile">Import profile</string>
     <string name="action_download">Download %s</string>
     <string name="action_delete">Delete %s</string>
     <string name="action_update">Update %s</string>
     <string name="action_select">Select segments</string>
-    <string name="action_cancel">Stop Download</string>
-    <string name="summary_segments">Size=%s\nFree=%s</string>
-    <string name="notification_channel_id">brouter_download</string>
-    <string name="notification_title">Download Segments</string>
-    <string name="channel_name">Downloads</string>
+    <string name="action_cancel">Stop download</string>
+    <string name="summary_segments">Size=%1$s\nFree=%2$s</string>
+    <string name="notification_title">Download segments</string>
 </resources>


### PR DESCRIPTION
- English, Arabic, Catalan, Dutch, French, German, Greek, Italian, Polish, Spanish
- Move fixed strings to donottranslate-strings.xml
- Remove unused strings
- Enable app localization

There are several texts in the code that can be moved to strings.xml and translated as well.

The translations were contributed by Cruiser users:
- https://github.com/devemux86/cruiser/discussions/382
