### PR TITLE
Added a switch to avoid u-turns

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -77,6 +77,7 @@ public final class RoutingContext {
   public double waypointCatchingRange;
   public boolean correctMisplacedViaPoints;
   public double correctMisplacedViaPointsDistance;
+  public boolean continueStraight;
   public boolean useDynamicDistance;
   public boolean buildBeelineOnRange;
 
@@ -125,6 +126,8 @@ public final class RoutingContext {
 
     correctMisplacedViaPoints = 0.f != expctxGlobal.getVariableValue("correctMisplacedViaPoints", 1.f);
     correctMisplacedViaPointsDistance = expctxGlobal.getVariableValue("correctMisplacedViaPointsDistance", 0.f); // 0 == don't use distance
+
+    continueStraight = 0.f != expctxGlobal.getVariableValue("continueStraight", 0.f);
 
     // process tags not used in the profile (to have them in the data-tab)
     processUnusedTags = 0.f != expctxGlobal.getVariableValue("processUnusedTags", 0.f);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -995,7 +995,7 @@ public class RoutingEngine extends Thread {
       } else {
         seg = searchTrack(matchedWaypoints.get(i), matchedWaypoints.get(i + 1), i == matchedWaypoints.size() - 2 ? nearbyTrack : null, refTracks[i]);
         wptIndex = i;
-        if (engineMode == BROUTER_ENGINEMODE_ROUNDTRIP) {
+        if (routingContext.continueStraight) {
           if (i < matchedWaypoints.size() - 2) {
             OsmNode lastPoint = seg.containsNode(matchedWaypoints.get(i+1).node1) ? matchedWaypoints.get(i+1).node1 : matchedWaypoints.get(i+1).node2;
             OsmNodeNamed nogo = new OsmNodeNamed(lastPoint);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1137,7 +1137,12 @@ public class RoutingEngine extends Thread {
         indexfore++;
 
         if (routingContext.correctMisplacedViaPointsDistance > 0 &&
-          wayDistance > routingContext.correctMisplacedViaPointsDistance) break;
+          wayDistance > routingContext.correctMisplacedViaPointsDistance) {
+          removeVoiceHintList.clear();
+          removeBackList.clear();
+          removeForeList.clear();
+          return false;
+        }
       }
 
 


### PR DESCRIPTION
As discussed in #773, here comes the change.

It could be activated by `profile:continueStraight=1` or `assign continueStraight = true`.

The default is false.
For round trips this was the default setting, but now you can decide.
