### PR TITLE
Fix compile and Lint issues

### DIFF
--- a/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
@@ -51,7 +51,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
     }
 
     // sort result list
-    comparator = new Comparator<>() {
+    comparator = new Comparator<MatchedWaypoint>() {
       @Override
       public int compare(MatchedWaypoint mw1, MatchedWaypoint mw2) {
         int cmpDist = Double.compare(mw1.radius, mw2.radius);

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -271,6 +271,7 @@ public class BRouterService extends Service {
       }
     }
 
+    @SuppressWarnings("deprecation")
     private void logBundle(Bundle params) {
       if (AppLogger.isLogging()) {
         for (String k : params.keySet()) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -36,6 +36,7 @@ public class BRouterWorker {
   public List<OsmNodeNamed> nogoPolygonsList;
   public String profileParams;
 
+  @SuppressWarnings("deprecation")
   public String getTrackFromParams(Bundle params) {
 
     int engineMode = 0;

--- a/brouter-util/src/main/java/btools/util/CompactLongMap.java
+++ b/brouter-util/src/main/java/btools/util/CompactLongMap.java
@@ -224,6 +224,7 @@ public class CompactLongMap<V> {
 
 
   // does sorted array "a" contain "id" ?
+  @SuppressWarnings("unchecked")
   private boolean contains(int idx, long id, boolean doPut) {
     long[] a = al[idx];
     int offset = a.length;
@@ -243,6 +244,7 @@ public class CompactLongMap<V> {
     return false;
   }
 
+  @SuppressWarnings("unchecked")
   protected void moveToFrozenArrays(long[] faid, List<V> flv) {
     for (int i = 1; i < MAXLISTS; i++) {
       pa[i] = 0;

--- a/brouter-util/src/main/java/btools/util/SortedHeap.java
+++ b/brouter-util/src/main/java/btools/util/SortedHeap.java
@@ -19,6 +19,7 @@ public final class SortedHeap<V> {
   /**
    * @return the lowest key value, or null if none
    */
+  @SuppressWarnings("unchecked")
   public V popLowestKeyValue() {
     SortedBin bin = firstNonEmpty;
     if (firstNonEmpty == null) {


### PR DESCRIPTION
During Android **release** builds with latest Android / Gradle, there are warnings and a compile error.

- The warnings are "unchecked" and "deprecation", we can suppress them,
or don't know if you want to handle them differently to have a clean build without warnings.

- More serious is the compile error at `Comparator` creation in `WaypointMatcherImpl`

Please see the pull request for the relevant sections in the code.