### PR TITLE
New voicehints for motorway exit

### DIFF
--- a/brouter-core/src/main/java/btools/router/FormatGpx.java
+++ b/brouter-core/src/main/java/btools/router/FormatGpx.java
@@ -49,7 +49,7 @@ public class FormatGpx extends Formatter {
       sb.append("<!--          cmd    idx        lon        lat d2next  geometry -->\n");
       sb.append("<!-- $turn-instruction-start$\n");
       for (VoiceHint hint : t.voiceHints.list) {
-        sb.append(String.format("     $turn$%6s;%6d;%10s;%10s;%6d;%s$\n", hint.getCommandString(), hint.indexInTrack,
+        sb.append(String.format("     $turn$%6s;%6d;%10s;%10s;%6d;%s$\n", hint.getCommandString(turnInstructionMode), hint.indexInTrack,
           formatILon(hint.ilon), formatILat(hint.ilat), (int) (hint.distanceToNext), hint.formatGeometry()));
       }
       sb.append("    $turn-instruction-end$ -->\n");
@@ -121,7 +121,7 @@ public class FormatGpx extends Formatter {
         sb.append("  <rtept lat=\"").append(formatILat(hint.ilat)).append("\" lon=\"")
           .append(formatILon(hint.ilon)).append("\">\n")
           .append("   <desc>")
-          .append(turnInstructionMode == 3 ? hint.getMessageString() : hint.getCruiserMessageString())
+          .append(turnInstructionMode == 3 ? hint.getMessageString(turnInstructionMode) : hint.getCruiserMessageString())
           .append("</desc>\n   <extensions>\n");
 
         rteTime = t.getVoiceHintTime(i + 1);
@@ -132,7 +132,7 @@ public class FormatGpx extends Formatter {
           lastRteTime = rteTime;
         }
         sb.append("    <turn>")
-          .append(turnInstructionMode == 3 ? hint.getCommandString() : hint.getCruiserCommandString())
+          .append(turnInstructionMode == 3 ? hint.getCommandString(turnInstructionMode) : hint.getCruiserCommandString())
           .append("</turn>\n    <turn-angle>").append("" + (int) hint.angle)
           .append("</turn-angle>\n    <offset>").append("" + hint.indexInTrack).append("</offset>\n  </extensions>\n </rtept>\n");
       }
@@ -154,7 +154,7 @@ public class FormatGpx extends Formatter {
           .append(formatILat(hint.ilat)).append("\">")
           .append(hint.selev == Short.MIN_VALUE ? "" : "<ele>" + (hint.selev / 4.) + "</ele>")
           .append("<name>")
-          .append(hint.getMessageString())
+          .append(hint.getMessageString(turnInstructionMode))
           .append("</name>")
           .append("<extensions><locus:rteDistance>").append("" + hint.distanceToNext).append("</locus:rteDistance>");
         float rteTime = t.getVoiceHintTime(i + 1);
@@ -173,9 +173,9 @@ public class FormatGpx extends Formatter {
       for (VoiceHint hint : t.voiceHints.list) {
         sb.append(" <wpt lon=\"").append(formatILon(hint.ilon)).append("\" lat=\"")
           .append(formatILat(hint.ilat)).append("\">")
-          .append("<name>").append(hint.getMessageString()).append("</name>")
-          .append("<sym>").append(hint.getSymbolString().toLowerCase()).append("</sym>")
-          .append("<type>").append(hint.getSymbolString()).append("</type>")
+          .append("<name>").append(hint.getMessageString(turnInstructionMode)).append("</name>")
+          .append("<sym>").append(hint.getSymbolString(turnInstructionMode).toLowerCase()).append("</sym>")
+          .append("<type>").append(hint.getSymbolString(turnInstructionMode)).append("</type>")
           .append("</wpt>\n");
       }
     }
@@ -270,7 +270,7 @@ public class FormatGpx extends Formatter {
             sele += "<name>" + mwpt.name + "</name>";
           }
           sele += "<desc>" + hint.getCruiserMessageString() + "</desc>";
-          sele += "<sym>" + hint.getCommandString(hint.cmd) + "</sym>";
+          sele += "<sym>" + hint.getCommandString(hint.cmd, turnInstructionMode) + "</sym>";
           if (mwpt != null) {
             sele += "<type>Via</type>";
           }
@@ -287,7 +287,7 @@ public class FormatGpx extends Formatter {
             sele += "<brouter:speed>" + (((int) (speed * 10)) / 10.f) + "</brouter:speed>";
           }
 
-          sele += "<brouter:voicehint>" + hint.getCommandString() + ";" + (int) (hint.distanceToNext) + "," + hint.formatGeometry() + "</brouter:voicehint>";
+          sele += "<brouter:voicehint>" + hint.getCommandString(turnInstructionMode) + ";" + (int) (hint.distanceToNext) + "," + hint.formatGeometry() + "</brouter:voicehint>";
           if (n.message != null && n.message.wayKeyValues != null && !n.message.wayKeyValues.equals(lastway)) {
             sele += "<brouter:way>" + n.message.wayKeyValues + "</brouter:way>";
             lastway = n.message.wayKeyValues;

--- a/brouter-core/src/main/java/btools/router/FormatJson.java
+++ b/brouter-core/src/main/java/btools/router/FormatJson.java
@@ -41,13 +41,13 @@ public class FormatJson extends Formatter {
       for (VoiceHint hint : t.voiceHints.list) {
         sb.append("          [");
         sb.append(hint.indexInTrack);
-        sb.append(',').append(hint.getJsonCommandIndex());
+        sb.append(',').append(hint.getJsonCommandIndex(turnInstructionMode));
         sb.append(',').append(hint.getExitNumber());
         sb.append(',').append(hint.distanceToNext);
         sb.append(',').append((int) hint.angle);
 
         // not always include geometry because longer and only needed for comment style
-        if (turnInstructionMode == 4) { // comment style
+        if (turnInstructionMode == 4 || turnInstructionMode == 9) { // comment style
           sb.append(",\"").append(hint.formatGeometry()).append("\"");
         }
 
@@ -122,7 +122,7 @@ public class FormatJson extends Formatter {
         .append(sele).append("],\n");
       nn = n;
     }
-    if (t.nodes != null && !t.nodes.isEmpty()) sb.deleteCharAt(sb.lastIndexOf(","));
+    sb.deleteCharAt(sb.lastIndexOf(","));
 
     sb.append("        ]\n");
     sb.append("      }\n");

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -469,6 +469,17 @@ public final class OsmTrack {
     List<VoiceHint> inputs = new ArrayList<>();
     while (node != null) {
       if (node.origin != null) {
+        if (nodeNr == nodes.size() - 1) {
+          VoiceHint input = new VoiceHint();
+          inputs.add(0, input);
+          input.ilat = node.getILat();
+          input.ilon = node.getILon();
+          input.selev = node.getSElev();
+          input.goodWay = node.message;
+          input.oldWay = node.message;
+          input.indexInTrack = nodes.size() - 1;
+          input.cmd = VoiceHint.END;
+        }
         VoiceHint input = new VoiceHint();
         inputs.add(input);
         input.ilat = node.origin.getILat();

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -592,8 +592,8 @@ public class RoutingEngine extends Thread {
       int startSize = matchedWaypoints.size();
       matchWaypointsToNodes(matchedWaypoints);
       if (startSize < matchedWaypoints.size()) {
-        refTracks = new OsmTrack[matchedWaypoints.size()]; // used ways for alternatives
-        lastTracks = new OsmTrack[matchedWaypoints.size()];
+        refTracks = new OsmTrack[matchedWaypoints.size()-1]; // used ways for alternatives
+        lastTracks = new OsmTrack[matchedWaypoints.size()-1];
         hasDirectRouting = true;
       }
 
@@ -624,9 +624,9 @@ public class RoutingEngine extends Thread {
         matchedWaypoints.add(nearbyTrack.endPoint);
       }
     } else {
-      if (lastTracks.length < matchedWaypoints.size()) {
-        refTracks = new OsmTrack[matchedWaypoints.size()]; // used ways for alternatives
-        lastTracks = new OsmTrack[matchedWaypoints.size()];
+      if (lastTracks.length < matchedWaypoints.size()-1) {
+        refTracks = new OsmTrack[matchedWaypoints.size()-1]; // used ways for alternatives
+        lastTracks = new OsmTrack[matchedWaypoints.size()-1];
         hasDirectRouting = true;
       }
     }

--- a/brouter-core/src/main/java/btools/router/VoiceHint.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHint.java
@@ -29,6 +29,8 @@ public class VoiceHint {
   static final int EL = 17; // exit left
   static final int ER = 18; // exit right
 
+  static final int END = 100; // end point
+
   int ilon;
   int ilat;
   short selev;
@@ -155,6 +157,8 @@ public class VoiceHint {
         return timode == 2 || timode == 9 ? "ER" : "KR";
       case OFFR:
         return "OFFR";
+      case END:
+        return "END";
       default:
         throw new IllegalArgumentException("unknown command: " + cmd);
     }

--- a/brouter-core/src/main/java/btools/router/VoiceHint.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHint.java
@@ -26,8 +26,8 @@ public class VoiceHint {
   static final int RNLB = 14; // Roundabout left
   static final int TU = 15; // 180 degree u-turn
   static final int BL = 16; // Beeline routing
-  static final int EL = 17; // Beeline routing
-  static final int ER = 18; // Beeline routing
+  static final int EL = 17; // exit left
+  static final int ER = 18; // exit right
 
   int ilon;
   int ilat;

--- a/brouter-core/src/main/java/btools/router/VoiceHint.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHint.java
@@ -26,6 +26,8 @@ public class VoiceHint {
   static final int RNLB = 14; // Roundabout left
   static final int TU = 15; // 180 degree u-turn
   static final int BL = 16; // Beeline routing
+  static final int EL = 17; // Beeline routing
+  static final int ER = 18; // Beeline routing
 
   int ilon;
   int ilat;
@@ -65,7 +67,7 @@ public class VoiceHint {
     badWays.add(badWay);
   }
 
-  public int getJsonCommandIndex() {
+  public int getJsonCommandIndex(int timode) {
     switch (cmd) {
       case TLU:
         return 10;
@@ -97,6 +99,10 @@ public class VoiceHint {
         return 14;
       case BL:
         return 16;
+      case EL:
+        return timode == 2 || timode == 9 ? 17 : 8;
+      case ER:
+        return timode == 2 || timode == 9 ? 18 : 9;
       case OFFR:
         return 12;
       default:
@@ -111,7 +117,7 @@ public class VoiceHint {
   /*
    * used by comment style, osmand style
    */
-  public String getCommandString() {
+  public String getCommandString(int timode) {
     switch (cmd) {
       case TLU:
         return "TU";  // should be changed to TLU when osmand uses new voice hint constants
@@ -143,6 +149,10 @@ public class VoiceHint {
         return "RNLB" + (-roundaboutExit);
       case BL:
         return "BL";
+      case EL:
+        return timode == 2 || timode == 9 ? "EL" : "KL";
+      case ER:
+        return timode == 2 || timode == 9 ? "ER" : "KR";
       case OFFR:
         return "OFFR";
       default:
@@ -153,7 +163,7 @@ public class VoiceHint {
   /*
    * used by trkpt/sym style
    */
-  public String getCommandString(int c) {
+  public String getCommandString(int c, int timode) {
     switch (c) {
       case TLU:
         return "TLU";
@@ -185,6 +195,10 @@ public class VoiceHint {
         return "RNLB" + (-roundaboutExit);
       case BL:
         return "BL";
+      case EL:
+        return timode == 2 || timode == 9 ? "EL" : "KL";
+      case ER:
+        return timode == 2 || timode == 9 ? "ER" : "KR";
       case OFFR:
         return "OFFR";
       default:
@@ -195,7 +209,7 @@ public class VoiceHint {
   /*
    * used by gpsies style
    */
-  public String getSymbolString() {
+  public String getSymbolString(int timode) {
     switch (cmd) {
       case TLU:
         return "TU";
@@ -227,6 +241,10 @@ public class VoiceHint {
         return "RNLB" + (-roundaboutExit);
       case BL:
         return "BL";
+      case EL:
+        return timode == 2 || timode == 9 ? "EL" : "KL";
+      case ER:
+        return timode == 2 || timode == 9 ? "ER" : "KR";
       case OFFR:
         return "OFFR";
       default:
@@ -269,6 +287,10 @@ public class VoiceHint {
         return "roundabout_e" + (-roundaboutExit);
       case BL:
         return "beeline";
+      case EL:
+        return "exit_left";
+      case ER:
+        return "exit_right";
       default:
         throw new IllegalArgumentException("unknown command: " + cmd);
     }
@@ -277,7 +299,7 @@ public class VoiceHint {
   /*
    * used by osmand style
    */
-  public String getMessageString() {
+  public String getMessageString(int timode) {
     switch (cmd) {
       case TLU:
         return "u-turn"; // should be changed to u-turn-left when osmand uses new voice hint constants
@@ -307,6 +329,10 @@ public class VoiceHint {
         return "Take exit " + roundaboutExit;
       case RNLB:
         return "Take exit " + (-roundaboutExit);
+      case EL:
+        return timode == 2 || timode == 9 ? "exit left" : "keep left";
+      case ER:
+        return timode == 2 || timode == 9 ? "exit right" : "keep right";
       default:
         throw new IllegalArgumentException("unknown command: " + cmd);
     }
@@ -345,6 +371,10 @@ public class VoiceHint {
         return 26 + roundaboutExit;
       case RNLB:
         return 26 - roundaboutExit;
+      case EL:
+        return 9;
+      case ER:
+        return 10;
       default:
         throw new IllegalArgumentException("unknown command: " + cmd);
     }
@@ -383,6 +413,10 @@ public class VoiceHint {
         return 1008 + roundaboutExit;
       case RNLB:
         return 1008 + roundaboutExit;
+      case EL:
+        return 1015;
+      case ER:
+        return 1014;
       default:
         throw new IllegalArgumentException("unknown command: " + cmd);
     }
@@ -423,6 +457,10 @@ public class VoiceHint {
         return "RNLB" + (-roundaboutExit);
       case BL:
         return "BL";
+      case EL:
+        return "EL";
+      case ER:
+        return "ER";
       case OFFR:
         return "OFFR";
       default:
@@ -465,6 +503,10 @@ public class VoiceHint {
         return "take exit " + (-roundaboutExit);
       case BL:
         return "beeline";
+      case EL:
+        return "exit left";
+      case ER:
+        return "exit right";
       case OFFR:
         return "offroad";
       default:

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -72,6 +72,12 @@ public final class VoiceHintProcessor {
         results.add(input);
         continue;
       }
+      if (hintIdx == 0) {
+        input.cmd = VoiceHint.END;
+        results.add(input);
+        continue;
+      }
+
       float turnAngle = input.goodWay.turnangle;
       distance += input.goodWay.linkdist;
       int currentPrio = input.goodWay.getPrio();
@@ -119,7 +125,7 @@ public final class VoiceHintProcessor {
         float tmpangle = 0;
         VoiceHint tmpRndAbt = new VoiceHint();
         tmpRndAbt.badWays = new ArrayList<>();
-        for (int i = hintIdx-1; i > roundaboudStartIdx; i--) {
+        for (int i = hintIdx - 1; i > roundaboudStartIdx; i--) {
           VoiceHint vh = inputs.get(i);
           tmpangle += inputs.get(i).goodWay.turnangle;
           if (vh.badWays != null) {
@@ -172,12 +178,14 @@ public final class VoiceHintProcessor {
           }
 
           if (badWay.isBadOneway()) {
-            if (minAbsAngeRaw == 180f) minAbsAngeRaw = turnAngle; // disable hasSomethingMoreStraight
+            if (minAbsAngeRaw == 180f)
+              minAbsAngeRaw = turnAngle; // disable hasSomethingMoreStraight
             continue; // ignore wrong oneways
           }
 
           if (Math.abs(badTurn) - Math.abs(turnAngle) > 80.f) {
-            if (minAbsAngeRaw == 180f) minAbsAngeRaw = turnAngle; // disable hasSomethingMoreStraight
+            if (minAbsAngeRaw == 180f)
+              minAbsAngeRaw = turnAngle; // disable hasSomethingMoreStraight
             continue; // ways from the back should not trigger a slight turn
           }
 
@@ -300,10 +308,12 @@ public final class VoiceHintProcessor {
       }
 
       if (nextInput == null) {
-        if ((input.cmd == VoiceHint.C ||
-             input.cmd == VoiceHint.KR ||
-             input.cmd == VoiceHint.KL)
-             && !input.goodWay.isLinktType()) {
+        if (input.cmd == VoiceHint.END) {
+          continue;
+        } else if ((input.cmd == VoiceHint.C ||
+          input.cmd == VoiceHint.KR ||
+          input.cmd == VoiceHint.KL)
+          && !input.goodWay.isLinktType()) {
           if (input.goodWay.getPrio() < input.maxBadPrio && (inputLastSaved != null && inputLastSaved.distanceToNext > catchingRange)) {
             results.add(input);
           } else {
@@ -318,14 +328,14 @@ public final class VoiceHintProcessor {
       } else {
         if ((inputLastSaved != null && inputLastSaved.distanceToNext > catchingRange) || input.distanceToNext > catchingRange) {
           if ((input.cmd == VoiceHint.C ||
-               input.cmd == VoiceHint.KR ||
-               input.cmd == VoiceHint.KL)
-               && !input.goodWay.isLinktType()) {
+            input.cmd == VoiceHint.KR ||
+            input.cmd == VoiceHint.KL)
+            && !input.goodWay.isLinktType()) {
             if (((Math.abs(input.lowerBadWayAngle) < 35.f ||
-                 input.higherBadWayAngle < 35.f)
-                 || input.goodWay.getPrio() < input.maxBadPrio)
-                 && (inputLastSaved != null && inputLastSaved.distanceToNext > minRange)
-                 && (input.distanceToNext > minRange)) {
+              input.higherBadWayAngle < 35.f)
+              || input.goodWay.getPrio() < input.maxBadPrio)
+              && (inputLastSaved != null && inputLastSaved.distanceToNext > minRange)
+              && (input.distanceToNext > minRange)) {
               // add only on prio
               results.add(input);
               inputLastSaved = input;
@@ -335,8 +345,8 @@ public final class VoiceHintProcessor {
               }
             }
           } else if ((input.goodWay.getPrio() == 29 && input.maxBadPrio == 30) &&
-                     ((hintIdx + 1 < inputs.size() && inputs.get(hintIdx+1).goodWay.getPrio() < 29) ||
-                      (hintIdx + 2 < inputs.size() && inputs.get(hintIdx+2).goodWay.getPrio() < 29))) {
+            checkForNextNoneMotorway(inputs, hintIdx, 3)
+          ) {
             // leave motorway
             if (input.cmd == VoiceHint.KR || input.cmd == VoiceHint.TSLR) {
               input.cmd = VoiceHint.ER;
@@ -349,10 +359,10 @@ public final class VoiceHintProcessor {
             // add all others
             // ignore motorway / primary continue
             if (((input.goodWay.getPrio() != 28) &&
-                (input.goodWay.getPrio() != 30) &&
-                (input.goodWay.getPrio() != 26))
-                || input.isRoundabout()
-                || Math.abs(input.angle) > 21.f) {
+              (input.goodWay.getPrio() != 30) &&
+              (input.goodWay.getPrio() != 26))
+              || input.isRoundabout()
+              || Math.abs(input.angle) > 21.f) {
               results.add(input);
               inputLastSaved = input;
             } else {
@@ -371,20 +381,20 @@ public final class VoiceHintProcessor {
           angles += nextInput.angle;
 
           if ((input.cmd == VoiceHint.C ||
-               input.cmd == VoiceHint.KR ||
-               input.cmd == VoiceHint.KL)
-               && !input.goodWay.isLinktType()) {
+            input.cmd == VoiceHint.KR ||
+            input.cmd == VoiceHint.KL)
+            && !input.goodWay.isLinktType()) {
             if (input.goodWay.getPrio() < input.maxBadPrio) {
               if (inputLastSaved != null && inputLastSaved.cmd != VoiceHint.C
-                  && (inputLastSaved != null && inputLastSaved.distanceToNext > minRange)
-                  && transportMode != VoiceHintList.TRANS_MODE_CAR) {
+                && (inputLastSaved != null && inputLastSaved.distanceToNext > minRange)
+                && transportMode != VoiceHintList.TRANS_MODE_CAR) {
                 // add when straight and not linktype
                 // and last vh not straight
                 save = true;
                 // remove when next straight and not linktype
                 if (nextInput != null &&
-                    nextInput.cmd == VoiceHint.C &&
-                    !nextInput.goodWay.isLinktType()) {
+                  nextInput.cmd == VoiceHint.C &&
+                  !nextInput.goodWay.isLinktType()) {
                   input.distanceToNext += nextInput.distanceToNext;
                   hintIdx++;
                 }
@@ -446,6 +456,15 @@ public final class VoiceHintProcessor {
     }
 
     return results;
+  }
+
+  boolean checkForNextNoneMotorway(List<VoiceHint> inputs, int offset, int testsize) {
+    for (int i = 1; i < testsize + 1 && offset + i < inputs.size(); i++) {
+      int prio = inputs.get(offset + i).goodWay.getPrio();
+      if (prio < 29) return true;
+      if (prio == 30) return false;
+    }
+    return false;
   }
 
 

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -334,6 +334,17 @@ public final class VoiceHintProcessor {
                 inputLastSaved.distanceToNext += input.distanceToNext;
               }
             }
+          } else if ((input.goodWay.getPrio() == 29 && input.maxBadPrio == 30) &&
+                     ((hintIdx + 1 < inputs.size() && inputs.get(hintIdx+1).goodWay.getPrio() < 29) ||
+                      (hintIdx + 2 < inputs.size() && inputs.get(hintIdx+2).goodWay.getPrio() < 29))) {
+            // leave motorway
+            if (input.cmd == VoiceHint.KR || input.cmd == VoiceHint.TSLR) {
+              input.cmd = VoiceHint.ER;
+            } else if (input.cmd == VoiceHint.KL || input.cmd == VoiceHint.TSLL) {
+              input.cmd = VoiceHint.EL;
+            }
+            results.add(input);
+            inputLastSaved = input;
           } else {
             // add all others
             // ignore motorway / primary continue
@@ -384,6 +395,14 @@ public final class VoiceHintProcessor {
                 inputLastSaved.distanceToNext += input.distanceToNext;
               }
             }
+          } else if ((input.goodWay.getPrio() == 29 && input.maxBadPrio == 30)) {
+            // leave motorway
+            if (input.cmd == VoiceHint.KR || input.cmd == VoiceHint.TSLR) {
+              input.cmd = VoiceHint.ER;
+            } else if (input.cmd == VoiceHint.KL || input.cmd == VoiceHint.TSLL) {
+              input.cmd = VoiceHint.EL;
+            }
+            save = true;
           } else if (VoiceHint.is180DegAngle(input.angle)) {
             // add u-turn, 180 degree
             save = true;

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -74,6 +74,7 @@ public final class VoiceHintProcessor {
       }
       if (hintIdx == 0) {
         input.cmd = VoiceHint.END;
+        input.distanceToNext = input.goodWay.linkdist;
         results.add(input);
         continue;
       }

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -29,7 +29,7 @@ public final class VoiceHintProcessor {
     float angle = 0.f;
     while (offset >= 0 && distance < range) {
       VoiceHint input = inputs.get(offset--);
-      if (input.turnAngleConsumed) {
+      if (input.turnAngleConsumed || input.cmd == VoiceHint.BL || input.cmd == VoiceHint.END) {
         break;
       }
       angle += input.goodWay.turnangle;
@@ -72,15 +72,10 @@ public final class VoiceHintProcessor {
         results.add(input);
         continue;
       }
-      if (hintIdx == 0) {
-        input.cmd = VoiceHint.END;
-        input.distanceToNext = input.goodWay.linkdist;
-        results.add(input);
-        continue;
-      }
 
       float turnAngle = input.goodWay.turnangle;
-      distance += input.goodWay.linkdist;
+      if (hintIdx != 0) distance += input.goodWay.linkdist;
+      //  System.out.println("range " + distance);
       int currentPrio = input.goodWay.getPrio();
       int oldPrio = input.oldWay.getPrio();
       int minPrio = Math.min(oldPrio, currentPrio);
@@ -259,6 +254,10 @@ public final class VoiceHintProcessor {
       VoiceHint hint = results.get(--i);
       if (hint.cmd == 0) {
         hint.calcCommand();
+      }
+      if (hint.cmd == VoiceHint.END) {
+        results2.add(hint);
+        continue;
       }
       if (!(hint.needsRealTurn && (hint.cmd == VoiceHint.C || hint.cmd == VoiceHint.BL))) {
         double dist = hint.distanceToNext;
@@ -454,6 +453,10 @@ public final class VoiceHintProcessor {
         }
       }
       inputLast = input;
+    }
+    if (results.size() > 0) {
+      // don't use END tag
+      if (results.get(results.size()-1).cmd == VoiceHint.END) results.remove(results.size()-1);
     }
 
     return results;

--- a/docs/features/voicehints.md
+++ b/docs/features/voicehints.md
@@ -25,6 +25,7 @@ And there are other rules
 * merge two hints when near to each other - e.g. left, left to u-turn left
 * marker when highway exit and continue nearly same direction
 * beeline goes direct from via to via point
+* junction on motorway via motorway_link and next way less then motorway_link is a motorway exit
 
 There are some variables in the profiles that affect on the voice hint generation:
 * considerTurnRestrictions -
@@ -51,4 +52,6 @@ Voice hint variables
 | RNDB     | roundabout |
 | RNLB     | roundabout left |
 | BL       | beeline routing |
+| EL       | exit left |
+| ER       | exit right |
 


### PR DESCRIPTION
This is the PR for #734

The problem with this new voicehints is, not all clients are ready for using.
First rule: the export contains what the clients can read. Means

- Locus already has this tags of Exit Left / Right
- all other become the old values - we can change later

For testing select you favorite turnInstructionMode.
Please use for a direct test export the button between close and export.
When using JSON export you could select `turnInstructionMode = 2` to get the new index.

For OsmAnd exists a special `turnInstructionMode = 8`. This is not reachable via the profile dialog, you have to set this inside the profile editor. It can be used to prepare OsmAnd to the new voicehints before BRouter delivers the new tags on `turnInstructionMode = 3`.

A Test is possible on the test server: [route](https://brouter.de/brouter-test/#map=12/53.3562/10.0729/osm-mapnik-german_style&lonlats=10.085098,53.311964;10.053516,53.390419&profile=car-fast) 

@devemux86 @vshcherb @vodie @menion
Please let us know when you change your rules in your apps, so we can go on to normalize the voicehint situation.
