### PR TITLE
Update Android app with lookups.dat version check

### DIFF
--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -782,7 +782,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
 
   public void parseFile(File file, String readOnlyContext, Map<String, String> keyValues) {
     if (!file.exists()) {
-      throw new IllegalArgumentException("profile " + file + " does not exist");
+      throw new IllegalArgumentException("profile " + file.getName() + " does not exist");
     }
     try {
       if (readOnlyContext != null) {
@@ -813,12 +813,12 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
         variableData[i] = readOnlyData[i];
       }
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("ParseException " + file + " at line " + linenr + ": " + e.getMessage());
+      throw new IllegalArgumentException("ParseException " + file.getName() + " at line " + linenr + ": " + e.getMessage());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
     if (expressionList.size() == 0) {
-      throw new IllegalArgumentException(file.getAbsolutePath()
+      throw new IllegalArgumentException(file.getName()
         + " does not contain expressions for context " + context + " (old version?)");
     }
   }

--- a/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/DownloadWorker.java
@@ -399,7 +399,6 @@ public class DownloadWorker extends Worker {
     List<ServiceModeConfig> map = new ArrayList<>();
     List<String> aProfiles = new ArrayList<>(Arrays.asList(inBuiltProfiles));
     BufferedReader br = null;
-    //String modesFile = baseDir.getAbsolutePath() + MODES_DIR + "serviceconfig.dat";
     File modesFile = new File(baseDir, MODES_DIR + "serviceconfig.dat");
     try {
       br = new BufferedReader(new FileReader(modesFile));


### PR DESCRIPTION
To protect the first start after an update in the lookups.dat version, the files
```
serviceconfig.dat
timeoutdata.txt
```
inspected for none inbuilt profiles.
