### PR TITLE
Enable a dynamic range search for matched way points

### DIFF
--- a/brouter-core/src/main/java/btools/router/FormatJson.java
+++ b/brouter-core/src/main/java/btools/router/FormatJson.java
@@ -122,7 +122,7 @@ public class FormatJson extends Formatter {
         .append(sele).append("],\n");
       nn = n;
     }
-    sb.deleteCharAt(sb.lastIndexOf(","));
+    if (t.nodes != null && !t.nodes.isEmpty()) sb.deleteCharAt(sb.lastIndexOf(","));
 
     sb.append("        ]\n");
     sb.append("      }\n");

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -76,6 +76,7 @@ public final class RoutingContext {
   public double waypointCatchingRange;
   public boolean correctMisplacedViaPoints;
   public double correctMisplacedViaPointsDistance;
+  public boolean useDynamicDistance;
 
   private void setModel(String className) {
     if (className == null) {
@@ -167,6 +168,8 @@ public final class RoutingContext {
     defaultC_r = expctxGlobal.getVariableValue("C_r", 0.01f);
     // Constant power of the biker (in W)
     bikerPower = expctxGlobal.getVariableValue("bikerPower", 100.f);
+
+    useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 0f) == 1f;
 
     boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
     if (!test) expctxGlobal.freeNoWays();

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/NodesCache.java
@@ -177,7 +177,8 @@ public final class NodesCache {
       }
 
       MicroCache segment = osmf.getMicroCache(ilon, ilat);
-      if (segment == null) {
+      // needed for a second chance
+      if (segment == null || (waypointMatcher != null && ((WaypointMatcherImpl) waypointMatcher).useDynamicRange)) {
         checkEnableCacheCleaning();
         segment = osmf.createMicroCache(ilon, ilat, dataBuffers, expCtxWay, waypointMatcher, directWeaving ? nodesMap : null);
 
@@ -282,15 +283,15 @@ public final class NodesCache {
     return existing;
   }
 
-  public void matchWaypointsToNodes(List<MatchedWaypoint> unmatchedWaypoints, double maxDistance, OsmNodePairSet islandNodePairs) {
+  public boolean matchWaypointsToNodes(List<MatchedWaypoint> unmatchedWaypoints, double maxDistance, OsmNodePairSet islandNodePairs) {
     waypointMatcher = new WaypointMatcherImpl(unmatchedWaypoints, maxDistance, islandNodePairs);
     for (MatchedWaypoint mwp : unmatchedWaypoints) {
       int cellsize = 12500;
-      preloadPosition(mwp.waypoint, cellsize);
+      preloadPosition(mwp.waypoint, cellsize, 1);
       // get a second chance
       if (mwp.crosspoint == null) {
         cellsize = 1000000 / 32;
-        preloadPosition(mwp.waypoint, cellsize);
+        preloadPosition(mwp.waypoint, cellsize, maxDistance < 0 ? 5 : 2);
       }
     }
 
@@ -305,7 +306,8 @@ public final class NodesCache {
           mwp.crosspoint = new OsmNode(mwp.waypoint.ilon, mwp.waypoint.ilat);
           mwp.direct = true;
         } else {
-          throw new IllegalArgumentException(mwp.name + "-position not mapped in existing datafile");
+          // do not break here throw new IllegalArgumentException(mwp.name + "-position not mapped in existing datafile");
+          return false;
         }
       }
       if (unmatchedWaypoints.size() > 1 && i == unmatchedWaypoints.size() - 1 && unmatchedWaypoints.get(i - 1).direct) {
@@ -313,17 +315,18 @@ public final class NodesCache {
         mwp.direct = true;
       }
     }
+    return true;
   }
 
-  private void preloadPosition(OsmNode n, int d) {
+  private void preloadPosition(OsmNode n, int d, int scale) {
     first_file_access_failed = false;
     first_file_access_name = null;
     loadSegmentFor(n.ilon, n.ilat);
     if (first_file_access_failed) {
       throw new IllegalArgumentException("datafile " + first_file_access_name + " not found");
     }
-    for (int idxLat = -1; idxLat <= 1; idxLat++)
-      for (int idxLon = -1; idxLon <= 1; idxLon++) {
+    for (int idxLat = -scale; idxLat <= scale; idxLat++)
+      for (int idxLon = -scale; idxLon <= scale; idxLon++) {
         if (idxLon != 0 || idxLat != 0) {
           loadSegmentFor(n.ilon + d * idxLon, n.ilat + d * idxLat);
         }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
@@ -29,6 +29,8 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
   private int lonLast;
   private int latLast;
   boolean useAsStartWay = true;
+  public boolean useDynamicRange;
+  private int maxWptIdx;
 
   private Comparator<MatchedWaypoint> comparator;
 
@@ -36,6 +38,11 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
     this.waypoints = waypoints;
     this.islandPairs = islandPairs;
     MatchedWaypoint last = null;
+    this.useDynamicRange = maxDistance < 0;
+    if (maxDistance < 0.) {
+      maxDistance *= -1;
+    }
+
     for (MatchedWaypoint mwp : waypoints) {
       mwp.radius = maxDistance;
       if (last != null && mwp.directionToNext == -1) {
@@ -50,6 +57,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
     } else {
       last.directionToNext = CheapAngleMeter.getDirection(last.waypoint.ilon, last.waypoint.ilat, waypoints.get(lastidx).waypoint.ilon, waypoints.get(lastidx).waypoint.ilat);
     }
+    maxWptIdx = waypoints.size() - 1;
 
     // sort result list
     comparator = new Comparator<>() {
@@ -105,7 +113,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
       double r22 = x2 * x2 + y2 * y2;
       double radius = Math.abs(r12 < r22 ? y1 * dx - x1 * dy : y2 * dx - x2 * dy) / d;
 
-      if (radius <= mwp.radius) {
+      if (radius <= mwp.radius || (this.useDynamicRange && (i == 0 || i == maxWptIdx))) {
         double s1 = x1 * dx + y1 * dy;
         double s2 = x2 * dx + y2 * dy;
 


### PR DESCRIPTION
This should enable the #387 issue.

It could be tested on the BRouter test server together with the #728 and #726 
[Sample](https://brouter.de/brouter-test/#map=10/23.6250/43.5354/standard&lonlats=43.503174,23.595478;43.421661,24.40659&profile=car-eco) 

The logic is only valid for the first and the last point. So please test 2 points routes only at the moment.

For a dynamic range test you will need a new profile constant
```
assign use_dynamic_range   = true  # %use_dynamic_range% | Enable distant start/end points | boolean
```

Please remember to test #728 with this entry
```
assign check_start_way      = true   # %check_start_way% | Activate a test for the starting way | boolean | noStartWay=route,ferry;highway,motorway;highway,motorway_link
```

