### PR TITLE
RFC7230 compliant HTTP header delimiter

### DIFF
--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -160,8 +160,8 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
       } else if (url.startsWith(PROFILE_UPLOAD_URL)) {
         if (getline.startsWith("OPTIONS")) {
           // handle CORS preflight request (Safari)
-          String corsHeaders = "Access-Control-Allow-Methods: GET, POST\n"
-            + "Access-Control-Allow-Headers: Content-Type\n";
+          String corsHeaders = "Access-Control-Allow-Methods: GET, POST\r\n"
+            + "Access-Control-Allow-Headers: Content-Type\r\n";
           writeHttpHeader(bw, "text/plain", null, corsHeaders, HTTP_STATUS_OK);
           bw.flush();
           return;
@@ -220,7 +220,7 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
           // no zip for this engineMode
           encodings = null;
         }
-        String headers = encodings == null || encodings.indexOf("gzip") < 0 ? null : "Content-Encoding: gzip\n";
+        String headers = encodings == null || encodings.indexOf("gzip") < 0 ? null : "Content-Encoding: gzip\r\n";
         writeHttpHeader(bw, handler.getMimeType(), handler.getFileName(), headers, HTTP_STATUS_OK);
         if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
             engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
@@ -407,17 +407,17 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
 
   private static void writeHttpHeader(BufferedWriter bw, String mimeType, String fileName, String headers, String status) throws IOException {
     // http-header
-    bw.write(String.format("HTTP/1.1 %s\n", status));
-    bw.write("Connection: close\n");
-    bw.write("Content-Type: " + mimeType + "; charset=utf-8\n");
+    bw.write(String.format("HTTP/1.1 %s\r\n", status));
+    bw.write("Connection: close\r\n");
+    bw.write("Content-Type: " + mimeType + "; charset=utf-8\r\n");
     if (fileName != null) {
-      bw.write("Content-Disposition: attachment; filename=\"" + fileName + "\"\n");
+      bw.write("Content-Disposition: attachment; filename=\"" + fileName + "\"\r\n");
     }
-    bw.write("Access-Control-Allow-Origin: *\n");
+    bw.write("Access-Control-Allow-Origin: *\r\n");
     if (headers != null) {
       bw.write(headers);
     }
-    bw.write("\n");
+    bw.write("\r\n");
   }
 
   private static void cleanupThreadQueue(Queue<RouteServer> threadQueue) {


### PR DESCRIPTION
I stumbled upon on this issue while using Brouter for routing in my personal project.

Some background:

I have a web frontend that I'm locally serving from [Parcel's](https://parceljs.org/) dev server. To make requests to Brouter, I'm using a proxy feature of the dev server to forward certain requests to a locally running Brouter.

For a while, I was stumped by an error while trying to forward requests to Brouter:

```
[HPM] Error occurred while proxying request localhost:1234/brouter?lonlats=.......&format=geojson&profile=safety to http://localhost:17777/ [HPE_INVALID_HEADER_TOKEN] (https://nodejs.org/api/errors.html#errors_common_system_errors)
```

Turns out the proxy middleware it is utilizing does not like that headers are separated by just `LF`. By changing headers endings to `CRLF`, it starts working just fine.

I imagine most recipients accept just `LF` but RFC7230 states that `CRLF` is the delimiter for headers: https://datatracker.ietf.org/doc/html/rfc7230#section-3

If needed, I can construct an example of this specific case.