### PR TITLE
Configure profile as service when changing profile settings

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
@@ -817,17 +817,17 @@ public class BRouterView extends View {
     }
   }
 
-  public void startConfigureService() {
+  public void startConfigureService(String sparams) {
     String[] modes = new String[]
       {"foot_short", "foot_fast", "bicycle_short", "bicycle_fast", "motorcar_short", "motorcar_fast"};
     boolean[] modesChecked = new boolean[6];
 
     String msg = "Choose service-modes to configure (" + profileName + " [" + nogoVetoList.size() + "])";
 
-    ((BRouterActivity) getContext()).selectRoutingModes(modes, modesChecked, msg);
+    ((BRouterActivity) getContext()).selectRoutingModes(modes, modesChecked, msg, sparams);
   }
 
-  public void configureService(String[] routingModes, boolean[] checkedModes) {
+  public void configureService(String[] routingModes, boolean[] checkedModes, String sparams) {
     // read in current config
     TreeMap<String, ServiceModeConfig> map = new TreeMap<>();
     BufferedReader br = null;
@@ -861,7 +861,8 @@ public class BRouterView extends View {
           s = sm.params;
           p = sm.profile;
         }
-        if (s == null || !p.equals(profileName)) s = "noparams";
+        if (!p.equals(profileName)) s = sparams;
+        if (s == null || s.equals("")) s = "noparams";
         ServiceModeConfig smc = new ServiceModeConfig(routingModes[i], profileName, s);
         for (OsmNodeNamed nogo : nogoVetoList) {
           smc.nogoVetos.add(nogo.ilon + "," + nogo.ilat);

--- a/brouter-routing-app/src/main/res/values-ar/strings.xml
+++ b/brouter-routing-app/src/main/res/values-ar/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">اختر إلى/عبر</string>
 
     <string name="msg_no_profile">لا توجد بيانات ملف التعريف</string>
-    <string name="msg_no_used_profile">، لا يوجد ملف تعريف مستخدم</string>
     <string name="msg_too_much_data">هناك الكثير من البيانات للتنزيل، من فضلك قم بتقليلها.</string>
     <string name="msg_download_start">تمت جدولة التنزيل، وتحقق من اتصالك بالإنترنت إذا لم يبدأ التنزيل.</string>
     <string name="msg_wpt_selection">نقاط الطريق الحالية المحددة:\n</string>

--- a/brouter-routing-app/src/main/res/values-ca/strings.xml
+++ b/brouter-routing-app/src/main/res/values-ca/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Seleccionar a/via</string>
 
     <string name="msg_no_profile">no hi ha dades al perfil</string>
-    <string name="msg_no_used_profile">, cap perfil utilitzat</string>
     <string name="msg_too_much_data">Massa dades per baixar. Si us plau, redueix-les.</string>
     <string name="msg_download_start">Baixada programada. Comprovar la connexió a internet si no comença.</string>
     <string name="msg_wpt_selection">selecció actual de fita:\n</string>

--- a/brouter-routing-app/src/main/res/values-de/strings.xml
+++ b/brouter-routing-app/src/main/res/values-de/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">"Nach"/Via wählen</string>
 
     <string name="msg_no_profile">Keine Profildaten</string>
-    <string name="msg_no_used_profile">, kein verwendetes Profil</string>
     <string name="msg_too_much_data">Zu viele Daten für den Download. Bitte reduzieren.</string>
     <string name="msg_download_start">Download geplant. Überprüfen Sie die Internetverbindung, wenn der Download nicht startet.</string>
     <string name="msg_wpt_selection">aktuelle Wegpunktauswahl:\n</string>

--- a/brouter-routing-app/src/main/res/values-el/strings.xml
+++ b/brouter-routing-app/src/main/res/values-el/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Επιλέξτε προς/μέσω</string>
 
     <string name="msg_no_profile">μη δεδομένα προφίλ</string>
-    <string name="msg_no_used_profile">, μη χρησιμοποιημένο προφίλ</string>
     <string name="msg_too_much_data">Πάρα πολλά δεδομένα για λήψη. Παρακαλώ μειώστε.</string>
     <string name="msg_download_start">Προγραμματισμένη λήψη. Ελέγξτε τη σύνδεση στο διαδίκτυο εάν δεν ξεκινά.</string>
     <string name="msg_wpt_selection">τρέχουσα επιλογή σημείου:\n</string>

--- a/brouter-routing-app/src/main/res/values-es/strings.xml
+++ b/brouter-routing-app/src/main/res/values-es/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Seleccionar a/vía</string>
 
     <string name="msg_no_profile">no hay datos en el perfil</string>
-    <string name="msg_no_used_profile">, ningún perfil utilizado</string>
     <string name="msg_too_much_data">Demasiados datos a descargar. Por favor, reducidlos.</string>
     <string name="msg_download_start">Descarga programada. Comprueba la conexión a internet si no se inicia.</string>
     <string name="msg_wpt_selection">selección actual de waypoint:\n</string>

--- a/brouter-routing-app/src/main/res/values-fr/strings.xml
+++ b/brouter-routing-app/src/main/res/values-fr/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Sélectionner vers/via</string>
 
     <string name="msg_no_profile">aucune donnée de profil</string>
-    <string name="msg_no_used_profile">, aucun profil utilisé</string>
     <string name="msg_too_much_data">Trop de données à télécharger. Veuillez réduire.</string>
     <string name="msg_download_start">Téléchargement planifié. Vérifiez la connexion Internet si elle ne démarre pas.</string>
     <string name="msg_wpt_selection">sélection actuelle du waypoint:\n</string>

--- a/brouter-routing-app/src/main/res/values-it/strings.xml
+++ b/brouter-routing-app/src/main/res/values-it/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Seleziona a/via</string>
 
     <string name="msg_no_profile">nessun dato del profilo</string>
-    <string name="msg_no_used_profile">, nessun profilo utilizzato</string>
     <string name="msg_too_much_data">Troppi dati per il download. Per favore riduci.</string>
     <string name="msg_download_start">Download programmato. Controlla la connessione Internet se non si avvia.</string>
     <string name="msg_wpt_selection">selezione del waypoint corrente:\n</string>

--- a/brouter-routing-app/src/main/res/values-ko/strings.xml
+++ b/brouter-routing-app/src/main/res/values-ko/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">선택 ~로/경유하여</string>
 
     <string name="msg_no_profile">프로필 데이터 없음</string>
-    <string name="msg_no_used_profile">, 사용된 프로필 없음</string>
     <string name="msg_too_much_data">다운로드 하기에 너무 많은 데이터. 줄이도록 하세요.</string>
     <string name="msg_download_start">다운로드 계획되어 있음. 인터넷 연결 체크 그렇지 않다면 시작.</string>
     <string name="msg_wpt_selection">현재 장소 선택:\n</string>

--- a/brouter-routing-app/src/main/res/values-nl/strings.xml
+++ b/brouter-routing-app/src/main/res/values-nl/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Selecteer naar/via</string>
 
     <string name="msg_no_profile">geen profiel data</string>
-    <string name="msg_no_used_profile">, geen gebruikt profiel</string>
     <string name="msg_too_much_data">Te veel gegevens om te downloaden. Verminder a.u.b.</string>
     <string name="msg_download_start">Download is gepland. Controleer de internetverbinding als deze  niet start.</string>
     <string name="msg_wpt_selection">huidige waypointselectie:\n</string>

--- a/brouter-routing-app/src/main/res/values-pl/strings.xml
+++ b/brouter-routing-app/src/main/res/values-pl/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Wybierz do/przez</string>
 
     <string name="msg_no_profile">brak danych profilu</string>
-    <string name="msg_no_used_profile">, brak używanego profilu</string>
     <string name="msg_too_much_data">Za dużo danych do pobrania. Proszę ogranicz.</string>
     <string name="msg_download_start">Pobieranie zaplanowane. Jeśli się nie rozpocznie, sprawdź połączenie internetowe.</string>
     <string name="msg_wpt_selection">bieżący wybór punktu trasy:\n</string>

--- a/brouter-routing-app/src/main/res/values/strings.xml
+++ b/brouter-routing-app/src/main/res/values/strings.xml
@@ -53,7 +53,6 @@
     <string name="action_select_to">Select to/via</string>
 
     <string name="msg_no_profile">no profile data</string>
-    <string name="msg_no_used_profile">, no used profile</string>
     <string name="msg_too_much_data">Too much data for download. Please reduce.</string>
     <string name="msg_download_start">Download scheduled. Check internet connection if it doesn\'t start.</string>
     <string name="msg_wpt_selection">current waypoint selection:\n</string>


### PR DESCRIPTION
When trying to change settings for a profile that was not yet configured as a service in the android app, the app exits instead of configuring the profile. This behavior is not very intuitive for users, as it is required to first configure the profile and then open the app again to change the settings.

This change instead adds a dialog to configure the profile as a new service in case `Profile Settings` is selected and the selected profile is not yet configured as a service.