### PR TITLE
Android targetSdk 34

### DIFF
--- a/brouter-routing-app/src/main/AndroidManifest.xml
+++ b/brouter-routing-app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
@@ -100,6 +101,10 @@
             android:enabled="true"
             android:exported="true"
             android:process=":brouter_service" />
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
@@ -4,6 +4,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.util.Log;
 
@@ -169,7 +170,10 @@ public class DownloadWorker extends Worker {
     }
     notificationBuilder.setContentText("Starting Download");
     // Mark the Worker as important
-    setForegroundAsync(new ForegroundInfo(NOTIFICATION_ID, notificationBuilder.build()));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      setForegroundAsync(new ForegroundInfo(NOTIFICATION_ID, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC));
+    else
+      setForegroundAsync(new ForegroundInfo(NOTIFICATION_ID, notificationBuilder.build()));
     try {
       if (DEBUG) Log.d(LOG_TAG, "Download lookup & profiles");
       if (!downloadLookup()) {


### PR DESCRIPTION
When BRouter app uses `targetSdk 34` some changes are needed.
This pull request contains the changes for the download manager.

- Declare [foreground service type](https://developer.android.com/about/versions/14/changes/fgs-types-required)(s) in your manifest. You must do this for each foreground service you intend to use.
- If applicable to the type selected, declare and request the [foreground service permission](https://developer.android.com/about/versions/14/changes/fgs-types-required#permission-for-fgs-type) that is appropriate for each foreground service type.

---

Documentation: https://support.google.com/googleplay/android-developer/answer/13392821

When your apps target Android 14 and above, you’ll need to declare any foreground service types that you use in a new declaration on the [App content](https://play.google.com/console/app/app-content/summary) page (Policy > App content) in Play Console.
- Include a link to a video demonstrating each foreground service feature. The video should demonstrate the steps the user needs to take in your app in order to trigger the feature.