### PR TITLE
Protect routing on empty way description.

### DIFF
--- a/brouter-core/src/main/java/btools/router/KinematicPrePath.java
+++ b/brouter-core/src/main/java/btools/router/KinematicPrePath.java
@@ -15,7 +15,10 @@ final class KinematicPrePath extends OsmPrePath {
 
   protected void initPrePath(OsmPath origin, RoutingContext rc) {
     byte[] description = link.descriptionBitmap;
-    if (description == null) throw new IllegalArgumentException("null description for: " + link);
+    if (description == null) {
+      //throw new IllegalArgumentException("null description for: " + link);
+      description = (targetNode.descriptionBitmap != null ? targetNode.descriptionBitmap : new byte[] {0, 1, 0});
+    }
 
     // extract the 3 positions of the first section
     int lon0 = origin.originLon;


### PR DESCRIPTION
From time to time there occurs a way description exception on car routing. 

But I had only one example on this - near the tile borders.
Please let us know if you find one, message text is

`null description for: n_xy
`