### PR TITLE
App: some error handling

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -96,6 +96,8 @@ public class BRouterService extends Service {
       if (errMsg != null) {
         return errMsg;
       }
+      // profile is already done
+      params.remove("profile");
 
       boolean canCompress = "true".equals(params.getString("acceptCompressedResult"));
       try {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -100,7 +100,7 @@ public class BRouterService extends Service {
       boolean canCompress = "true".equals(params.getString("acceptCompressedResult"));
       try {
         String gpxMessage = worker.getTrackFromParams(params);
-        if (canCompress) {
+        if (canCompress && (gpxMessage.startsWith("<") || gpxMessage.startsWith("{"))) {
           try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             baos.write("z64".getBytes(Charset.forName("UTF-8"))); // marker prefix

--- a/brouter-routing-app/src/main/java/btools/routingapp/RoutingParameterDialog.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/RoutingParameterDialog.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -168,39 +169,50 @@ public class RoutingParameterDialog extends AppCompatActivity {
         new OnBackInvokedCallback() {
           @Override
           public void onBackInvoked() {
-            StringBuilder sb = null;
-            if (sharedValues != null) {
-              // fill preference with used params
-              // for direct use in the BRouter interface "extraParams"
-              sb = new StringBuilder();
-              for (Map.Entry<String, ?> entry : sharedValues.getAll().entrySet()) {
-                if (!entry.getKey().equals("params")) {
-                  sb.append(sb.length() > 0 ? "&" : "")
-                    .append(entry.getKey())
-                    .append("=");
-                  String s = entry.getValue().toString();
-                  if (s.equals("true")) s = "1";
-                  else if (s.equals("false")) s = "0";
-                  sb.append(s);
-                }
-              }
-            }
-            // and return the array
-            // one should be enough
-            Intent i = new Intent();
-            // i.putExtra("PARAMS", listParams);
-            i.putExtra("PROFILE", profile);
-            i.putExtra("PROFILE_HASH", profile_hash);
-            if (sb != null) i.putExtra("PARAMS_VALUES", sb.toString());
-
-            setResult(Activity.RESULT_OK, i);
-            finish();
+            handleBackPressed();
           }
         }
       );
-
-
+    } else {
+      OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+          handleBackPressed();
+        }
+      };
+      getOnBackPressedDispatcher().addCallback(this, callback);
     }
+  }
+
+  private void handleBackPressed() {
+    StringBuilder sb = null;
+    if (sharedValues != null) {
+      // fill preference with used params
+      // for direct use in the BRouter interface "extraParams"
+      sb = new StringBuilder();
+      for (Map.Entry<String, ?> entry : sharedValues.getAll().entrySet()) {
+        if (!entry.getKey().equals("params")) {
+          sb.append(sb.length() > 0 ? "&" : "")
+            .append(entry.getKey())
+            .append("=");
+          String s = entry.getValue().toString();
+          if (s.equals("true")) s = "1";
+          else if (s.equals("false")) s = "0";
+          sb.append(s);
+        }
+      }
+    }
+    // and return the array
+    // one should be enough
+    Intent i = new Intent();
+    // i.putExtra("PARAMS", listParams);
+    i.putExtra("PROFILE", profile);
+    i.putExtra("PROFILE_HASH", profile_hash);
+    if (sb != null) i.putExtra("PARAMS_VALUES", sb.toString());
+
+    setResult(Activity.RESULT_OK, i);
+    finish();
+
   }
 
   @Override


### PR DESCRIPTION
According to the issue #643 a change in the back pressed handling for the `RoutingParameterDialog`.

Additional:
- compressed output only for gpx and json. Otherwise an error message also comes compressed
- in app the parameter `profile` is used outside the standard parameter setting in `RoutingParamCollector`. So it is better to remove it.
