### PR TITLE
Fix 'sees' typo in consider_river switch

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -25,7 +25,7 @@ assign allow_motorways       = false  # %allow_motorways% | Set to true to allow
 
 assign consider_traffic      = false  # %consider_traffic% | Activate to avoid traffic | boolean
 assign consider_noise        = false  # %consider_noise% | Activate to prefer a low-noise route | boolean
-assign consider_river        = false  # %consider_river% | Activate to prefer a route along rivers or sees | boolean
+assign consider_river        = false  # %consider_river% | Activate to prefer a route along rivers, lakes, etc. | boolean
 assign consider_forest       = false  # %consider_forest% | Activate to prefer a route in forest or parks | boolean
 assign consider_town         = false  # %consider_town% | Activate to bypass cities / big towns as far as possible | boolean
 

--- a/misc/profiles2/hiking-mountain.brf
+++ b/misc/profiles2/hiking-mountain.brf
@@ -12,7 +12,7 @@
 
 assign   consider_elevation     = false   # %consider_elevation% | Activate to prefer a route with few elevation meters | boolean
 assign   consider_noise         = false   # %consider_noise% | Activate to prefer a low-noise route | boolean
-assign   consider_river         = false   # %consider_river% | Activate to prefer a route along rivers or sees | boolean
+assign   consider_river         = false   # %consider_river% | Activate to prefer a route along rivers, lakes, etc. | boolean
 assign   consider_forest        = false   # %consider_forest% | Activate to prefer a route in forest or green areas| boolean
 assign   consider_town          = false   # %consider_town% | Activate to bypass cities / big towns as far as possible | boolean
 assign   consider_traffic       = 1       # %consider_traffic% | how do you plan to drive the tour? |  [1=as cyclist alone in the week, 0.5=as cyclist alone at weekend, 0.3 =with a group of cyclists, 0.1=with a group of cyclists at week-end]

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -16,7 +16,7 @@ assign   stick_to_cycleroutes     = false  # %stick_to_cycleroutes% | Set true t
 assign   avoid_unsafe             = false  # %avoid_unsafe% | Set true to avoid standard highways | boolean
 
 assign   consider_noise           = false  # %consider_noise% | Activate to prefer a low-noise route | boolean
-assign   consider_river           = false  # %consider_river% | Activate to prefer a route along rivers or sees | boolean
+assign   consider_river           = false  # %consider_river% | Activate to prefer a route along rivers, lakes, etc. | boolean
 assign   consider_forest          = false  # %consider_forest% | Activate to prefer a route in forest or parks | boolean
 assign   consider_town            = false  # %consider_town% | Activate to bypass cities / big towns as far as possible | boolean
 assign   consider_traffic         = false  # %consider_traffic% | Activate to consider traffic estimates | boolean


### PR DESCRIPTION
Replace "rivers or sees" with "rivers, lakers, etc.", based on wording proposed by @gnbl in https://github.com/nrenner/brouter-web/issues/747.
