### PR TITLE
Mismatched point extention for roundabouts

### DIFF
--- a/brouter-core/src/main/java/btools/router/FormatGpx.java
+++ b/brouter-core/src/main/java/btools/router/FormatGpx.java
@@ -212,10 +212,14 @@ public class FormatGpx extends Formatter {
         }
       }
     }
-    if (t.exportCorrectedWaypoints && t.correctedWaypoints != null) {
-      for (int i = 0; i <= t.correctedWaypoints.size() - 1; i++) {
-        OsmNodeNamed n = t.correctedWaypoints.get(i);
-        formatWaypointGpx(sb, n, "via_corr");
+    if (t.exportCorrectedWaypoints) {
+      for (int i = 0; i <= t.matchedWaypoints.size() - 1; i++) {
+        MatchedWaypoint wt = t.matchedWaypoints.get(i);
+        if (wt.correctedpoint != null) {
+          OsmNodeNamed n = new OsmNodeNamed(wt.correctedpoint);
+          n.name = wt.name + "_corr";
+          formatWaypointGpx(sb, n, "via_corr");
+        }
       }
     }
 

--- a/brouter-core/src/main/java/btools/router/FormatJson.java
+++ b/brouter-core/src/main/java/btools/router/FormatJson.java
@@ -158,15 +158,19 @@ public class FormatJson extends Formatter {
       }
       if (t.exportCorrectedWaypoints) {
         if (t.exportWaypoints) sb.append("    ,\n");
-        for (int i = 0; i <= t.correctedWaypoints.size() - 1; i++) {
+        boolean hasCorrPoints = false;
+        for (int i = 0; i <= t.matchedWaypoints.size() - 1; i++) {
           String type = "via_corr";
 
-          OsmNodeNamed wp = t.correctedWaypoints.get(i);
-          addFeature(sb, type, wp.name, wp.ilat, wp.ilon, wp.getSElev());
-          if (i < t.correctedWaypoints.size() - 1) {
-            sb.append(",");
+          MatchedWaypoint wp = t.matchedWaypoints.get(i);
+          if (wp.correctedpoint != null) {
+            if (hasCorrPoints) {
+              sb.append(",");
+            }
+            addFeature(sb, type, wp.name + "_corr", wp.correctedpoint.ilat, wp.correctedpoint.ilon, wp.correctedpoint.getSElev());
+            sb.append("    \n");
+            hasCorrPoints = true;
           }
-          sb.append("    \n");
         }
       }
     } else {

--- a/brouter-core/src/main/java/btools/router/FormatKml.java
+++ b/brouter-core/src/main/java/btools/router/FormatKml.java
@@ -1,5 +1,6 @@
 package btools.router;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import btools.mapaccess.MatchedWaypoint;
@@ -63,8 +64,17 @@ public class FormatKml extends Formatter {
         createFolder(sb, "end", t.matchedWaypoints.subList(size - 1, size));
       }
       if (t.exportCorrectedWaypoints) {
-        int size = t.correctedWaypoints.size();
-        createViaFolder(sb, "via_cor", t.correctedWaypoints.subList(0, size));
+        List<OsmNodeNamed> list = new ArrayList<>();
+        for (int i = 0; i < t.matchedWaypoints.size(); i++) {
+          MatchedWaypoint wp = t.matchedWaypoints.get(i);
+          if (wp.correctedpoint != null) {
+            OsmNodeNamed n = new OsmNodeNamed(wp.correctedpoint);
+            n.name = wp.name + "_corr";
+            list.add(n);
+          }
+        }
+        int size = list.size();
+        createViaFolder(sb, "via_corr", list.subList(0, size));
       }
     }
     sb.append("  </Document>\n");
@@ -84,6 +94,7 @@ public class FormatKml extends Formatter {
   }
 
   private void createViaFolder(StringBuilder sb, String type, List<OsmNodeNamed> waypoints) {
+    if (waypoints.isEmpty()) return;
     sb.append("    <Folder>\n");
     sb.append("      <name>" + type + "</name>\n");
     for (int i = 0; i < waypoints.size(); i++) {

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -61,7 +61,6 @@ public final class OsmTrack {
   public String name = "unset";
 
   protected List<MatchedWaypoint> matchedWaypoints;
-  protected List<OsmNodeNamed> correctedWaypoints;
   public boolean exportWaypoints = false;
   public boolean exportCorrectedWaypoints = false;
 

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -339,6 +339,7 @@ public final class OsmTrack {
     }
     float t0 = ourSize > 0 ? nodes.get(ourSize - 1).getTime() : 0;
     float e0 = ourSize > 0 ? nodes.get(ourSize - 1).getEnergy() : 0;
+    int c0 = ourSize > 0 ? nodes.get(ourSize - 1).cost : 0;
     for (i = 0; i < t.nodes.size(); i++) {
       OsmPathElement e = t.nodes.get(i);
       if (i == 0 && ourSize > 0 && nodes.get(ourSize - 1).getSElev() == Short.MIN_VALUE)
@@ -346,6 +347,7 @@ public final class OsmTrack {
       if (i > 0 || ourSize == 0) {
         e.setTime(e.getTime() + t0);
         e.setEnergy(e.getEnergy() + e0);
+        e.cost = e.cost + c0;
         if (e.message != null){
           if (!(e.message.lon == e.getILon() && e.message.lat == e.getILat())) {
             e.message.lon = e.getILon();

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -41,7 +41,6 @@ public class RoutingEngine extends Thread {
   private boolean finished = false;
 
   protected List<OsmNodeNamed> waypoints = null;
-  protected List<OsmNodeNamed> correctedWaypoints = null;
   List<OsmNodeNamed> extraWaypoints = null;
   protected List<MatchedWaypoint> matchedWaypoints;
   private int linksProcessed = 0;
@@ -1036,7 +1035,6 @@ public class RoutingEngine extends Thread {
 
     matchedWaypoints.get(matchedWaypoints.size() - 1).indexInTrack = totaltrack.nodes.size() - 1;
     totaltrack.matchedWaypoints = matchedWaypoints;
-    totaltrack.correctedWaypoints = correctedWaypoints;
     totaltrack.processVoiceHints(routingContext);
     totaltrack.prepareSpeedProfile(routingContext);
 
@@ -1195,12 +1193,8 @@ public class RoutingEngine extends Thread {
 
       setNewVoiceHint(t, last, lastJunctions, newJunction, newTarget);
 
-      if (correctedWaypoints == null) correctedWaypoints = new ArrayList<>();
-      OsmNodeNamed n = new OsmNodeNamed();
-      n.ilon = newJunction.getILon();
-      n.ilat = newJunction.getILat();
-      n.name = startWp.name + "_corr";
-      correctedWaypoints.add(n);
+      // fill to correctedpoint
+      startWp.correctedpoint = new OsmNode(newJunction.getILon(), newJunction.getILat());
 
       return true;
     }

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
@@ -16,6 +16,7 @@ public final class MatchedWaypoint {
   public OsmNode node2;
   public OsmNode crosspoint;
   public OsmNode waypoint;
+  public OsmNode correctedpoint;
   public String name;  // waypoint name used in error messages
   public double radius;  // distance in meter between waypoint and crosspoint
   public boolean direct;  // from this point go direct to next = beeline routing

--- a/brouter-server/src/test/java/btools/server/RouteServerTest.java
+++ b/brouter-server/src/test/java/btools/server/RouteServerTest.java
@@ -14,6 +14,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -28,7 +30,7 @@ public class RouteServerTest {
   public static TemporaryFolder profileDir = new TemporaryFolder();
 
   @BeforeClass
-  public static void setupServer() throws IOException, InterruptedException {
+  public static void setupServer() throws IOException, InterruptedException, URISyntaxException {
     File workingDir = new File(".").getCanonicalFile();
     File segmentDir = new File(workingDir, "../brouter-map-creator/build/resources/test/tmp/segments");
     File profileSourceDir = new File(workingDir, "../misc/profiles2");
@@ -41,7 +43,7 @@ public class RouteServerTest {
       try {
         RouteServer.main(new String[]{segmentDir.getAbsolutePath(), profileDir.getRoot().getAbsolutePath(), customProfileDir, port, "1"});
       } catch (Exception e) {
-        e.printStackTrace();
+        e.printStackTrace(System.out);
       }
     };
 
@@ -49,7 +51,7 @@ public class RouteServerTest {
     thread.start();
 
     // Busy-wait for server startup
-    URL requestUrl = new URL(baseUrl);
+    URL requestUrl = new URI(baseUrl).toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     for (int i = 20; i >= 0; i--) {
       try {
@@ -66,8 +68,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void defaultRouteTrekking() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.723037,50.000491|8.712737,50.002899&nogos=&profile=trekking&alternativeidx=0&format=geojson");
+  public void defaultRouteTrekking() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.723037,50.000491%7C8.712737,50.002899&nogos=&profile=trekking&alternativeidx=0&format=geojson").toURL();
 
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
@@ -82,8 +84,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void overrideParameter() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.723037,50.000491|8.712737,50.002899&nogos=&profile=trekking&alternativeidx=0&format=geojson&profile:avoid_unsafe=1");
+  public void overrideParameter() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.723037,50.000491%7C8.712737,50.002899&nogos=&profile=trekking&alternativeidx=0&format=geojson&profile:avoid_unsafe=1").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -95,8 +97,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void voiceHints() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.705796,50.003124|8.705859,50.0039599&nogos=&profile=trekking&alternativeidx=0&format=geojson&timode=2");
+  public void voiceHints() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.705796,50.003124%7C8.705859,50.0039599&nogos=&profile=trekking&alternativeidx=0&format=geojson&timode=2").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -108,8 +110,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void directRoutingFirst() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.718354,50.001514|8.718917,50.001361|8.716986,50.000105|8.718306,50.00145&nogos=&profile=trekking&alternativeidx=0&format=geojson&straight=0&timode=3");
+  public void directRoutingFirst() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.718354,50.001514%7C8.718917,50.001361%7C8.716986,50.000105%7C8.718306,50.00145&nogos=&profile=trekking&alternativeidx=0&format=geojson&straight=0&timode=3").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -121,8 +123,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void directRoutingLast() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.718306,50.00145|8.717464,50.000405|8.718917,50.001361|8.718354,50.001514&nogos=&profile=trekking&alternativeidx=0&format=geojson&straight=2&timode=3");
+  public void directRoutingLast() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.718306,50.00145%7C8.717464,50.000405%7C8.718917,50.001361%7C8.718354,50.001514&nogos=&profile=trekking&alternativeidx=0&format=geojson&straight=2&timode=3").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -134,8 +136,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void directRoutingMiddle() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.718539,50.006581|8.718198,50.006065,d|8.71785,50.006034|8.7169,50.004456&nogos=&profile=trekking&alternativeidx=0&format=geojson&timode=3");
+  public void directRoutingMiddle() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.718539,50.006581%7C8.718198,50.006065,d%7C8.71785,50.006034%7C8.7169,50.004456&nogos=&profile=trekking&alternativeidx=0&format=geojson&timode=3").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -147,8 +149,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void misplacedPoints() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter?lonlats=8.708678,49.999188|8.71145,49.999761|8.715801,50.00065&nogos=&profile=trekking&alternativeidx=0&format=geojson&correctMisplacedViaPoints=1&timode=3");
+  public void misplacedPoints() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.708678,49.999188%7C8.71145,49.999761%7C8.715801,50.00065&nogos=&profile=trekking&alternativeidx=0&format=geojson&correctMisplacedViaPoints=1&timode=3").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -160,8 +162,21 @@ public class RouteServerTest {
   }
 
   @Test
-  public void uploadValidProfile() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter/profile");
+  public void misplacedPointsRoundabout() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter?lonlats=8.699487,50.001257%7C8.701569,50.000092%7C8.704873,49.998898&nogos=&profile=trekking&alternativeidx=0&format=geojson&profile:correctMisplacedViaPoints=1&timode=3").toURL();
+    HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
+    httpConnection.connect();
+
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, httpConnection.getResponseCode());
+
+    InputStream inputStream = httpConnection.getInputStream();
+    JSONObject geoJson = new JSONObject(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+    Assert.assertEquals("482", geoJson.query("/features/0/properties/track-length"));
+  }
+
+  @Test
+  public void uploadValidProfile() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter/profile").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
 
     httpConnection.setRequestMethod("POST");
@@ -192,8 +207,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void uploadInvalidProfile() throws IOException {
-    URL requestUrl = new URL(baseUrl + "brouter/profile");
+  public void uploadInvalidProfile() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "brouter/profile").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
 
     httpConnection.setRequestMethod("POST");
@@ -214,8 +229,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void robots() throws IOException {
-    URL requestUrl = new URL(baseUrl + "robots.txt");
+  public void robots() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "robots.txt").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 
@@ -226,8 +241,8 @@ public class RouteServerTest {
   }
 
   @Test
-  public void invalidUrl() throws IOException {
-    URL requestUrl = new URL(baseUrl + "invalid");
+  public void invalidUrl() throws IOException, URISyntaxException {
+    URL requestUrl = new URI(baseUrl + "invalid").toURL();
     HttpURLConnection httpConnection = (HttpURLConnection) requestUrl.openConnection();
     httpConnection.connect();
 


### PR DESCRIPTION
Here a variant of the issue #519 

This should work with four situations on aroundabouts.

![via_rds_1](https://github.com/user-attachments/assets/1288518d-f266-40f9-8944-4e54ba091518) ![via_rds_2](https://github.com/user-attachments/assets/00ad3392-f19c-46ff-b770-8747ba82545d)
![via_rds_3](https://github.com/user-attachments/assets/bbcaacb7-530f-4bd3-b85f-3c2956914a89) ![via_rds_4](https://github.com/user-attachments/assets/b97727a4-a601-4880-9680-a53dcb706bb8)


And the more complicated situation:
![via_rd_1](https://github.com/user-attachments/assets/91e54455-4f74-4889-81e6-73a912064d2c) ![via_rd_2](https://github.com/user-attachments/assets/d3e88448-c353-46ed-87bd-b8629bd3c150)
![via_rd_3](https://github.com/user-attachments/assets/c401f153-0c69-4c27-a925-c7530a2571c0) ![via_rd_4](https://github.com/user-attachments/assets/9fb3658f-6891-407a-9f56-c075e0294112)

Please note that the correction of the via point is moved to the start of the roundabout. This should make it easier to move the second line later on. 