### PR TITLE
Error reading rawTrack: do not throw exception, fix #671

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -285,7 +285,9 @@ public final class OsmTrack {
           }
           dis.close();
         } catch (Exception e) {
-          throw new RuntimeException("Exception reading rawTrack: " + e);
+          if (debugInfo != null) {
+            debugInfo.append("Error reading rawTrack: " + e);
+          }
         }
       }
     }


### PR DESCRIPTION
Do not throw an exception as it is already handled by the returned null result.

For details see #671.