### PR TITLE
Fix Canvas.drawRect on older Android

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BInstallerView.java
@@ -175,7 +175,7 @@ public class BInstallerView extends View {
           int tidx = gridPos2Tileindex(ix, iy);
           int tilesize = BInstallerSizes.getRd5Size(tidx);
           if (tilesize > 0) {
-            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, paintGrid);
+            canvas.drawRect(fw * ix, fh * iy, fw * (ix + 1), fh * (iy + 1), paintGrid);
           }
         }
       }
@@ -214,7 +214,7 @@ public class BInstallerView extends View {
             canvas.drawLine(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt);
 
             // draw frame
-            canvas.drawRect(fw * ix, fh * (iy + 1), fw * (ix + 1), fh * iy, pnt);
+            canvas.drawRect(fw * ix, fh * iy, fw * (ix + 1), fh * (iy + 1), pnt);
           }
         }
       }


### PR DESCRIPTION
BRouter download manager does not show the grid on older Android.

The reason seems to be that the `y` parameters are passed in wrong order in `Canvas.drawRect`.
They are "left, top, right, bottom" where we usually expect left < right and top < bottom.
The left < right are correct, but currently the top > bottom with no rectangles showing.

If we reverse them, then the rectangles appear again on older Android.
Newer Android works because it may reorder the parameters internally.