### PR TITLE
New Roundtrip function

### DIFF
--- a/brouter-core/src/main/java/btools/router/AreaInfo.java
+++ b/brouter-core/src/main/java/btools/router/AreaInfo.java
@@ -26,7 +26,7 @@ public class AreaInfo {
     direction = dir;
   }
 
-  void checkGreeness(BExpressionContext expctxWay, double elev, byte[] ab) {
+  void checkAreaInfo(BExpressionContext expctxWay, double elev, byte[] ab) {
     ways++;
 
     double test = elevStart - elev;
@@ -39,7 +39,7 @@ public class AreaInfo {
       greenWays++;
     }
 
-    if (numRiver != -1 && ld2[numForest] > 1) {
+    if (numRiver != -1 && ld2[numRiver] > 1) {
       riverWays++;
     }
 

--- a/brouter-core/src/main/java/btools/router/AreaInfo.java
+++ b/brouter-core/src/main/java/btools/router/AreaInfo.java
@@ -19,8 +19,6 @@ public class AreaInfo {
   public int riverWays = 0;
   public double elevStart = 0;
   public int elev50 = 0;
-  public int elev100 = 0;
-  public int elevMore = 0;
 
   public AreaInfo(int dir) {
     direction = dir;
@@ -43,7 +41,6 @@ public class AreaInfo {
       riverWays++;
     }
 
-
   }
 
   public int getElev50Weight() {
@@ -65,9 +62,9 @@ public class AreaInfo {
     StringBuilder sb = new StringBuilder();
     sb.append("Area ").append(direction).append(" ").append(elevStart).append("m ways ").append(ways);
     if (ways > 0) {
-      sb.append("\nArea ways <50m  " + elev50 + " " + getElev50Weight() + "%");
-      sb.append("\nArea ways green " + greenWays + " " + getGreen() + "% " /*+ (greenWaysWeight/greenWays)*/);
-      sb.append("\nArea ways river " + riverWays + " " + getRiver() + "% " /*+ (greenWaysWeight/greenWays)*/);
+      sb.append("\nArea ways <50m  ").append(elev50).append(" ").append(getElev50Weight()).append("%");
+      sb.append("\nArea ways green ").append(greenWays).append(" ").append(getGreen()).append("%");
+      sb.append("\nArea ways river ").append(riverWays).append(" ").append(getRiver()).append("%");
     }
     return sb.toString();
   }

--- a/brouter-core/src/main/java/btools/router/AreaInfo.java
+++ b/brouter-core/src/main/java/btools/router/AreaInfo.java
@@ -1,0 +1,74 @@
+package btools.router;
+
+import btools.expressions.BExpressionContext;
+
+public class AreaInfo {
+  final static int RESULT_TYPE_NONE = 0;
+  final static int RESULT_TYPE_ELEV50 = 1;
+  final static int RESULT_TYPE_GREEN = 4;
+  final static int RESULT_TYPE_RIVER = 5;
+
+  public int direction;
+  public int numForest = -1;
+  public int numRiver = -1;
+
+  public OsmNogoPolygon polygon;
+
+  public int ways = 0;
+  public int greenWays = 0;
+  public int riverWays = 0;
+  public double elevStart = 0;
+  public int elev50 = 0;
+  public int elev100 = 0;
+  public int elevMore = 0;
+
+  public AreaInfo(int dir) {
+    direction = dir;
+  }
+
+  void checkGreeness(BExpressionContext expctxWay, double elev, byte[] ab) {
+    ways++;
+
+    double test = elevStart - elev;
+    if (Math.abs(test) < 50) elev50++;
+
+    int[] ld2 = expctxWay.createNewLookupData();
+    expctxWay.decode(ld2, false, ab);
+
+    if (numForest != -1 && ld2[numForest] > 1) {
+      greenWays++;
+    }
+
+    if (numRiver != -1 && ld2[numForest] > 1) {
+      riverWays++;
+    }
+
+
+  }
+
+  public int getElev50Weight() {
+    if (ways == 0) return 0;
+    return (int) (elev50 * 100. / ways);
+  }
+
+  public int getGreen() {
+    if (ways == 0) return 0;
+    return (int) (greenWays * 100. / ways);
+  }
+
+  public int getRiver() {
+    if (ways == 0) return 0;
+    return (int) (riverWays * 100. / ways);
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Area ").append(direction).append(" ").append(elevStart).append("m ways ").append(ways);
+    if (ways > 0) {
+      sb.append("\nArea ways <50m  " + elev50 + " " + getElev50Weight() + "%");
+      sb.append("\nArea ways green " + greenWays + " " + getGreen() + "% " /*+ (greenWaysWeight/greenWays)*/);
+      sb.append("\nArea ways river " + riverWays + " " + getRiver() + "% " /*+ (greenWaysWeight/greenWays)*/);
+    }
+    return sb.toString();
+  }
+}

--- a/brouter-core/src/main/java/btools/router/AreaReader.java
+++ b/brouter-core/src/main/java/btools/router/AreaReader.java
@@ -135,7 +135,8 @@ public class AreaReader {
           used++;
       }
     } catch (Exception e) {
-      System.err.println(e.getMessage());
+      System.err.println("AreaReader: after " + used + "/" + count + " " + e.getMessage());
+      ais.clear();
     } finally {
       if (pf != null)
         try {
@@ -159,14 +160,14 @@ public class AreaReader {
       OsmFile osmf = new OsmFile(pf, lonDegree, latDegree, dataBuffers);
       if (osmf.hasData()) {
         int cellsize = 1000000 / div;
-        int tmplon = inlon; // + cellsize * idxLon;
-        int tmplat = inlat; // + cellsize * idxLat;
+        int tmplon = inlon;
+        int tmplat = inlat;
         int lonIdx = tmplon / cellsize;
         int latIdx = tmplat / cellsize;
 
         MicroCache segment = osmf.createMicroCache(lonIdx, latIdx, dataBuffers, expctxWay, null, true, null);
 
-        if (segment != null /*&& segment.getDataSize()>0*/) {
+        if (segment != null) {
           int size = segment.getSize();
           for (int i = 0; i < size; i++) {
             long id = segment.getIdForIndex(i);
@@ -196,8 +197,7 @@ public class AreaReader {
         return true;
       }
     } catch (Exception e) {
-      System.err.println(e.getMessage());
-    } finally {
+      System.err.println("AreaReader: " + e.getMessage());
     }
     return false;
   }
@@ -205,9 +205,8 @@ public class AreaReader {
   boolean ignoreCenter(int maxscale, int idxLon, int idxLat) {
     int centerScale = (int) Math.round(maxscale * .2) - 1;
     if (centerScale < 0) return false;
-    if (idxLon >= -centerScale && idxLon <= centerScale &&
-      idxLat >= -centerScale && idxLat <= centerScale) return true;
-    return false;
+    return idxLon >= -centerScale && idxLon <= centerScale &&
+      idxLat >= -centerScale && idxLat <= centerScale;
   }
 
   /*

--- a/brouter-core/src/main/java/btools/router/AreaReader.java
+++ b/brouter-core/src/main/java/btools/router/AreaReader.java
@@ -1,0 +1,161 @@
+package btools.router;
+
+import java.io.File;
+import java.util.List;
+
+import btools.codec.DataBuffers;
+import btools.codec.MicroCache;
+import btools.expressions.BExpressionContextWay;
+import btools.mapaccess.NodesCache;
+import btools.mapaccess.OsmFile;
+import btools.mapaccess.OsmLink;
+import btools.mapaccess.OsmNode;
+import btools.mapaccess.OsmNodesMap;
+import btools.mapaccess.PhysicalFile;
+
+public class AreaReader {
+
+  File segmentFolder;
+
+  public void getDirectAllData(File folder, RoutingContext rc, OsmNodeNamed wp, int maxscale, BExpressionContextWay expctxWay, OsmNogoPolygon searchRect, List<AreaInfo> ais) {
+    this.segmentFolder = folder;
+
+    int cellsize = 1000000 / 32;
+    int scale = maxscale;
+    int count = 0;
+    int used = 0;
+    for (int idxLat = -scale; idxLat <= scale; idxLat++) {
+      for (int idxLon = -scale; idxLon <= scale; idxLon++) {
+        int tmplon = wp.ilon + cellsize * idxLon;
+        int tmplat = wp.ilat + cellsize * idxLat;
+        if (getDirectData(tmplon, tmplat, rc, expctxWay, searchRect, ais)) used++;
+        count++;
+      }
+    }
+
+  }
+
+  public boolean getDirectData(int inlon, int inlat, RoutingContext rc, BExpressionContextWay expctxWay, OsmNogoPolygon searchRect, List<AreaInfo> ais) {
+    int lonDegree = inlon / 1000000;
+    int latDegree = inlat / 1000000;
+    int lonMod5 = (int) lonDegree % 5;
+    int latMod5 = (int) latDegree % 5;
+
+    int lon = (int) lonDegree - 180 - lonMod5;
+    String slon = lon < 0 ? "W" + (-lon) : "E" + lon;
+
+    int lat = (int) latDegree - 90 - latMod5;
+    String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
+    lon = 180000000 + (int) (lon * 1000000 + 0.5);
+    lat = 90000000 + (int) (lat * 1000000 + 0.5);
+
+    String filenameBase = slon + "_" + slat;
+
+    File file = new File(segmentFolder, filenameBase + ".rd5");
+    PhysicalFile pf = null;
+
+    long maxmem = rc.memoryclass * 1024L * 1024L; // in MB
+    NodesCache nodesCache = new NodesCache(segmentFolder, expctxWay, rc.forceSecondaryData, maxmem, null, false);
+
+    OsmNodesMap nodesMap = new OsmNodesMap();
+
+    try {
+
+      DataBuffers dataBuffers = new DataBuffers();
+      pf = new PhysicalFile(file, dataBuffers, -1, -1);
+      int div = pf.divisor;
+
+      OsmFile osmf = new OsmFile(pf, lonDegree, latDegree, dataBuffers);
+      if (osmf.hasData()) {
+        int cellsize = 1000000 / div;
+        int tmplon = inlon; // + cellsize * idxLon;
+        int tmplat = inlat; // + cellsize * idxLat;
+        int lonIdx = tmplon / cellsize;
+        int latIdx = tmplat / cellsize;
+        int subIdx = (latIdx - div * latDegree) * div + (lonIdx - div * lonDegree);
+
+        int subLonIdx = (lonIdx - div * lonDegree);
+        int subLatIdx = (latIdx - div * latDegree);
+
+        OsmNogoPolygon dataRect = new OsmNogoPolygon(true);
+        lon = lonDegree * 1000000;
+        lat = latDegree * 1000000;
+        int tmplon2 = lon + cellsize * (subLonIdx);
+        int tmplat2 = lat + cellsize * (subLatIdx);
+        dataRect.addVertex(tmplon2, tmplat2);
+
+        tmplon2 = lon + cellsize * (subLonIdx + 1);
+        tmplat2 = lat + cellsize * (subLatIdx);
+        dataRect.addVertex(tmplon2, tmplat2);
+
+        tmplon2 = lon + cellsize * (subLonIdx + 1);
+        tmplat2 = lat + cellsize * (subLatIdx + 1);
+        dataRect.addVertex(tmplon2, tmplat2);
+
+        tmplon2 = lon + cellsize * (subLonIdx);
+        tmplat2 = lat + cellsize * (subLatIdx + 1);
+        dataRect.addVertex(tmplon2, tmplat2);
+
+        boolean intersects = searchRect.intersects(dataRect.points.get(0).x, dataRect.points.get(0).y, dataRect.points.get(2).x, dataRect.points.get(2).y);
+        if (!intersects)
+          intersects = searchRect.intersects(dataRect.points.get(1).x, dataRect.points.get(1).y, dataRect.points.get(3).x, dataRect.points.get(3).y);
+        if (!intersects)
+          intersects = containsRect(searchRect, dataRect.points.get(0).x, dataRect.points.get(0).y, dataRect.points.get(2).x, dataRect.points.get(2).y);
+
+        if (!intersects) {
+          return false;
+        }
+
+        MicroCache segment = osmf.createMicroCache(lonIdx, latIdx, dataBuffers, expctxWay, null, true, null);
+
+        if (segment != null /*&& segment.getDataSize()>0*/) {
+          int size = segment.getSize();
+          for (int i = 0; i < size; i++) {
+            long id = segment.getIdForIndex(i);
+            OsmNode node = new OsmNode(id);
+            if (segment.getAndClear(id)) {
+              node.parseNodeBody(segment, nodesMap, expctxWay);
+              if (node.firstlink instanceof OsmLink) {
+                for (OsmLink link = node.firstlink; link != null; link = link.getNext(node)) {
+                  OsmNode nextNode = link.getTarget(node);
+                  if (nextNode.firstlink == null)
+                    continue; // don't care about dead ends
+                  if (nextNode.firstlink.descriptionBitmap == null)
+                    continue;
+
+                  for (AreaInfo ai : ais) {
+                    if (ai.polygon.isWithin(node.ilon, node.ilat)) {
+                      ai.checkAreaInfo(expctxWay, node.getElev(), nextNode.firstlink.descriptionBitmap);
+                      break;
+                    }
+                  }
+                  break;
+                }
+              }
+            }
+          }
+        }
+        return true;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      if (pf != null)
+        try {
+          pf.close();
+        } catch (Exception ee) {
+        }
+      nodesCache.close();
+      nodesCache = null;
+    }
+    return false;
+  }
+
+  /*
+    in this case the polygon is 'only' a rectangle
+  */
+  boolean containsRect(OsmNogoPolygon searchRect, int p1x, int p1y, int p2x, int p2y) {
+    return searchRect.isWithin((long) p1x, (long) p1y) &&
+      searchRect.isWithin(p2x, p2y);
+  }
+}

--- a/brouter-core/src/main/java/btools/router/AreaReader.java
+++ b/brouter-core/src/main/java/btools/router/AreaReader.java
@@ -8,7 +8,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import btools.codec.DataBuffers;
 import btools.codec.MicroCache;
@@ -28,57 +33,30 @@ public class AreaReader {
   public void getDirectAllData(File folder, RoutingContext rc, OsmNodeNamed wp, int maxscale, BExpressionContextWay expctxWay, OsmNogoPolygon searchRect, List<AreaInfo> ais) {
     this.segmentFolder = folder;
 
-    int cellsize = 1000000 / 32;
+    int div = 32;
+    int cellsize = 1000000 / div;
     int scale = maxscale;
     int count = 0;
     int used = 0;
+    boolean checkBorder = maxscale > 7;
+
+    Map<Long, String> tiles = new TreeMap<>();
     for (int idxLat = -scale; idxLat <= scale; idxLat++) {
       for (int idxLon = -scale; idxLon <= scale; idxLon++) {
         if (ignoreCenter(maxscale, idxLon, idxLat)) continue;
         int tmplon = wp.ilon + cellsize * idxLon;
         int tmplat = wp.ilat + cellsize * idxLat;
-        if (getDirectData(tmplon, tmplat, rc, expctxWay, searchRect, ais, maxscale > 7)) used++;
-        count++;
-      }
-    }
+        int lonDegree = tmplon / 1000000;
+        int latDegree = tmplat / 1000000;
+        int lonMod5 = (int) lonDegree % 5;
+        int latMod5 = (int) latDegree % 5;
 
-  }
+        int lon = (int) lonDegree - 180 - lonMod5;
+        String slon = lon < 0 ? "W" + (-lon) : "E" + lon;
+        int lat = (int) latDegree - 90 - latMod5;
+        String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
+        String filenameBase = slon + "_" + slat;
 
-  public boolean getDirectData(int inlon, int inlat, RoutingContext rc, BExpressionContextWay expctxWay, OsmNogoPolygon searchRect, List<AreaInfo> ais, boolean checkBorder) {
-    int lonDegree = inlon / 1000000;
-    int latDegree = inlat / 1000000;
-    int lonMod5 = (int) lonDegree % 5;
-    int latMod5 = (int) latDegree % 5;
-
-    int lon = (int) lonDegree - 180 - lonMod5;
-    String slon = lon < 0 ? "W" + (-lon) : "E" + lon;
-
-    int lat = (int) latDegree - 90 - latMod5;
-    String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
-    lon = 180000000 + (int) (lon * 1000000 + 0.5);
-    lat = 90000000 + (int) (lat * 1000000 + 0.5);
-
-    String filenameBase = slon + "_" + slat;
-
-    File file = new File(segmentFolder, filenameBase + ".rd5");
-    PhysicalFile pf = null;
-
-    long maxmem = rc.memoryclass * 1024L * 1024L; // in MB
-    NodesCache nodesCache = new NodesCache(segmentFolder, expctxWay, rc.forceSecondaryData, maxmem, null, false);
-
-    OsmNodesMap nodesMap = new OsmNodesMap();
-
-    try {
-
-      DataBuffers dataBuffers = new DataBuffers();
-      pf = new PhysicalFile(file, dataBuffers, -1, -1);
-      int div = pf.divisor;
-
-      OsmFile osmf = new OsmFile(pf, lonDegree, latDegree, dataBuffers);
-      if (osmf.hasData()) {
-        int cellsize = 1000000 / div;
-        int tmplon = inlon; // + cellsize * idxLon;
-        int tmplat = inlat; // + cellsize * idxLat;
         int lonIdx = tmplon / cellsize;
         int latIdx = tmplat / cellsize;
         int subIdx = (latIdx - div * latDegree) * div + (lonIdx - div * lonDegree);
@@ -105,13 +83,13 @@ public class AreaReader {
         tmplat2 = lat + cellsize * (subLatIdx + 1);
         dataRect.addVertex(tmplon2, tmplat2);
 
-        // check for quadrant border
         boolean intersects = checkBorder && dataRect.intersects(searchRect.points.get(0).x, searchRect.points.get(0).y, searchRect.points.get(2).x, searchRect.points.get(2).y);
         if (!intersects && checkBorder)
           intersects = dataRect.intersects(searchRect.points.get(1).x, searchRect.points.get(1).y, searchRect.points.get(2).x, searchRect.points.get(3).y);
         if (intersects) {
-          return false;
+          continue;
         }
+
         intersects = searchRect.intersects(dataRect.points.get(0).x, dataRect.points.get(0).y, dataRect.points.get(2).x, dataRect.points.get(2).y);
         if (!intersects)
           intersects = searchRect.intersects(dataRect.points.get(1).x, dataRect.points.get(1).y, dataRect.points.get(3).x, dataRect.points.get(3).y);
@@ -119,8 +97,72 @@ public class AreaReader {
           intersects = containsRect(searchRect, dataRect.points.get(0).x, dataRect.points.get(0).y, dataRect.points.get(2).x, dataRect.points.get(2).y);
 
         if (!intersects) {
-          return false;
+          continue;
         }
+
+        tiles.put(((long) tmplon) << 32 | tmplat, filenameBase);
+        count++;
+      }
+    }
+
+    List<Map.Entry<Long, String>> list = new ArrayList<>(tiles.entrySet());
+    Collections.sort(list, new Comparator<>() {
+      @Override
+      public int compare(Map.Entry<Long, String> e1, Map.Entry<Long, String> e2) {
+        return e1.getValue().compareTo(e2.getValue());
+      }
+    });
+
+    long maxmem = rc.memoryclass * 1024L * 1024L; // in MB
+    NodesCache nodesCache = new NodesCache(segmentFolder, expctxWay, rc.forceSecondaryData, maxmem, null, false);
+    PhysicalFile pf = null;
+    String lastFilenameBase = "";
+    DataBuffers dataBuffers = null;
+    try {
+      for (Map.Entry<Long, String> entry : list) {
+        OsmNode n = new OsmNode(entry.getKey());
+        // System.out.println("areareader set " + n.getILon() + "_" + n.getILat() + " " + entry.getValue());
+        String filenameBase = entry.getValue();
+        if (!filenameBase.equals(lastFilenameBase)) {
+          if (pf != null) pf.close();
+          lastFilenameBase = filenameBase;
+          File file = new File(segmentFolder, filenameBase + ".rd5");
+          dataBuffers = new DataBuffers();
+
+          pf = new PhysicalFile(file, dataBuffers, -1, -1);
+        }
+        if (getDirectData(pf, dataBuffers, n.getILon(), n.getILat(), rc, expctxWay, ais))
+          used++;
+      }
+    } catch (Exception e) {
+      System.err.println(e.getMessage());
+    } finally {
+      if (pf != null)
+        try {
+          pf.close();
+        } catch (Exception ee) {
+        }
+      nodesCache.close();
+    }
+  }
+
+  public boolean getDirectData(PhysicalFile pf, DataBuffers dataBuffers, int inlon, int inlat, RoutingContext rc, BExpressionContextWay expctxWay, List<AreaInfo> ais) {
+
+    int lonDegree = inlon / 1000000;
+    int latDegree = inlat / 1000000;
+
+    OsmNodesMap nodesMap = new OsmNodesMap();
+
+    try {
+      int div = pf.divisor;
+
+      OsmFile osmf = new OsmFile(pf, lonDegree, latDegree, dataBuffers);
+      if (osmf.hasData()) {
+        int cellsize = 1000000 / div;
+        int tmplon = inlon; // + cellsize * idxLon;
+        int tmplat = inlat; // + cellsize * idxLat;
+        int lonIdx = tmplon / cellsize;
+        int latIdx = tmplat / cellsize;
 
         MicroCache segment = osmf.createMicroCache(lonIdx, latIdx, dataBuffers, expctxWay, null, true, null);
 
@@ -154,15 +196,8 @@ public class AreaReader {
         return true;
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      System.err.println(e.getMessage());
     } finally {
-      if (pf != null)
-        try {
-          pf.close();
-        } catch (Exception ee) {
-        }
-      nodesCache.close();
-      nodesCache = null;
     }
     return false;
   }

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -141,6 +141,10 @@ abstract class OsmPath implements OsmLinkHolder {
     // evaluate the way tags
     rc.expctxWay.evaluate(rc.inverseDirection ^ isReverse, description);
 
+    // and check if is useful
+    if (rc.ai != null && rc.ai.polygon.isWithin(lon1, lat1)) {
+      rc.ai.checkAreaInfo(rc.expctxWay, ele1/4., description);
+    }
 
     // calculate the costfactor inputs
     float costfactor = rc.expctxWay.getCostfactor();

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -77,6 +77,7 @@ public final class RoutingContext {
   public boolean correctMisplacedViaPoints;
   public double correctMisplacedViaPointsDistance;
   public boolean useDynamicDistance;
+  public int roundTripPoints;
 
   private void setModel(String className) {
     if (className == null) {
@@ -170,6 +171,11 @@ public final class RoutingContext {
     bikerPower = expctxGlobal.getVariableValue("bikerPower", 100.f);
 
     useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 0f) == 1f;
+
+    roundTripPoints = (int) expctxGlobal.getVariableValue("roundTripPoints", 5.f);
+    if (roundTripPoints < 3 || roundTripPoints > 20) {
+      roundTripPoints = 5;
+    }
 
     boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
     if (!test) freeNoWays();

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -77,6 +77,7 @@ public final class RoutingContext {
   public boolean correctMisplacedViaPoints;
   public double correctMisplacedViaPointsDistance;
   public boolean useDynamicDistance;
+  public boolean buildBeelineOnRange;
 
   public AreaInfo ai;
 
@@ -171,7 +172,8 @@ public final class RoutingContext {
     // Constant power of the biker (in W)
     bikerPower = expctxGlobal.getVariableValue("bikerPower", 100.f);
 
-    useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 0f) == 1f;
+    useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 1f) == 1f;
+    buildBeelineOnRange = expctxGlobal.getVariableValue("add_beeline", 0f) == 1f;
 
     boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
     if (!test) freeNoWays();

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -193,8 +193,8 @@ public final class RoutingContext {
   public Integer startDirection;
   public boolean startDirectionValid;
   public boolean forceUseStartDirection;
-  public Integer roundtripDistance;
-  public Integer roundtripDirectionAdd;
+  public Integer roundTripDistance;
+  public Integer roundTripDirectionAdd;
   public Integer roundTripPoints;
   public boolean allowSamewayback;
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -191,6 +191,9 @@ public final class RoutingContext {
   public Integer startDirection;
   public boolean startDirectionValid;
   public boolean forceUseStartDirection;
+  public Integer roundtripDistance;
+  public Integer roundtripDirectionAdd;
+  public boolean allowSamewayback;
 
   public CheapAngleMeter anglemeter = new CheapAngleMeter();
 

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -36,6 +36,7 @@ public final class RoutingContext {
   public Map<String, String> keyValues;
 
   public String rawTrackPath;
+  public String rawAreaPath;
 
   public String getProfileName() {
     String name = localFunction == null ? "unknown" : localFunction;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -77,7 +77,6 @@ public final class RoutingContext {
   public boolean correctMisplacedViaPoints;
   public double correctMisplacedViaPointsDistance;
   public boolean useDynamicDistance;
-  public int roundTripPoints;
 
   private void setModel(String className) {
     if (className == null) {
@@ -172,11 +171,6 @@ public final class RoutingContext {
 
     useDynamicDistance = expctxGlobal.getVariableValue("use_dynamic_range", 0f) == 1f;
 
-    roundTripPoints = (int) expctxGlobal.getVariableValue("roundTripPoints", 5.f);
-    if (roundTripPoints < 3 || roundTripPoints > 20) {
-      roundTripPoints = 5;
-    }
-
     boolean test = expctxGlobal.getVariableValue("check_start_way", 1f) == 1f;
     if (!test) freeNoWays();
 
@@ -199,6 +193,7 @@ public final class RoutingContext {
   public boolean forceUseStartDirection;
   public Integer roundtripDistance;
   public Integer roundtripDirectionAdd;
+  public Integer roundTripPoints;
   public boolean allowSamewayback;
 
   public CheapAngleMeter anglemeter = new CheapAngleMeter();

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -78,6 +78,8 @@ public final class RoutingContext {
   public double correctMisplacedViaPointsDistance;
   public boolean useDynamicDistance;
 
+  public AreaInfo ai;
+
   private void setModel(String className) {
     if (className == null) {
       pm = new StdModel();
@@ -120,7 +122,7 @@ public final class RoutingContext {
     considerTurnRestrictions = 0.f != expctxGlobal.getVariableValue("considerTurnRestrictions", footMode ? 0.f : 1.f);
 
     correctMisplacedViaPoints = 0.f != expctxGlobal.getVariableValue("correctMisplacedViaPoints", 1.f);
-    correctMisplacedViaPointsDistance = expctxGlobal.getVariableValue("correctMisplacedViaPointsDistance", 40.f);
+    correctMisplacedViaPointsDistance = expctxGlobal.getVariableValue("correctMisplacedViaPointsDistance", 0.f); // 0 == don't use distance
 
     // process tags not used in the profile (to have them in the data-tab)
     processUnusedTags = 0.f != expctxGlobal.getVariableValue("processUnusedTags", 0.f);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -670,13 +670,25 @@ public class RoutingEngine extends Thread {
 
     switch (preferredRandomType) {
       case AreaInfo.RESULT_TYPE_ELEV50:
-        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getElev50Weight));
+        Collections.sort(ais, new Comparator<AreaInfo>() {
+          public int compare(AreaInfo o1, AreaInfo o2) {
+            return o2.getElev50Weight() - o1.getElev50Weight();
+          }
+        });
         break;
       case AreaInfo.RESULT_TYPE_GREEN:
-        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getGreen));
+        Collections.sort(ais, new Comparator<AreaInfo>() {
+          public int compare(AreaInfo o1, AreaInfo o2) {
+            return o2.getGreen() - o1.getGreen();
+          }
+        });
         break;
       case AreaInfo.RESULT_TYPE_RIVER:
-        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getRiver));
+        Collections.sort(ais, new Comparator<AreaInfo>() {
+          public int compare(AreaInfo o1, AreaInfo o2) {
+            return o2.getRiver() - o1.getRiver();
+          }
+        });
         break;
       default:
         return (int) (Math.random()*360);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -716,7 +716,7 @@ public class RoutingEngine extends Thread {
     }
 
     int angle = ais.get(0).direction;
-    return angle - 45 + (int) (Math.random()*90);
+    return angle - 30 + (int) (Math.random() * 60);
   }
 
   int getRandomDirectionFromRouting(OsmNodeNamed wp, double searchRadius) {

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1140,6 +1140,18 @@ public class RoutingEngine extends Thread {
       } else {
         seg = searchTrack(matchedWaypoints.get(i), matchedWaypoints.get(i + 1), i == matchedWaypoints.size() - 2 ? nearbyTrack : null, refTracks[i]);
         wptIndex = i;
+        if (engineMode == BROUTER_ENGINEMODE_ROUNDTRIP) {
+          if (i < matchedWaypoints.size() - 2) {
+            OsmNode lastPoint = seg.containsNode(matchedWaypoints.get(i+1).node1) ? matchedWaypoints.get(i+1).node1 : matchedWaypoints.get(i+1).node2;
+            OsmNodeNamed nogo = new OsmNodeNamed(lastPoint);
+            nogo.radius = 5;
+            nogo.name = "nogo" + (i+1);
+            nogo.nogoWeight = 9999.;
+            nogo.isNogo = true;
+            if (routingContext.nogopoints == null) routingContext.nogopoints = new ArrayList<>();
+            routingContext.nogopoints.add(nogo);
+          }
+        }
       }
       if (seg == null)
         return null;

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -669,13 +670,13 @@ public class RoutingEngine extends Thread {
 
     switch (preferredRandomType) {
       case AreaInfo.RESULT_TYPE_ELEV50:
-        ais.sort(Comparator.comparingInt(AreaInfo::getElev50Weight));
+        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getElev50Weight));
         break;
       case AreaInfo.RESULT_TYPE_GREEN:
-        ais.sort(Comparator.comparingInt(AreaInfo::getGreen));
+        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getGreen));
         break;
       case AreaInfo.RESULT_TYPE_RIVER:
-        ais.sort(Comparator.comparingInt(AreaInfo::getRiver));
+        Collections.sort(ais, Comparator.comparingInt(AreaInfo::getRiver));
         break;
       default:
         return (int) (Math.random()*360);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -50,7 +50,7 @@ public class RoutingEngine extends Thread {
 
   private int engineMode = 0;
 
-  private int MAX_STEPS_CHECK = 250;
+  private int MAX_STEPS_CHECK = 500;
 
   private int ROUNDTRIP_DEFAULT_DIRECTIONADD = 45;
 
@@ -205,15 +205,15 @@ public class RoutingEngine extends Thread {
           onn.name = "to";
           waypoints.add(onn);
         } else {
-          waypoints.get(waypoints.size()-1).name = "via" + (waypoints.size()-1) + "_center";
+          waypoints.get(waypoints.size() - 1).name = "via" + (waypoints.size() - 1) + "_center";
           List<OsmNodeNamed> newpoints = new ArrayList<>();
-          for (int i = waypoints.size()-2; i >= 0; i--) {
+          for (int i = waypoints.size() - 2; i >= 0; i--) {
             // System.out.println("back " + waypoints.get(i));
             OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(waypoints.get(i).ilon, waypoints.get(i).ilat));
             onn.name = "via";
             newpoints.add(onn);
           }
-          newpoints.get(newpoints.size()-1).name = "to";
+          newpoints.get(newpoints.size() - 1).name = "to";
           waypoints.addAll(newpoints);
         }
       }
@@ -405,24 +405,24 @@ public class RoutingEngine extends Thread {
           }
         }
         int otherIdx = 0;
-        if (minIdx == t.nodes.size()-1) {
-          otherIdx = minIdx-1;
+        if (minIdx == t.nodes.size() - 1) {
+          otherIdx = minIdx - 1;
         } else {
-          otherIdx = minIdx+1;
+          otherIdx = minIdx + 1;
         }
         int otherdist = t.nodes.get(otherIdx).calcDistance(listOne.get(0).crosspoint);
         int minSElev = t.nodes.get(minIdx).getSElev();
         int otherSElev = t.nodes.get(otherIdx).getSElev();
         int diffSElev = 0;
         diffSElev = otherSElev - minSElev;
-        double diff = (double) mindist/(mindist + otherdist) * diffSElev;
+        double diff = (double) mindist / (mindist + otherdist) * diffSElev;
 
 
         OsmNodeNamed n = new OsmNodeNamed(listOne.get(0).crosspoint);
         n.name = wpt1.name;
         n.selev = minIdx != -1 ? (short) (minSElev + (int) diff) : Short.MIN_VALUE;
         if (engineMode == BROUTER_ENGINEMODE_GETINFO) {
-          n.nodeDescription = (start1 != null && start1.firstlink!=null ? start1.firstlink.descriptionBitmap : null);
+          n.nodeDescription = (start1 != null && start1.firstlink != null ? start1.firstlink.descriptionBitmap : null);
           t.pois.add(n);
           //t.message = "get_info";
           //t.messageList.add(t.message);
@@ -484,10 +484,10 @@ public class RoutingEngine extends Thread {
       wpt1.name = "roundtrip";
 
       routingContext.useDynamicDistance = true;
-      double searchRadius = (routingContext.roundtripDistance == null ? 1500 :routingContext.roundtripDistance);
-      double direction = (routingContext.startDirection == null ? -1 :routingContext.startDirection);
-      if (direction == -1) direction = (int) (Math.random()*360);
-      double directionAdd = (routingContext.roundtripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD :routingContext.roundtripDirectionAdd);
+      double searchRadius = (routingContext.roundtripDistance == null ? 1500 : routingContext.roundtripDistance);
+      double direction = (routingContext.startDirection == null ? -1 : routingContext.startDirection);
+      if (direction == -1) direction = (int) (Math.random() * 360);
+      double directionAdd = (routingContext.roundtripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD : routingContext.roundtripDirectionAdd);
 
       if (routingContext.allowSamewayback) {
         int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, direction);
@@ -496,41 +496,11 @@ public class RoutingEngine extends Thread {
         wpt2.name = "rt1_" + direction;
 
         OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
-        onn.name = "via1";
+        onn.name = "rt1";
         waypoints.add(onn);
       } else {
-        int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, direction-directionAdd);
-        MatchedWaypoint wpt2 = new MatchedWaypoint();
-        wpt2.waypoint = new OsmNode(pos[0], pos[1]);
-        wpt2.name = "via1_" + (int) (direction-directionAdd);
-
-        OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
-        onn.name = "via1";
-        waypoints.add(onn);
-
-
-        pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, direction+directionAdd);
-        MatchedWaypoint wpt3 = new MatchedWaypoint();
-        wpt3.waypoint = new OsmNode(pos[0], pos[1]);
-        wpt3.name = "via2_" + (int) (direction+directionAdd);
-
-        onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
-        onn.name = "via2";
-        waypoints.add(onn);
-
-        pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius/2, direction);
-        OsmNodeNamed n = new OsmNodeNamed();
-        n.name = "nogo" + (int) (searchRadius/3);
-        n.ilon = pos[0];
-        n.ilat = pos[1];
-        n.isNogo = true;
-        n.radius = (int) (searchRadius/3);
-        n.nogoWeight = Double.NaN;
-        routingContext.setWaypoint(n, false);
-
-        onn = new OsmNodeNamed(waypoints.get(0));
-        onn.name = "to_rt";
-        waypoints.add(onn);
+        //buildPointsFromAngle(waypoints, direction, directionAdd, searchRadius, true);
+        buildPointsFromCircle(waypoints, direction, searchRadius, 5);
       }
 
       routingContext.waypointCatchingRange = 1000;
@@ -545,6 +515,50 @@ public class RoutingEngine extends Thread {
     }
 
   }
+
+  void buildPointsFromAngle(List<OsmNodeNamed> waypoints, double startAngle, double addAngle, double searchRadius, boolean withNogoCenter) {
+    int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, startAngle - addAngle);
+    OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
+    onn.name = "rt1";
+    waypoints.add(onn);
+
+    pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, startAngle + addAngle);
+    onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
+    onn.name = "rt2";
+    waypoints.add(onn);
+
+    onn = new OsmNodeNamed(waypoints.get(0));
+    onn.name = "to_rt";
+    waypoints.add(onn);
+
+    if (withNogoCenter) { // add a nogo area
+      pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius/2, startAngle);
+      OsmNodeNamed n = new OsmNodeNamed();
+      n.name = "nogo" + (int) (searchRadius/3);
+      n.ilon = pos[0];
+      n.ilat = pos[1];
+      n.isNogo = true;
+      n.radius = (int) (searchRadius/3);
+      n.nogoWeight = Double.NaN;
+      routingContext.setWaypoint(n, false);
+    }
+  }
+
+  void buildPointsFromCircle(List<OsmNodeNamed> waypoints, double startAngle, double searchRadius, int points) {
+    //startAngle -= 90;
+    for (int i = 1; i < points; i++) {
+      double anAngle = 90 - (180.0 * i / points);
+      int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, startAngle - anAngle);
+      OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
+      onn.name = "rt" + i;
+      waypoints.add(onn);
+    }
+
+    OsmNodeNamed onn = new OsmNodeNamed(waypoints.get(0));
+    onn.name = "to_rt";
+    waypoints.add(onn);
+  }
+
 
   private void postElevationCheck(OsmTrack track) {
     OsmPathElement lastPt = null;
@@ -738,21 +752,21 @@ public class RoutingEngine extends Thread {
       // add extra waypoints from the last broken round
       for (OsmNodeNamed wp : extraWaypoints) {
         if (wp.direct) hasDirectRouting = true;
-        if (wp.name.startsWith("from"))  {
+        if (wp.name.startsWith("from")) {
           waypoints.add(1, wp);
           waypoints.get(0).direct = true;
           nUnmatched++;
         } else {
-          waypoints.add(waypoints.size()-1, wp);
-          waypoints.get(waypoints.size()-2).direct = true;
+          waypoints.add(waypoints.size() - 1, wp);
+          waypoints.get(waypoints.size() - 2).direct = true;
           nUnmatched++;
         }
       }
       extraWaypoints = null;
     }
-    if (lastTracks.length < waypoints.size()-1) {
-      refTracks = new OsmTrack[waypoints.size()-1]; // used ways for alternatives
-      lastTracks = new OsmTrack[waypoints.size()-1];
+    if (lastTracks.length < waypoints.size() - 1) {
+      refTracks = new OsmTrack[waypoints.size() - 1]; // used ways for alternatives
+      lastTracks = new OsmTrack[waypoints.size() - 1];
       hasDirectRouting = true;
     }
     for (OsmNodeNamed wp : waypoints) {
@@ -787,13 +801,14 @@ public class RoutingEngine extends Thread {
       int startSize = matchedWaypoints.size();
       matchWaypointsToNodes(matchedWaypoints);
       if (startSize < matchedWaypoints.size()) {
-        refTracks = new OsmTrack[matchedWaypoints.size()-1]; // used ways for alternatives
-        lastTracks = new OsmTrack[matchedWaypoints.size()-1];
+        refTracks = new OsmTrack[matchedWaypoints.size() - 1]; // used ways for alternatives
+        lastTracks = new OsmTrack[matchedWaypoints.size() - 1];
         hasDirectRouting = true;
       }
 
       for (MatchedWaypoint mwp : matchedWaypoints) {
-        if (hasInfo() && matchedWaypoints.size() != nUnmatched) logInfo("new wp=" + mwp.waypoint + " "  + mwp.crosspoint + (mwp.direct ? " direct" : ""));
+        if (hasInfo() && matchedWaypoints.size() != nUnmatched)
+          logInfo("new wp=" + mwp.waypoint + " " + mwp.crosspoint + (mwp.direct ? " direct" : ""));
       }
 
       routingContext.checkMatchedWaypointAgainstNogos(matchedWaypoints);
@@ -823,9 +838,9 @@ public class RoutingEngine extends Thread {
         matchedWaypoints.add(nearbyTrack.endPoint);
       }
     } else {
-      if (lastTracks.length < matchedWaypoints.size()-1) {
-        refTracks = new OsmTrack[matchedWaypoints.size()-1]; // used ways for alternatives
-        lastTracks = new OsmTrack[matchedWaypoints.size()-1];
+      if (lastTracks.length < matchedWaypoints.size() - 1) {
+        refTracks = new OsmTrack[matchedWaypoints.size() - 1]; // used ways for alternatives
+        lastTracks = new OsmTrack[matchedWaypoints.size() - 1];
         hasDirectRouting = true;
       }
     }
@@ -884,7 +899,7 @@ public class RoutingEngine extends Thread {
 
   // check for way back on way point
   private boolean snappPathConnection(OsmTrack tt, OsmTrack t, MatchedWaypoint startWp) {
-    if (!startWp.name.startsWith("via"))
+    if (!startWp.name.startsWith("via") && !startWp.name.startsWith("rt"))
       return false;
 
     int ourSize = tt.nodes.size();
@@ -977,7 +992,7 @@ public class RoutingEngine extends Thread {
         indexfore++;
 
         if (routingContext.correctMisplacedViaPointsDistance > 0 &&
-            wayDistance > routingContext.correctMisplacedViaPointsDistance) break;
+          wayDistance > routingContext.correctMisplacedViaPointsDistance) break;
       }
 
 
@@ -1188,7 +1203,8 @@ public class RoutingEngine extends Thread {
       range = -MAX_DYNAMIC_RANGE;
       List<MatchedWaypoint> tmp = new ArrayList<>();
       for (MatchedWaypoint mwp : unmatchedWaypoints) {
-        if (mwp.crosspoint == null || mwp.radius >= routingContext.waypointCatchingRange) tmp.add(mwp);
+        if (mwp.crosspoint == null || mwp.radius >= routingContext.waypointCatchingRange)
+          tmp.add(mwp);
       }
       ok = nodesCache.matchWaypointsToNodes(tmp, range, islandNodePairs);
     }
@@ -1199,56 +1215,53 @@ public class RoutingEngine extends Thread {
       }
     }
     // add beeline points when not already done
-    if (useDynamicDistance && !useNodePoints) {
+    if (useDynamicDistance && !useNodePoints && engineMode != BROUTER_ENGINEMODE_ROUNDTRIP) {
       List<MatchedWaypoint> waypoints = new ArrayList<>();
       for (int i = 0; i < unmatchedWaypoints.size(); i++) {
         MatchedWaypoint wp = unmatchedWaypoints.get(i);
         if (wp.waypoint.calcDistance(wp.crosspoint) > routingContext.waypointCatchingRange) {
-          if (engineMode != BROUTER_ENGINEMODE_ROUNDTRIP) {
-            MatchedWaypoint nmw = new MatchedWaypoint();
-            if (i == 0) {
-              OsmNodeNamed onn = new OsmNodeNamed(wp.waypoint);
-              onn.name = "from";
-              nmw.waypoint = onn;
-              nmw.name = onn.name;
-              nmw.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
-              nmw.direct = true;
-              onn = new OsmNodeNamed(wp.crosspoint);
-              onn.name = wp.name + "_add";
-              wp.waypoint = onn;
-              waypoints.add(nmw);
-              wp.name = wp.name + "_add";
-              waypoints.add(wp);
-            } else {
-              OsmNodeNamed onn = new OsmNodeNamed(wp.crosspoint);
-              onn.name = wp.name + "_add";
-              nmw.waypoint = onn;
-              nmw.crosspoint = new OsmNode(wp.crosspoint.ilon, wp.crosspoint.ilat);
-              nmw.node1 = new OsmNode(wp.node1.ilon, wp.node1.ilat);
-              nmw.node2 = new OsmNode(wp.node2.ilon, wp.node2.ilat);
-              nmw.direct = true;
 
-              if (wp.name != null) nmw.name = wp.name;
-              waypoints.add(nmw);
-              wp.name = wp.name + "_add";
-              waypoints.add(wp);
-              if (wp.name.startsWith("via")) {
-                wp.direct = true;
-                MatchedWaypoint emw = new MatchedWaypoint();
-                OsmNodeNamed onn2 = new OsmNodeNamed(wp.crosspoint);
-                onn2.name = wp.name + "_2";
-                emw.name = onn2.name;
-                emw.waypoint = onn2;
-                emw.crosspoint = new OsmNode(nmw.crosspoint.ilon, nmw.crosspoint.ilat);
-                emw.node1 = new OsmNode(nmw.node1.ilon, nmw.node1.ilat);
-                emw.node2 = new OsmNode(nmw.node2.ilon, nmw.node2.ilat);
-                emw.direct = false;
-                waypoints.add(emw);
-              }
-              wp.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
-            }
-          } else {
+          MatchedWaypoint nmw = new MatchedWaypoint();
+          if (i == 0) {
+            OsmNodeNamed onn = new OsmNodeNamed(wp.waypoint);
+            onn.name = "from";
+            nmw.waypoint = onn;
+            nmw.name = onn.name;
+            nmw.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
+            nmw.direct = true;
+            onn = new OsmNodeNamed(wp.crosspoint);
+            onn.name = wp.name + "_add";
+            wp.waypoint = onn;
+            waypoints.add(nmw);
+            wp.name = wp.name + "_add";
             waypoints.add(wp);
+          } else {
+            OsmNodeNamed onn = new OsmNodeNamed(wp.crosspoint);
+            onn.name = wp.name + "_add";
+            nmw.waypoint = onn;
+            nmw.crosspoint = new OsmNode(wp.crosspoint.ilon, wp.crosspoint.ilat);
+            nmw.node1 = new OsmNode(wp.node1.ilon, wp.node1.ilat);
+            nmw.node2 = new OsmNode(wp.node2.ilon, wp.node2.ilat);
+            nmw.direct = true;
+
+            if (wp.name != null) nmw.name = wp.name;
+            waypoints.add(nmw);
+            wp.name = wp.name + "_add";
+            waypoints.add(wp);
+            if (wp.name.startsWith("via")) {
+              wp.direct = true;
+              MatchedWaypoint emw = new MatchedWaypoint();
+              OsmNodeNamed onn2 = new OsmNodeNamed(wp.crosspoint);
+              onn2.name = wp.name + "_2";
+              emw.name = onn2.name;
+              emw.waypoint = onn2;
+              emw.crosspoint = new OsmNode(nmw.crosspoint.ilon, nmw.crosspoint.ilat);
+              emw.node1 = new OsmNode(nmw.node1.ilon, nmw.node1.ilat);
+              emw.node2 = new OsmNode(nmw.node2.ilon, nmw.node2.ilat);
+              emw.direct = false;
+              waypoints.add(emw);
+            }
+            wp.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
           }
         } else {
           waypoints.add(wp);
@@ -1257,6 +1270,16 @@ public class RoutingEngine extends Thread {
       unmatchedWaypoints.clear();
       unmatchedWaypoints.addAll(waypoints);
     }
+
+    // round trip cross point to way point
+    if (engineMode == BROUTER_ENGINEMODE_ROUNDTRIP) {
+      for (int i = 1; i < unmatchedWaypoints.size()-1; i++) {
+        MatchedWaypoint wp = unmatchedWaypoints.get(i);
+        wp.waypoint.ilon = wp.crosspoint.ilon;
+        wp.waypoint.ilat = wp.crosspoint.ilat;
+      }
+    }
+
   }
 
   private OsmTrack searchTrack(MatchedWaypoint startWp, MatchedWaypoint endWp, OsmTrack nearbyTrack, OsmTrack refTrack) {

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1473,6 +1473,7 @@ public class RoutingEngine extends Thread {
   private void matchWaypointsToNodes(List<MatchedWaypoint> unmatchedWaypoints) {
     resetCache(false);
     boolean useDynamicDistance = routingContext.useDynamicDistance;
+    boolean bAddBeeline = routingContext.buildBeelineOnRange;
     double range = routingContext.waypointCatchingRange;
     boolean ok = nodesCache.matchWaypointsToNodes(unmatchedWaypoints, range, islandNodePairs);
     if (!ok && useDynamicDistance) {
@@ -1493,7 +1494,7 @@ public class RoutingEngine extends Thread {
       }
     }
     // add beeline points when not already done
-    if (useDynamicDistance && !useNodePoints && engineMode != BROUTER_ENGINEMODE_ROUNDTRIP) {
+    if (useDynamicDistance && !useNodePoints && bAddBeeline) {
       List<MatchedWaypoint> waypoints = new ArrayList<>();
       for (int i = 0; i < unmatchedWaypoints.size(); i++) {
         MatchedWaypoint wp = unmatchedWaypoints.get(i);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -606,7 +606,9 @@ public class RoutingEngine extends Thread {
 
     RoutingEngine re = null;
     RoutingContext rc = new RoutingContext();
-    rc.localFunction = "dummy";
+    String name = routingContext.localFunction;
+    int idx = name.lastIndexOf(File.separator);
+    rc.localFunction = idx == -1 ? "dummy" : name.substring(0, idx+1) + "dummy.brf";
 
     re = new RoutingEngine(null, null, segmentDir, wpliststart, rc, BROUTER_ENGINEMODE_ROUNDTRIP);
     rc.useDynamicDistance = true;
@@ -746,7 +748,9 @@ public class RoutingEngine extends Thread {
 
     RoutingEngine re = null;
     RoutingContext rc = new RoutingContext();
-    rc.localFunction = "dummy";
+    String name = routingContext.localFunction;
+    int idx = name.lastIndexOf(File.separator);
+    rc.localFunction = idx == -1 ? "dummy" : name.substring(0, idx+1) + "dummy.brf";
 
     re = new RoutingEngine(null, null, segmentDir, wpliststart, rc, BROUTER_ENGINEMODE_ROUNDTRIP);
     rc.useDynamicDistance = true;

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -489,9 +489,9 @@ public class RoutingEngine extends Thread {
       wpt1.name = "roundtrip";
 
       routingContext.useDynamicDistance = true;
-      double searchRadius = (routingContext.roundtripDistance == null ? 1500 : routingContext.roundtripDistance);
+      double searchRadius = (routingContext.roundTripDistance == null ? 1500 : routingContext.roundTripDistance);
       double direction = (routingContext.startDirection == null ? -1 : routingContext.startDirection);
-      double directionAdd = (routingContext.roundtripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD : routingContext.roundtripDirectionAdd);
+      double directionAdd = (routingContext.roundTripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD : routingContext.roundTripDirectionAdd);
       if (direction == -1) direction = getRandomDirectionByRouting(waypoints.get(0), searchRadius);
 
       if (routingContext.allowSamewayback) {

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -203,7 +203,6 @@ public class RoutingEngine extends Thread {
         if (waypoints.size() == 2) {
           OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(waypoints.get(0).ilon, waypoints.get(0).ilat));
           onn.name = "to";
-          onn.radius = 1000;
           waypoints.add(onn);
         } else {
           waypoints.get(waypoints.size()-1).name = "via" + (waypoints.size()-1) + "_center";
@@ -212,7 +211,6 @@ public class RoutingEngine extends Thread {
             // System.out.println("back " + waypoints.get(i));
             OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(waypoints.get(i).ilon, waypoints.get(i).ilat));
             onn.name = "via";
-            onn.radius = 1000;
             newpoints.add(onn);
           }
           newpoints.get(newpoints.size()-1).name = "to";
@@ -499,7 +497,6 @@ public class RoutingEngine extends Thread {
 
         OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
         onn.name = "via1";
-        onn.radius = 1000;
         waypoints.add(onn);
       } else {
         int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, direction-directionAdd);
@@ -509,7 +506,6 @@ public class RoutingEngine extends Thread {
 
         OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
         onn.name = "via1";
-        onn.radius = 1000;
         waypoints.add(onn);
 
 
@@ -520,7 +516,6 @@ public class RoutingEngine extends Thread {
 
         onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
         onn.name = "via2";
-        onn.radius = 1000;
         waypoints.add(onn);
 
         pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius/2, direction);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1204,49 +1204,52 @@ public class RoutingEngine extends Thread {
       for (int i = 0; i < unmatchedWaypoints.size(); i++) {
         MatchedWaypoint wp = unmatchedWaypoints.get(i);
         if (wp.waypoint.calcDistance(wp.crosspoint) > routingContext.waypointCatchingRange) {
-          MatchedWaypoint nmw = new MatchedWaypoint();
-          if (i == 0) {
-            OsmNodeNamed onn = new OsmNodeNamed(wp.waypoint);
-            onn.name = "from";
-            nmw.waypoint = onn;
-            nmw.name = onn.name;
-            nmw.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
-            nmw.direct = true;
-            onn = new OsmNodeNamed(wp.crosspoint);
-            onn.name = wp.name + "_add";
-            wp.waypoint = onn;
-            waypoints.add(nmw);
-            wp.name = wp.name + "_add";
-            waypoints.add(wp);
-          } else {
-            OsmNodeNamed onn = new OsmNodeNamed(wp.crosspoint);
-            onn.name = wp.name + "_add";
-            nmw.waypoint = onn;
-            nmw.crosspoint = new OsmNode(wp.crosspoint.ilon, wp.crosspoint.ilat);
-            nmw.node1 = new OsmNode(wp.node1.ilon, wp.node1.ilat);
-            nmw.node2 = new OsmNode(wp.node2.ilon, wp.node2.ilat);
-            nmw.direct = true;
+          if (engineMode != BROUTER_ENGINEMODE_ROUNDTRIP) {
+            MatchedWaypoint nmw = new MatchedWaypoint();
+            if (i == 0) {
+              OsmNodeNamed onn = new OsmNodeNamed(wp.waypoint);
+              onn.name = "from";
+              nmw.waypoint = onn;
+              nmw.name = onn.name;
+              nmw.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
+              nmw.direct = true;
+              onn = new OsmNodeNamed(wp.crosspoint);
+              onn.name = wp.name + "_add";
+              wp.waypoint = onn;
+              waypoints.add(nmw);
+              wp.name = wp.name + "_add";
+              waypoints.add(wp);
+            } else {
+              OsmNodeNamed onn = new OsmNodeNamed(wp.crosspoint);
+              onn.name = wp.name + "_add";
+              nmw.waypoint = onn;
+              nmw.crosspoint = new OsmNode(wp.crosspoint.ilon, wp.crosspoint.ilat);
+              nmw.node1 = new OsmNode(wp.node1.ilon, wp.node1.ilat);
+              nmw.node2 = new OsmNode(wp.node2.ilon, wp.node2.ilat);
+              nmw.direct = true;
 
-            if (wp.name != null) nmw.name = wp.name;
-            waypoints.add(nmw);
-            wp.name = wp.name + "_add";
-            waypoints.add(wp);
-            if (wp.name.startsWith("via")) {
-              wp.direct = true;
-              MatchedWaypoint emw = new MatchedWaypoint();
-              OsmNodeNamed onn2 = new OsmNodeNamed(wp.crosspoint);
-              onn2.name = wp.name + "_2";
-              emw.name = onn2.name;
-              emw.waypoint = onn2;
-              emw.crosspoint = new OsmNode(nmw.crosspoint.ilon, nmw.crosspoint.ilat);
-              emw.node1 = new OsmNode(nmw.node1.ilon, nmw.node1.ilat);
-              emw.node2 = new OsmNode(nmw.node2.ilon, nmw.node2.ilat);
-              emw.direct = false;
-              waypoints.add(emw);
+              if (wp.name != null) nmw.name = wp.name;
+              waypoints.add(nmw);
+              wp.name = wp.name + "_add";
+              waypoints.add(wp);
+              if (wp.name.startsWith("via")) {
+                wp.direct = true;
+                MatchedWaypoint emw = new MatchedWaypoint();
+                OsmNodeNamed onn2 = new OsmNodeNamed(wp.crosspoint);
+                onn2.name = wp.name + "_2";
+                emw.name = onn2.name;
+                emw.waypoint = onn2;
+                emw.crosspoint = new OsmNode(nmw.crosspoint.ilon, nmw.crosspoint.ilat);
+                emw.node1 = new OsmNode(nmw.node1.ilon, nmw.node1.ilat);
+                emw.node2 = new OsmNode(nmw.node2.ilon, nmw.node2.ilat);
+                emw.direct = false;
+                waypoints.add(emw);
+              }
+              wp.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
             }
-            wp.crosspoint = new OsmNode(wp.waypoint.ilon, wp.waypoint.ilat);
+          } else {
+            waypoints.add(wp);
           }
-
         } else {
           waypoints.add(wp);
         }

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -670,21 +670,21 @@ public class RoutingEngine extends Thread {
 
     switch (preferredRandomType) {
       case AreaInfo.RESULT_TYPE_ELEV50:
-        Collections.sort(ais, new Comparator<AreaInfo>() {
+        Collections.sort(ais, new Comparator<>() {
           public int compare(AreaInfo o1, AreaInfo o2) {
             return o2.getElev50Weight() - o1.getElev50Weight();
           }
         });
         break;
       case AreaInfo.RESULT_TYPE_GREEN:
-        Collections.sort(ais, new Comparator<AreaInfo>() {
+        Collections.sort(ais, new Comparator<>() {
           public int compare(AreaInfo o1, AreaInfo o2) {
             return o2.getGreen() - o1.getGreen();
           }
         });
         break;
       case AreaInfo.RESULT_TYPE_RIVER:
-        Collections.sort(ais, new Comparator<AreaInfo>() {
+        Collections.sort(ais, new Comparator<>() {
           public int compare(AreaInfo o1, AreaInfo o2) {
             return o2.getRiver() - o1.getRiver();
           }

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -500,7 +500,7 @@ public class RoutingEngine extends Thread {
         waypoints.add(onn);
       } else {
         //buildPointsFromAngle(waypoints, direction, directionAdd, searchRadius, true);
-        buildPointsFromCircle(waypoints, direction, searchRadius, 5);
+        buildPointsFromCircle(waypoints, direction, searchRadius, routingContext.roundTripPoints);
       }
 
       routingContext.waypointCatchingRange = 1000;

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -202,10 +202,10 @@ public class RoutingParamCollector {
           rctx.forceUseStartDirection = true;
         } else if (key.equals("direction")) {
           rctx.startDirection = Integer.valueOf(value);
-        } else if (key.equals("roundtripDistance")) {
-          rctx.roundtripDistance = Integer.valueOf(value);
-        } else if (key.equals("roundtripDirectionAdd")) {
-          rctx.roundtripDirectionAdd = Integer.valueOf(value);
+        } else if (key.equals("roundTripDistance")) {
+          rctx.roundTripDistance = Integer.valueOf(value);
+        } else if (key.equals("roundTripDirectionAdd")) {
+          rctx.roundTripDirectionAdd = Integer.valueOf(value);
         } else if (key.equals("roundTripPoints")) {
           rctx.roundTripPoints = Integer.valueOf(value);
           if (rctx.roundTripPoints == null || rctx.roundTripPoints < 3 || rctx.roundTripPoints > 20) {

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -202,6 +202,12 @@ public class RoutingParamCollector {
           rctx.forceUseStartDirection = true;
         } else if (key.equals("direction")) {
           rctx.startDirection = Integer.valueOf(value);
+        } else if (key.equals("roundtripDistance")) {
+          rctx.roundtripDistance = Integer.valueOf(value);
+        } else if (key.equals("roundtripDirectionAdd")) {
+          rctx.roundtripDirectionAdd = Integer.valueOf(value);
+        } else if (key.equals("allowSamewayback")) {
+          rctx.allowSamewayback = Integer.parseInt(value)==1;
         } else if (key.equals("alternativeidx")) {
           rctx.setAlternativeIdx(Integer.parseInt(value));
         } else if (key.equals("turnInstructionMode")) {

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -206,6 +206,11 @@ public class RoutingParamCollector {
           rctx.roundtripDistance = Integer.valueOf(value);
         } else if (key.equals("roundtripDirectionAdd")) {
           rctx.roundtripDirectionAdd = Integer.valueOf(value);
+        } else if (key.equals("roundTripPoints")) {
+          rctx.roundTripPoints = Integer.valueOf(value);
+          if (rctx.roundTripPoints == null || rctx.roundTripPoints < 3 || rctx.roundTripPoints > 20) {
+            rctx.roundTripPoints = 5;
+          }
         } else if (key.equals("allowSamewayback")) {
           rctx.allowSamewayback = Integer.parseInt(value)==1;
         } else if (key.equals("alternativeidx")) {

--- a/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
+++ b/brouter-core/src/test/java/btools/router/OsmNodeNamedTest.java
@@ -1,6 +1,7 @@
 package btools.router;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -109,5 +110,23 @@ public class OsmNodeNamedTest {
       node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
       0.1 * 5
     );
+  }
+
+  @Test
+  public void testDestination() {
+    // Segment ends
+    int lon1, lat1, lon2, lat2;
+    // Circle definition
+    OsmNodeNamed node = new OsmNodeNamed();
+    // Center
+    node.ilon = toOsmLon(0);
+    node.ilat = toOsmLat(0);
+    double startDist = 1000;
+
+    for (int i = 0; i <= 360; i += 45) {
+      int[] pos = CheapRuler.destination(node.ilon, node.ilat, startDist, i);
+      double dist = CheapRuler.distance(node.ilon, node.ilat, pos[0], pos[1]);
+      assertTrue("pos " + pos[0] + " " + pos[1] + " distance (" + dist + ") should be around (" + startDist + ")", dist -1 < startDist && dist +1 > startDist);
+    }
   }
 }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/OsmFile.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/OsmFile.java
@@ -17,7 +17,7 @@ import btools.codec.WaypointMatcher;
 import btools.util.ByteDataReader;
 import btools.util.Crc32;
 
-final class OsmFile {
+final public class OsmFile {
   private RandomAccessFile is = null;
   private long fileOffset;
 

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/PhysicalFile.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/PhysicalFile.java
@@ -143,4 +143,14 @@ final public class PhysicalFile {
       elevationType = dis.readByte();
     } catch (Exception e) {}
   }
+
+  public void close(){
+    if (ra != null) {
+      try {
+        ra.close();
+      } catch (Exception ee) {
+      }
+    }
+  }
+
 }

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterService.java
@@ -64,7 +64,8 @@ public class BRouterService extends Service {
       worker.segmentDir = new File(baseDir, "brouter/segments4");
       String errMsg = null;
 
-      if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING) {
+      if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
+          engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
         String remoteProfile = params.getString("remoteProfile", null);
 
         if (remoteProfile == null) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -136,7 +136,8 @@ public class BRouterWorker {
     cr.quite = true;
     cr.doRun(maxRunningTime);
 
-    if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING) {
+    if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
+        engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
       // store new reference track if any
       // (can exist for timed-out search)
       if (cr.getFoundRawTrack() != null) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -46,7 +46,7 @@ public class BRouterWorker {
 
     RoutingContext rc = new RoutingContext();
     rc.rawTrackPath = rawTrackPath;
-    rc.rawAreaPath = rawTrackPath.substring(0, rawTrackPath.lastIndexOf(File.separator)+1) + "rawAreaInfo.dat";
+    rc.rawAreaPath = (rawTrackPath != null ? rawTrackPath.substring(0, rawTrackPath.lastIndexOf(File.separator)+1) + "rawAreaInfo.dat" : null);
     rc.localFunction = profilePath;
 
     RoutingParamCollector routingParamCollector = new RoutingParamCollector();

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -46,6 +46,7 @@ public class BRouterWorker {
 
     RoutingContext rc = new RoutingContext();
     rc.rawTrackPath = rawTrackPath;
+    rc.rawAreaPath = rawTrackPath.substring(0, rawTrackPath.lastIndexOf(File.separator)+1) + "rawAreaInfo.dat";
     rc.localFunction = profilePath;
 
     RoutingParamCollector routingParamCollector = new RoutingParamCollector();

--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -222,7 +222,8 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
         }
         String headers = encodings == null || encodings.indexOf("gzip") < 0 ? null : "Content-Encoding: gzip\n";
         writeHttpHeader(bw, handler.getMimeType(), handler.getFileName(), headers, HTTP_STATUS_OK);
-        if (engineMode == 0) {
+        if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
+            engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
           if (track != null) {
             if (headers != null) { // compressed
               ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -235,7 +236,8 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
               bw.write(handler.formatTrack(track));
             }
           }
-        } else if (engineMode == 2) {
+        } else if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETELEV ||
+                   engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETINFO) {
           String s = cr.getFoundInfo();
           if (s != null) {
             bw.write(s);

--- a/brouter-util/src/main/java/btools/util/CheapRuler.java
+++ b/brouter-util/src/main/java/btools/util/CheapRuler.java
@@ -77,4 +77,21 @@ public final class CheapRuler {
     double dlat = (ilat1 - ilat2) * kxky[1];
     return Math.sqrt(dlat * dlat + dlon * dlon); // in m
   }
+
+  public static int[] destination(int lon1, int lat1, double distance, double angle) {
+
+    double[] lonlat2m = getLonLatToMeterScales(lat1);
+    double lon2m = lonlat2m[0];
+    double lat2m = lonlat2m[1];
+    angle = 90. - angle;
+    double st = Math.sin(angle * Math.PI / 180.);
+    double ct = Math.cos(angle * Math.PI / 180.);
+
+    int lon2 = (int) (0.5 + lon1 + ct * distance / lon2m);
+    int lat2 = (int) (0.5 + lat1 + st * distance / lat2m);
+    int[] ret = new int[2];
+    ret[0] = lon2;
+    ret[1] = lat2;
+    return ret;
+  }
 }


### PR DESCRIPTION
Here comes the new engineMode for roundtrips.

Parameters to play with:

direction - angle around start point (default random)
roundtripDistance - distance from start point (default 1500m)
roundtripDirectionAdd - changes the angle added to the direction (default 20 degrees)
allowSamewayback - go back the same way (default false)

exportWaypoints - export the generated points (default false)
profile:correctMisplacedViaPoints - correct the results (default false)
profile:correctMisplacedViaPointsDistance - distance for correction,  0 = don'r check distance (default 40m)

some samples:

direction = 90
![90](https://github.com/user-attachments/assets/39ce1520-8794-443b-9d92-79a5c6acdcb6)

direction 360 correctMisplacedViaPoints off
![360_nosnap](https://github.com/user-attachments/assets/f41f5de8-a767-41d0-ac3a-26e55a8297e0)

direction 360, correctMisplacedViaPoints on
![360_snap](https://github.com/user-attachments/assets/5f9c5d15-9ae8-47f0-a50b-5ade808da2c6)

direction 180 roundtripDirectionAdd 45deg
![180_45](https://github.com/user-attachments/assets/df731273-d5b5-4877-9b01-ff9400d5f50b)

direction 360 allowSamewayback true
![360_back](https://github.com/user-attachments/assets/a3f8e75f-cc19-4f59-848c-d2d10cfe25e6)
