### PR TITLE
Get elevation expanded, added get info

### DIFF
--- a/brouter-core/src/main/java/btools/router/FormatGpx.java
+++ b/brouter-core/src/main/java/btools/router/FormatGpx.java
@@ -197,10 +197,7 @@ public class FormatGpx extends Formatter {
 
     for (int i = 0; i <= t.pois.size() - 1; i++) {
       OsmNodeNamed poi = t.pois.get(i);
-      sb.append(" <wpt lon=\"").append(formatILon(poi.ilon)).append("\" lat=\"")
-        .append(formatILat(poi.ilat)).append("\">\n")
-        .append("  <name>").append(StringUtils.escapeXml10(poi.name)).append("</name>\n")
-        .append(" </wpt>\n");
+      formatWaypointGpx(sb, poi);
     }
 
     if (t.exportWaypoints) {

--- a/brouter-core/src/main/java/btools/router/FormatJson.java
+++ b/brouter-core/src/main/java/btools/router/FormatJson.java
@@ -130,8 +130,8 @@ public class FormatJson extends Formatter {
       sb.append("    },\n");
       for (int i = 0; i <= t.pois.size() - 1; i++) {
         OsmNodeNamed poi = t.pois.get(i);
-        addFeature(sb, "poi", poi.name, poi.ilat, poi.ilon);
-        if (i < t.matchedWaypoints.size() - 1) {
+        addFeature(sb, "poi", poi.name, poi.ilat, poi.ilon, poi.getSElev());
+        if (i < t.pois.size() - 1) {
           sb.append(",");
         }
         sb.append("    \n");
@@ -148,7 +148,7 @@ public class FormatJson extends Formatter {
           }
 
           MatchedWaypoint wp = t.matchedWaypoints.get(i);
-          addFeature(sb, type, wp.name, wp.waypoint.ilat, wp.waypoint.ilon);
+          addFeature(sb, type, wp.name, wp.waypoint.ilat, wp.waypoint.ilon, wp.waypoint.getSElev());
           if (i < t.matchedWaypoints.size() - 1) {
             sb.append(",");
           }
@@ -164,7 +164,7 @@ public class FormatJson extends Formatter {
     return sb.toString();
   }
 
-  private void addFeature(StringBuilder sb, String type, String name, int ilat, int ilon) {
+  private void addFeature(StringBuilder sb, String type, String name, int ilat, int ilon, short selev) {
     sb.append("    {\n");
     sb.append("      \"type\": \"Feature\",\n");
     sb.append("      \"properties\": {\n");
@@ -175,7 +175,7 @@ public class FormatJson extends Formatter {
     sb.append("        \"type\": \"Point\",\n");
     sb.append("        \"coordinates\": [\n");
     sb.append("          " + formatILon(ilon) + ",\n");
-    sb.append("          " + formatILat(ilat) + "\n");
+    sb.append("          " + formatILat(ilat) + (selev != Short.MIN_VALUE ? ",\n          " + selev / 4. : "") + "\n");
     sb.append("        ]\n");
     sb.append("      }\n");
     sb.append("    }");

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -172,8 +172,13 @@ public final class RoutingContext {
     useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 0f) == 1f;
 
     boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
-    if (!test) expctxGlobal.freeNoWays();
+    if (!test) freeNoWays();
 
+  }
+
+  public void freeNoWays() {
+    BExpressionContext expctxGlobal = expctxWay;
+    if (expctxGlobal != null) expctxGlobal.freeNoWays();
   }
 
   public List<OsmNodeNamed> poipoints;

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -327,6 +327,8 @@ public class RoutingEngine extends Thread {
     try {
       startTime = System.currentTimeMillis();
 
+      routingContext.freeNoWays();
+
       MatchedWaypoint wpt1 = new MatchedWaypoint();
       wpt1.waypoint = waypoints.get(0);
       wpt1.name = "wpt_info";

--- a/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
+++ b/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
@@ -35,7 +35,7 @@ interface IBRouterService {
     //  "timode"          = turnInstructionMode [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style] default 0
     //  "heading"         = angle (optional to give a route a start direction)
     //  "direction"       = angle (optional, used like "heading" on a recalculation request by Locus as start direction)
-    //  "engineMode"      = 0 (optional, default 0, 2 = get elevation)
+    //  "engineMode"      = 0 (optional, default 0, 2 = get elevation, 3 = get segment info)
 
     // return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
     //        the resultas string when 'pathToFileResult' is null, this should be default when Android Q or later

--- a/brouter-server/src/main/java/btools/server/BRouter.java
+++ b/brouter-server/src/main/java/btools/server/BRouter.java
@@ -102,7 +102,8 @@ public class BRouter {
     }
     try {
       RoutingEngine re = null;
-      if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETELEV) {
+      if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETELEV ||
+          engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETINFO) {
         re = new RoutingEngine("testinfo", null, new File(args[0]), wplist, rc, engineMode);
       } else {
         re = new RoutingEngine("testtrack", null, new File(args[0]), wplist, rc, engineMode);
@@ -111,7 +112,7 @@ public class BRouter {
     } catch (Exception e) {
       System.out.println(e.getMessage());
     }
-    
+
   }
 
 

--- a/docs/developers/android_service.md
+++ b/docs/developers/android_service.md
@@ -131,4 +131,8 @@ This suppress the first question after installation for the BRouter path, genera
 
 ### get elevation
 
-"engineMode=2" allows a client to only request an elevation for a point. This can be restricted with "waypointCatchingRange".
+"engineMode=2" allows a client to request only an elevation for a point. This can be restricted with "waypointCatchingRange".
+
+### get info
+
+"engineMode=3" allows a client to request the description tags for  a segment. This can be restricted with "waypointCatchingRange".


### PR DESCRIPTION
The elevation function to get an elevation for a single point wasn't ready in my eyes.
Previously, only the first and last points of a segment were used. This now changes by using all segment points and searching for the nearest one.

Additionally, the routine can also provide the segment info.

It is recommended to play with the profiles to get a desired segment information.

trekking.brf
![trekking](https://github.com/user-attachments/assets/29702dbf-436f-426c-8ad0-c83b75636638) 

car-eco.brf
![car](https://github.com/user-attachments/assets/e0b46667-bdeb-4c69-bdb1-2c65b8e4d35b)

