### PR TITLE
Android 16

### DIFF
--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -102,7 +102,7 @@ repositories {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
-    implementation 'androidx.work:work-runtime:2.10.1'
+    implementation 'androidx.work:work-runtime:2.10.2'
     implementation 'com.google.android.material:material:1.12.0'
 
     implementation project(':brouter-mapaccess')
@@ -115,7 +115,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'androidx.work:work-testing:2.10.1'
+    androidTestImplementation 'androidx.work:work-testing:2.10.2'
 }
 
 gradle.projectsEvaluated {

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     base {
         archivesName = "BRouterApp."  + project.version
@@ -100,7 +100,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation 'androidx.work:work-runtime:2.10.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/brouter-util/src/main/java/btools/util/StackSampler.java
+++ b/brouter-util/src/main/java/btools/util/StackSampler.java
@@ -1,5 +1,7 @@
 package btools.util;
 
+import android.os.Build;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -12,7 +14,7 @@ import java.util.Map;
 import java.util.Random;
 
 public class StackSampler extends Thread {
-  private DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS", new Locale("en", "US"));
+  private DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS", new Locale.Builder().setLanguage("en").setRegion("US").build());
   private BufferedWriter bw;
   private Random rand = new Random();
 
@@ -47,6 +49,7 @@ public class StackSampler extends Thread {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public void dumpThreads() {
     try {
       int wait1 = rand.nextInt(interval);
@@ -65,7 +68,8 @@ public class StackSampler extends Thread {
           continue;
         }
 
-        sb.append(" (ID=").append(t.getId()).append(" \"").append(t.getName()).append("\" ").append(t.getState()).append("\n");
+        final long threadId = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA ? t.threadId() : t.getId();
+        sb.append(" (ID=").append(threadId).append(" \"").append(t.getName()).append("\" ").append(t.getState()).append("\n");
         for (StackTraceElement line : stack) {
           sb.append("    ").append(line.toString()).append("\n");
         }

--- a/brouter-util/src/main/java/btools/util/StackSampler.java
+++ b/brouter-util/src/main/java/btools/util/StackSampler.java
@@ -1,7 +1,5 @@
 package btools.util;
 
-import android.os.Build;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -49,7 +47,6 @@ public class StackSampler extends Thread {
     }
   }
 
-  @SuppressWarnings("deprecation")
   public void dumpThreads() {
     try {
       int wait1 = rand.nextInt(interval);
@@ -68,8 +65,7 @@ public class StackSampler extends Thread {
           continue;
         }
 
-        final long threadId = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA ? t.threadId() : t.getId();
-        sb.append(" (ID=").append(threadId).append(" \"").append(t.getName()).append("\" ").append(t.getState()).append("\n");
+        sb.append(" (ID=").append(t.getId()).append(" \"").append(t.getName()).append("\" ").append(t.getState()).append("\n");
         for (StackTraceElement line : stack) {
           sb.append("    ").append(line.toString()).append("\n");
         }


### PR DESCRIPTION
We should also increase the `targetSdkVersion` to `35` or `36`.

As the updates on Google Play have such target requirement.

`StackSampler` demonstrates fixes for some deprecation warnings that appear when compiling with Android 16.