### PR TITLE
Added export for corrected Via Points

### DIFF
--- a/brouter-core/src/main/java/btools/router/FormatGpx.java
+++ b/brouter-core/src/main/java/btools/router/FormatGpx.java
@@ -197,25 +197,28 @@ public class FormatGpx extends Formatter {
 
     for (int i = 0; i <= t.pois.size() - 1; i++) {
       OsmNodeNamed poi = t.pois.get(i);
-      formatWaypointGpx(sb, poi);
+      formatWaypointGpx(sb, poi, "poi");
     }
 
     if (t.exportWaypoints) {
       for (int i = 0; i <= t.matchedWaypoints.size() - 1; i++) {
         MatchedWaypoint wt = t.matchedWaypoints.get(i);
-        sb.append(" <wpt lon=\"").append(formatILon(wt.waypoint.ilon)).append("\" lat=\"")
-          .append(formatILat(wt.waypoint.ilat)).append("\">\n")
-          .append("  <name>").append(StringUtils.escapeXml10(wt.name)).append("</name>\n");
         if (i == 0) {
-          sb.append("  <type>from</type>\n");
+          formatWaypointGpx(sb, wt, "from");
         } else if (i == t.matchedWaypoints.size() - 1) {
-          sb.append("  <type>to</type>\n");
+          formatWaypointGpx(sb, wt, "to");
         } else {
-          sb.append("  <type>via</type>\n");
+          formatWaypointGpx(sb, wt, "via");
         }
-        sb.append(" </wpt>\n");
       }
     }
+    if (t.exportCorrectedWaypoints && t.correctedWaypoints != null) {
+      for (int i = 0; i <= t.correctedWaypoints.size() - 1; i++) {
+        OsmNodeNamed n = t.correctedWaypoints.get(i);
+        formatWaypointGpx(sb, n, "via_corr");
+      }
+    }
+
     sb.append(" <trk>\n");
     if (turnInstructionMode == 9
       || turnInstructionMode == 2
@@ -454,7 +457,7 @@ public class FormatGpx extends Formatter {
       StringWriter sw = new StringWriter(8192);
       BufferedWriter bw = new BufferedWriter(sw);
       formatGpxHeader(bw);
-      formatWaypointGpx(bw, n);
+      formatWaypointGpx(bw, n, null);
       formatGpxFooter(bw);
       bw.close();
       sw.close();
@@ -477,7 +480,7 @@ public class FormatGpx extends Formatter {
     sb.append("</gpx>\n");
   }
 
-  public void formatWaypointGpx(BufferedWriter sb, OsmNodeNamed n) throws IOException {
+  public void formatWaypointGpx(BufferedWriter sb, OsmNodeNamed n, String type) throws IOException {
     sb.append(" <wpt lon=\"").append(formatILon(n.ilon)).append("\" lat=\"")
       .append(formatILat(n.ilat)).append("\">");
     if (n.getSElev() != Short.MIN_VALUE) {
@@ -488,6 +491,24 @@ public class FormatGpx extends Formatter {
     }
     if (n.nodeDescription != null && rc != null) {
       sb.append("<desc>").append(rc.expctxWay.getKeyValueDescription(false, n.nodeDescription)).append("</desc>");
+    }
+    if (type != null) {
+      sb.append("<type>").append(type).append("</type>");
+    }
+    sb.append("</wpt>\n");
+  }
+
+  public void formatWaypointGpx(BufferedWriter sb, MatchedWaypoint wp, String type) throws IOException {
+    sb.append(" <wpt lon=\"").append(formatILon(wp.waypoint.ilon)).append("\" lat=\"")
+      .append(formatILat(wp.waypoint.ilat)).append("\">");
+    if (wp.waypoint.getSElev() != Short.MIN_VALUE) {
+      sb.append("<ele>").append("" + wp.waypoint.getElev()).append("</ele>");
+    }
+    if (wp.name != null) {
+      sb.append("<name>").append(StringUtils.escapeXml10(wp.name)).append("</name>");
+    }
+    if (type != null) {
+      sb.append("<type>").append(type).append("</type>");
     }
     sb.append("</wpt>\n");
   }

--- a/brouter-core/src/main/java/btools/router/FormatJson.java
+++ b/brouter-core/src/main/java/btools/router/FormatJson.java
@@ -126,7 +126,7 @@ public class FormatJson extends Formatter {
 
     sb.append("        ]\n");
     sb.append("      }\n");
-    if (t.exportWaypoints || !t.pois.isEmpty()) {
+    if (t.exportWaypoints || t.exportCorrectedWaypoints || !t.pois.isEmpty()) {
       sb.append("    },\n");
       for (int i = 0; i <= t.pois.size() - 1; i++) {
         OsmNodeNamed poi = t.pois.get(i);
@@ -137,6 +137,7 @@ public class FormatJson extends Formatter {
         sb.append("    \n");
       }
       if (t.exportWaypoints) {
+        if (!t.pois.isEmpty()) sb.append("    ,\n");
         for (int i = 0; i <= t.matchedWaypoints.size() - 1; i++) {
           String type;
           if (i == 0) {
@@ -150,6 +151,19 @@ public class FormatJson extends Formatter {
           MatchedWaypoint wp = t.matchedWaypoints.get(i);
           addFeature(sb, type, wp.name, wp.waypoint.ilat, wp.waypoint.ilon, wp.waypoint.getSElev());
           if (i < t.matchedWaypoints.size() - 1) {
+            sb.append(",");
+          }
+          sb.append("    \n");
+        }
+      }
+      if (t.exportCorrectedWaypoints) {
+        if (t.exportWaypoints) sb.append("    ,\n");
+        for (int i = 0; i <= t.correctedWaypoints.size() - 1; i++) {
+          String type = "via_corr";
+
+          OsmNodeNamed wp = t.correctedWaypoints.get(i);
+          addFeature(sb, type, wp.name, wp.ilat, wp.ilon, wp.getSElev());
+          if (i < t.correctedWaypoints.size() - 1) {
             sb.append(",");
           }
           sb.append("    \n");

--- a/brouter-core/src/main/java/btools/router/FormatKml.java
+++ b/brouter-core/src/main/java/btools/router/FormatKml.java
@@ -43,7 +43,7 @@ public class FormatKml extends Formatter {
     sb.append("        </LineString>\n");
     sb.append("      </Placemark>\n");
     sb.append("    </Folder>\n");
-    if (t.exportWaypoints || !t.pois.isEmpty()) {
+    if (t.exportWaypoints || t.exportCorrectedWaypoints || !t.pois.isEmpty()) {
       if (!t.pois.isEmpty()) {
         sb.append("    <Folder>\n");
         sb.append("      <name>poi</name>\n");
@@ -62,6 +62,10 @@ public class FormatKml extends Formatter {
         }
         createFolder(sb, "end", t.matchedWaypoints.subList(size - 1, size));
       }
+      if (t.exportCorrectedWaypoints) {
+        int size = t.correctedWaypoints.size();
+        createViaFolder(sb, "via_cor", t.correctedWaypoints.subList(0, size));
+      }
     }
     sb.append("  </Document>\n");
     sb.append("</kml>\n");
@@ -75,6 +79,16 @@ public class FormatKml extends Formatter {
     for (int i = 0; i < waypoints.size(); i++) {
       MatchedWaypoint wp = waypoints.get(i);
       createPlaceMark(sb, wp.name, wp.waypoint.ilat, wp.waypoint.ilon);
+    }
+    sb.append("    </Folder>\n");
+  }
+
+  private void createViaFolder(StringBuilder sb, String type, List<OsmNodeNamed> waypoints) {
+    sb.append("    <Folder>\n");
+    sb.append("      <name>" + type + "</name>\n");
+    for (int i = 0; i < waypoints.size(); i++) {
+      OsmNodeNamed wp = waypoints.get(i);
+      createPlaceMark(sb, wp.name, wp.ilat, wp.ilon);
     }
     sb.append("    </Folder>\n");
   }

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -61,7 +61,9 @@ public final class OsmTrack {
   public String name = "unset";
 
   protected List<MatchedWaypoint> matchedWaypoints;
+  protected List<OsmNodeNamed> correctedWaypoints;
   public boolean exportWaypoints = false;
+  public boolean exportCorrectedWaypoints = false;
 
   public void addNode(OsmPathElement node) {
     nodes.add(0, node);

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -221,6 +221,7 @@ public final class RoutingContext {
 
   public String outputFormat = "gpx";
   public boolean exportWaypoints = false;
+  public boolean exportCorrectedWaypoints = false;
 
   public OsmPrePath firstPrePath;
 

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -41,6 +41,7 @@ public class RoutingEngine extends Thread {
   private boolean finished = false;
 
   protected List<OsmNodeNamed> waypoints = null;
+  protected List<OsmNodeNamed> correctedWaypoints = null;
   List<OsmNodeNamed> extraWaypoints = null;
   protected List<MatchedWaypoint> matchedWaypoints;
   private int linksProcessed = 0;
@@ -262,6 +263,7 @@ public class RoutingEngine extends Thread {
           }
           oldTrack = null;
           track.exportWaypoints = routingContext.exportWaypoints;
+          track.exportCorrectedWaypoints = routingContext.exportCorrectedWaypoints;
           filename = outfileBase + i + "." + routingContext.outputFormat;
           switch (routingContext.outputFormat) {
             case "gpx":
@@ -975,6 +977,10 @@ public class RoutingEngine extends Thread {
         hasDirectRouting = true;
       }
     }
+    for (MatchedWaypoint mwp : matchedWaypoints) {
+      //System.out.println(FormatGpx.getWaypoint(mwp.waypoint.ilon, mwp.waypoint.ilat, mwp.name, null));
+      //System.out.println(FormatGpx.getWaypoint(mwp.crosspoint.ilon, mwp.crosspoint.ilat, mwp.name+"_cp", null));
+    }
 
     routingContext.hasDirectRouting = hasDirectRouting;
 
@@ -1030,6 +1036,7 @@ public class RoutingEngine extends Thread {
 
     matchedWaypoints.get(matchedWaypoints.size() - 1).indexInTrack = totaltrack.nodes.size() - 1;
     totaltrack.matchedWaypoints = matchedWaypoints;
+    totaltrack.correctedWaypoints = correctedWaypoints;
     totaltrack.processVoiceHints(routingContext);
     totaltrack.prepareSpeedProfile(routingContext);
 
@@ -1182,6 +1189,13 @@ public class RoutingEngine extends Thread {
       newTarget = t.nodes.get(1);
 
       setNewVoiceHint(t, last, lastJunctions, newJunction, newTarget);
+
+      if (correctedWaypoints == null) correctedWaypoints = new ArrayList<>();
+      OsmNodeNamed n = new OsmNodeNamed();
+      n.ilon = newJunction.getILon();
+      n.ilat = newJunction.getILat();
+      n.name = startWp.name + "_corr";
+      correctedWaypoints.add(n);
 
       return true;
     }

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -227,6 +227,8 @@ public class RoutingParamCollector {
           }
         } else if (key.equals("exportWaypoints")) {
           rctx.exportWaypoints = (Integer.parseInt(value) == 1);
+        } else if (key.equals("exportCorrectedWaypoints")) {
+          rctx.exportCorrectedWaypoints = (Integer.parseInt(value) == 1);
         } else if (key.equals("format")) {
           rctx.outputFormat = ((String) value).toLowerCase();
         } else if (key.equals("trackFormat")) {

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -161,6 +161,7 @@ public class BRouterWorker {
       track = cr.getFoundTrack();
       if (track != null) {
         track.exportWaypoints = rc.exportWaypoints;
+        track.exportCorrectedWaypoints = rc.exportCorrectedWaypoints;
         if (pathToFileResult == null) {
           switch (writeFromat) {
             case OUTPUT_FORMAT_KML:

--- a/brouter-server/src/main/java/btools/server/request/ServerHandler.java
+++ b/brouter-server/src/main/java/btools/server/request/ServerHandler.java
@@ -78,6 +78,10 @@ public class ServerHandler extends RequestHandler {
     if (exportWaypointsStr != null && Integer.parseInt(exportWaypointsStr) != 0) {
       track.exportWaypoints = true;
     }
+    exportWaypointsStr = params.get("exportCorrectedWaypoints");
+    if (exportWaypointsStr != null && Integer.parseInt(exportWaypointsStr) != 0) {
+      track.exportCorrectedWaypoints = true;
+    }
 
     if (format == null || "gpx".equals(format)) {
       result = new FormatGpx(rc).format(track);


### PR DESCRIPTION
This is the PR for #769 
It brings a new parameter
```
exportCorrectedWaypoints=1
```
and added the reworked waypoints - if any - to the output formats gpx, kml and json.
The point have the new type `via_corr`

This allows clients to correct their via points and, in the event of a route change, only recalculate the sections before and after the moved point.