### PR TITLE
Preparing for  version 1.7.4

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -23,8 +23,8 @@ import btools.util.CompactLongMap;
 import btools.util.FrozenLongMap;
 
 public final class OsmTrack {
-  final public static String version = "1.7.3";
-  final public static String versionDate = "19082023";
+  final public static String version = "1.7.4";
+  final public static String versionDate = "09042024";
 
   // csv-header-line
   private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags\tTime\tEnergy";

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -11,7 +11,7 @@ android {
         namespace 'btools.routingapp'
         applicationId "btools.routingapp"
 
-        versionCode 50
+        versionCode 51
         versionName project.version
 
         resValue('string', 'app_version', defaultConfig.versionName)

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
     // app: build.gradle (versionCode only)
     // OsmTrack (version and versionDate)
     // docs revisions.md (version and versionDate)
-    project.version  "1.7.3"
+    project.version  "1.7.4"
     group 'org.btools'
 
     repositories {

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -2,6 +2,29 @@
 
 (ZIP-Archives including APK, readme + profiles)
 
+
+### Changes since last version
+
+Library
+
+- new "DIVIDE" command for profile calculation
+- new "maxslope" and "maxslopecost" parameters
+- new parameter collector
+- new output logic
+- rework on voice hints and roundabouts
+- enabled elevation raster files with 1 asec
+
+
+Android
+
+- BRouter translations
+- fallback on certificate problems
+
+
+- Minor bug fixes
+
+[Solved issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue+milestone%3A%22Version+1.7.4%22+is%3Aclosed)
+
 ### [brouter-1.7.3.zip](../brouter_bin/brouter-1.7.3.zip) (current revision, 19.08.2023)
 
 - Minor bug fixes

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -3,7 +3,7 @@
 (ZIP-Archives including APK, readme + profiles)
 
 
-### Changes since last version
+### [brouter-1.7.4.zip](../brouter_bin/brouter-1.7.4.zip) (current revision, 09.04.2024)
 
 Library
 
@@ -25,7 +25,8 @@ Android
 
 [Solved issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue+milestone%3A%22Version+1.7.4%22+is%3Aclosed)
 
-### [brouter-1.7.3.zip](../brouter_bin/brouter-1.7.3.zip) (current revision, 19.08.2023)
+
+### [brouter-1.7.3.zip](../brouter_bin/brouter-1.7.3.zip) (19.08.2023)
 
 - Minor bug fixes
 


### PR DESCRIPTION
There are some finished issues. Please [see](https://github.com/abrensch/brouter/pulls?q=is%3Apr+milestone%3A%22Version+1.7.4%22+is%3Aclosed)