### PR TITLE
Waypoint distance error

### DIFF
--- a/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/WaypointMatcherImpl.java
@@ -116,7 +116,7 @@ public final class WaypointMatcherImpl implements WaypointMatcher {
       double r22 = x2 * x2 + y2 * y2;
       double radius = Math.abs(r12 < r22 ? y1 * dx - x1 * dy : y2 * dx - x2 * dy) / d;
 
-      if (radius < mwp.radius) {
+      if (radius <= mwp.radius) {
         double s1 = x1 * dx + y1 * dy;
         double s2 = x2 * dx + y2 * dy;
 


### PR DESCRIPTION
There was a report on an unexpected result in waypoint positioning.
When waypoint is exact on a node1 or a node2 it stopped searching for more and use the current way for routing.
![via_1](https://github.com/user-attachments/assets/cca5cd2a-150a-42bb-84c9-e3eb4b37cef8)
Original from [Cruiser Forum](https://github.com/devemux86/cruiser/discussions/799#discussioncomment-13387145)


