### PR TITLE
Add functionality to list available profiles and download a single profile

### DIFF
--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.io.FileInputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -38,6 +39,7 @@ import btools.util.StackSampler;
 
 public class RouteServer extends Thread implements Comparable<RouteServer> {
   public static final String PROFILE_UPLOAD_URL = "/brouter/profile";
+  public static final String PROFILES_URL = "/brouter/getprofiles";
   static final String HTTP_STATUS_OK = "200 OK";
   static final String HTTP_STATUS_BAD_REQUEST = "400 Bad Request";
   static final String HTTP_STATUS_FORBIDDEN = "403 Forbidden";
@@ -180,6 +182,9 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
           bw.flush();
           return;
         }
+      } else if (url.startsWith(PROFILES_URL)) {
+        handleProfilesRequest(url, bw);
+        return;
       } else if (url.startsWith("/brouter/suspects")) {
         writeHttpHeader(bw, url.endsWith(".json") ? "application/json" : "text/html", HTTP_STATUS_OK);
         SuspectManager.process(url, bw);
@@ -278,6 +283,45 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
     }
   }
 
+  private void handleProfilesRequest(String url, BufferedWriter bw) throws IOException {
+    File profileDir = new File(serviceContext.profileDir);
+    File[] profiles = profileDir.listFiles((dir, name) -> name.endsWith(".brf"));
+    if (profiles == null) {
+      writeHttpHeader(bw, HTTP_STATUS_INTERNAL_SERVER_ERROR);
+      bw.write("Could not list profiles");
+      bw.flush();
+      return;
+    }
+
+    if (url.equals(PROFILES_URL)) {
+      writeHttpHeader(bw, "application/json", HTTP_STATUS_OK);
+      bw.write("[");
+      for (int i = 0; i < profiles.length; i++) {
+        if (i > 0) {
+          bw.write(",");
+        }
+        bw.write("\"" + profiles[i].getName() + "\"");
+      }
+      bw.write("]");
+    } else {
+      String profileName = url.substring(PROFILES_URL.length() + 1);
+      File profileFile = new File(profileDir, profileName);
+      if (!profileFile.exists() || !profileFile.isFile()) {
+        writeHttpHeader(bw, HTTP_STATUS_NOT_FOUND);
+        bw.write("Profile not found: " + profileName);
+      } else {
+        writeHttpHeader(bw, "text/plain", HTTP_STATUS_OK);
+        BufferedReader profileReader = new BufferedReader(new InputStreamReader(new FileInputStream(profileFile), "UTF-8"));
+        String line;
+        while ((line = profileReader.readLine()) != null) {
+          bw.write(line);
+          bw.write("\n");
+        }
+        profileReader.close();
+      }
+    }
+    bw.flush();
+  }
 
   public static void main(String[] args) throws Exception {
     System.out.println("BRouter " + OsmTrack.version + " / " + OsmTrack.versionDate);

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -11,6 +11,7 @@ import btools.router.OsmTrack;
 import btools.router.RoutingContext;
 import btools.server.ServiceContext;
 
+
 /**
  * URL query parameter handler for web and standalone server. Supports all
  * BRouter features without restrictions.
@@ -20,7 +21,7 @@ import btools.server.ServiceContext;
  * lonlats = lon,lat|... (unlimited list of lon,lat waypoints separated by |)
  * nogos = lon,lat,radius,weight|... (optional, list of lon, lat, radius in meters, weight (optional) separated by |)
  * polylines = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)
- * polygons        = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)
+ * polygons = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)
  * profile = profile file name without .brf
  * alternativeidx = [0|1|2|3] (optional, default 0)
  * format = [kml|gpx|geojson] (optional, default gpx)
@@ -31,10 +32,14 @@ import btools.server.ServiceContext;
  * heading = angle (optional to give a route a start direction)
  * profile:xxx = parameter in profile (optional)
  * straight = idx1,idx2,.. (optional, minimum one value, index of a direct routing point in the waypoint list)
+ * getprofiles = returns a list of available profiles in JSON format
+ * getprofiles/profilename = returns the content of the specified profile
  * <p>
  * Example URLs:
  * {@code http://localhost:17777/brouter?lonlats=8.799297,49.565883|8.811764,49.563606&nogos=&profile=trekking&alternativeidx=0&format=gpx}
  * {@code http://localhost:17777/brouter?lonlats=1.1,1.2|2.1,2.2|3.1,3.2|4.1,4.2&nogos=-1.1,-1.2,1|-2.1,-2.2,2&profile=shortest&alternativeidx=1&format=kml&trackname=Ride&pois=1.1,2.1,Barner Bar}
+ * {@code http://localhost:17777/brouter/getprofiles}
+ * {@code http://localhost:17777/brouter/getprofiles/trekking.brf}
  */
 public class ServerHandler extends RequestHandler {
 


### PR DESCRIPTION
This pull request adds new functionality to the BRouter server to support listing available profiles and downloading a single profile. it addresses: https://github.com/abrensch/brouter/issues/749

The following changes have been made:

**New Parameters:**

getprofiles: Returns a list of available profiles in JSON format.
getprofiles/profilename.brf: Returns the content of the specified profile.

**Updated Documentation:**

The README section in ServerHandler.java has been updated to include the new parameters and example URLs.

Example URLs:

List available profiles:
`http://localhost:17777/brouter/getprofiles`

Download a specific profile:
`http://localhost:17777/brouter/getprofiles/trekking.brf`


Please review the changes and let me know if there are any questions or further improvements needed.

Thank you!