### PR TITLE
Update MIME type for GeoJSON responses

### DIFF
--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -107,7 +107,7 @@ public class ServerHandler extends RequestHandler {
       } else if ("kml".equals(format)) {
         result = "application/vnd.google-earth.kml+xml";
       } else if ("geojson".equals(format)) {
-        result = "application/vnd.geo+json";
+        result = "application/geo+json";
       } else if ("csv".equals(format)) {
         result = "text/tab-separated-values";
       }


### PR DESCRIPTION
The MIME type for GeoJSON registered with IANA is application/geo+json, replacing the old value application/vnd.geo+json. The change was published with RFC 7946 in 2016.

Example request:

`GET /brouter?lonlats=13.377485,52.516247%7C13.351221,52.515004&profile=trekking&alternativeidx=0&format=geojson HTTP/1.1`

Exampe response headers:

```
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Disposition: attachment; filename="brouter.geojson"
Access-Control-Allow-Origin: *
Connection: close
Content-Type: application/geo+json; charset=utf-8
```

References:

- https://www.iana.org/assignments/media-types/application/vnd.geo+json
- https://www.iana.org/assignments/media-types/application/geo+json
- https://datatracker.ietf.org/doc/html/rfc7946#section-12