### PR TITLE
Enable beeline voicehints when there are no detours

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -452,7 +452,8 @@ public final class OsmTrack {
     voiceHints.setTransportMode(rc.carMode, rc.bikeMode);
     voiceHints.turnInstructionMode = rc.turnInstructionMode;
 
-    if (detourMap == null) {
+    if (detourMap == null && !rc.hasDirectRouting) {
+      // only when no direct way points
       return;
     }
     int nodeNr = nodes.size() - 1;
@@ -487,13 +488,15 @@ public final class OsmTrack {
             input.distanceToNext = node.calcDistance(node.origin);
           }
         }
-        OsmPathElementHolder detours = detourMap.get(node.origin.getIdFromPos());
-        if (nodeNr >= 0 && detours != null) {
-          OsmPathElementHolder h = detours;
-          while (h != null) {
-            OsmPathElement e = h.node;
-            input.addBadWay(startSection(e, node.origin));
-            h = h.nextHolder;
+        if (detourMap != null) {
+          OsmPathElementHolder detours = detourMap.get(node.origin.getIdFromPos());
+          if (nodeNr >= 0 && detours != null) {
+            OsmPathElementHolder h = detours;
+            while (h != null) {
+              OsmPathElement e = h.node;
+              input.addBadWay(startSection(e, node.origin));
+              h = h.nextHolder;
+            }
           }
         }
         /* else if (nodeNr == 0 && detours != null) {

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -203,6 +203,7 @@ public final class RoutingContext {
   public boolean showSpeedProfile;
   public boolean inverseRouting;
   public boolean showTime;
+  public boolean hasDirectRouting;
 
   public String outputFormat = "gpx";
   public boolean exportWaypoints = false;

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -631,6 +631,8 @@ public class RoutingEngine extends Thread {
       }
     }
 
+    routingContext.hasDirectRouting = hasDirectRouting;
+
     OsmPath.seg = 1; // set segment counter
     for (int i = 0; i < matchedWaypoints.size() - 1; i++) {
       if (lastTracks[i] != null) {

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -294,6 +294,11 @@ public final class VoiceHintProcessor {
         nextInput = inputs.get(hintIdx + 1);
       }
 
+      if (input.cmd == VoiceHint.BL) {
+        results.add(input);
+        continue;
+      }
+
       if (nextInput == null) {
         if ((input.cmd == VoiceHint.C ||
              input.cmd == VoiceHint.KR ||


### PR DESCRIPTION
As shown in issue #387 sample there is no beeline information generated when we don't have detours.