### PR TITLE
Start way check added

### DIFF
--- a/brouter-codec/src/main/java/btools/codec/MicroCache2.java
+++ b/brouter-codec/src/main/java/btools/codec/MicroCache2.java
@@ -161,7 +161,8 @@ public final class MicroCache2 extends MicroCache {
           int ilontarget = ilon + dlon_remaining;
           int ilattarget = ilat + dlat_remaining;
           if (matcher != null) {
-            if (!matcher.start(ilon, ilat, ilontarget, ilattarget)) {
+            boolean useAsStartWay = wayValidator.checkStartWay(wayTags.data);
+            if (!matcher.start(ilon, ilat, ilontarget, ilattarget, useAsStartWay)) {
               matcher = null;
             }
           }

--- a/brouter-codec/src/main/java/btools/codec/TagValueValidator.java
+++ b/brouter-codec/src/main/java/btools/codec/TagValueValidator.java
@@ -13,4 +13,6 @@ public interface TagValueValidator {
   boolean isLookupIdxUsed(int idx);
 
   void setDecodeForbidden(boolean decodeForbidden);
+
+  boolean checkStartWay(byte[] ab);
 }

--- a/brouter-codec/src/main/java/btools/codec/WaypointMatcher.java
+++ b/brouter-codec/src/main/java/btools/codec/WaypointMatcher.java
@@ -6,7 +6,7 @@ package btools.codec;
  * matches to the waypoints
  */
 public interface WaypointMatcher {
-  boolean start(int ilonStart, int ilatStart, int ilonTarget, int ilatTarget);
+  boolean start(int ilonStart, int ilatStart, int ilonTarget, int ilatTarget, boolean useAsStartWay);
 
   void transferNode(int ilon, int ilat);
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -167,6 +167,10 @@ public final class RoutingContext {
     defaultC_r = expctxGlobal.getVariableValue("C_r", 0.01f);
     // Constant power of the biker (in W)
     bikerPower = expctxGlobal.getVariableValue("bikerPower", 100.f);
+
+    boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
+    if (!test) expctxGlobal.freeNoWays();
+
   }
 
   public List<OsmNodeNamed> poipoints;

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
@@ -129,4 +129,6 @@ public final class BExpressionContextWay extends BExpressionContext implements T
   public void setDecodeForbidden(boolean decodeForbidden) {
     this.decodeForbidden = decodeForbidden;
   }
+
+
 }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/DirectWeaver.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/DirectWeaver.java
@@ -116,7 +116,8 @@ public final class DirectWeaver extends ByteDataWriter {
           int ilontarget = ilon + dlon_remaining;
           int ilattarget = ilat + dlat_remaining;
           if (matcher != null) {
-            if (!matcher.start(ilon, ilat, ilontarget, ilattarget)) {
+            boolean useAsStartWay = wayTags==null || wayValidator.checkStartWay(wayTags.data);
+            if (!matcher.start(ilon, ilat, ilontarget, ilattarget, useAsStartWay)) {
               matcher = null;
             }
           }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
@@ -28,6 +28,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
   private boolean anyUpdate;
   private int lonLast;
   private int latLast;
+  boolean useAsStartWay = true;
 
   private Comparator<MatchedWaypoint> comparator;
 
@@ -78,6 +79,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
 
     //for ( MatchedWaypoint mwp : waypoints )
     for (int i = 0; i < waypoints.size(); i++) {
+      if (!useAsStartWay && i==0) continue;
       MatchedWaypoint mwp = waypoints.get(i);
 
       if (mwp.direct &&
@@ -141,7 +143,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
   }
 
   @Override
-  public boolean start(int ilonStart, int ilatStart, int ilonTarget, int ilatTarget) {
+  public boolean start(int ilonStart, int ilatStart, int ilonTarget, int ilatTarget, boolean useAsStartWay) {
     if (islandPairs.size() > 0) {
       long n1 = ((long) ilonStart) << 32 | ilatStart;
       long n2 = ((long) ilonTarget) << 32 | ilatTarget;
@@ -154,6 +156,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
     lonTarget = ilonTarget;
     latTarget = ilatTarget;
     anyUpdate = false;
+    this.useAsStartWay = useAsStartWay;
     return true;
   }
 


### PR DESCRIPTION
This is the answer on the issues #600 and #682.

The idea is to place a definition for excludes highways in the profile.
This is scanned at routing start and an array is created with the index of the lookup entry and the lookup value.
The array is then used to exclude the way from the routing.

The test server is prepared for using this feature.
You have to assign a new global rule in the profile - there is no entry for this feature in the profiles at the moment.
```
assign   check_start_way          = true   # %check_start_way% | Activate a test for the starting way | boolean | noStartWay=route,ferry;highway,motorway;highway,motorway_link
```
As you see the comment part of the assign has in this case an array with 4 entries - please note, the web client can not check that at the moment, so you don't see the assigned entry in the option window (I guess, some of the RegEx in [Profile.js](https://github.com/nrenner/brouter-web/blob/6b24a8790eea72bf6e95a63bfaadc0417f36d3fa/js/control/Profile.js) should be changed).
The fourth part of the array contains the excluded entries.
```
noStartWay= - a fix constant for this new feature
route,ferry - entry for route=ferry
; - more entries comes here

```

Here the links for the test server:
[issue 600](https://brouter.de/brouter-test/#map=14/51.1065/7.8808/standard&lonlats=7.885628,51.100827;7.878391,51.114132)
[issee 682](https://brouter.de/brouter-test/#map=15/51.9843/7.5538/standard&lonlats=7.555976,51.984186;7.550569,51.985726)