### PR TITLE
Lib small workaround

### DIFF
--- a/brouter-core/src/main/java/btools/router/VoiceHint.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHint.java
@@ -580,7 +580,11 @@ public class VoiceHint {
       } else if (lowerBadWayAngle >= -100.f && higherBadWayAngle < 45.f) {
         cmd = KL;
       } else {
-        cmd = C;
+        if (lowerBadWayAngle > -35.f && higherBadWayAngle > 55.f) {
+          cmd = KR;
+        } else {
+          cmd = C;
+        }
       }
     } else if (cmdAngle < 5.f) {
       if (lowerBadWayAngle > -30.f) {
@@ -597,7 +601,11 @@ public class VoiceHint {
       } else if (lowerBadWayAngle > -45.f && higherBadWayAngle <= 100.f) {
         cmd = KR;
       } else {
-        cmd = C;
+        if (lowerBadWayAngle < -55.f && higherBadWayAngle < 35.f) {
+          cmd = KL;
+        } else {
+          cmd = C;
+        }
       }
     } else if (cmdAngle < 45.f) {
       cmd = TSLR;

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -116,6 +116,7 @@ public final class VoiceHintProcessor {
         input.angle = roundAboutTurnAngle;
         input.goodWay.turnangle = roundAboutTurnAngle;
         input.distanceToNext = distance;
+        input.turnAngleConsumed = true;
         //input.roundaboutExit = startTurn < 0 ? roundaboutExit : -roundaboutExit;
         input.roundaboutExit = roundAboutTurnAngle < 0 ? roundaboutExit : -roundaboutExit;
         float tmpangle = 0;

--- a/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
+++ b/brouter-core/src/main/java/btools/router/VoiceHintProcessor.java
@@ -314,7 +314,13 @@ public final class VoiceHintProcessor {
           input.cmd == VoiceHint.KR ||
           input.cmd == VoiceHint.KL)
           && !input.goodWay.isLinktType()) {
-          if (input.goodWay.getPrio() < input.maxBadPrio && (inputLastSaved != null && inputLastSaved.distanceToNext > catchingRange)) {
+          if (
+            ((Math.abs(input.lowerBadWayAngle) < 35.f ||
+              input.higherBadWayAngle < 35.f)
+              || input.goodWay.getPrio() < input.maxBadPrio)
+              && (inputLastSaved != null && inputLastSaved.distanceToNext > minRange)
+              && (input.distanceToNext > minRange)
+              ) {
             results.add(input);
           } else {
             if (inputLast != null) { // when drop add distance to last

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContext.java
@@ -782,7 +782,7 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
 
   public void parseFile(File file, String readOnlyContext, Map<String, String> keyValues) {
     if (!file.exists()) {
-      throw new IllegalArgumentException("profile " + file + " does not exist");
+      throw new IllegalArgumentException("profile " + file.getName() + " does not exist");
     }
     try {
       if (readOnlyContext != null) {
@@ -813,12 +813,12 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
         variableData[i] = readOnlyData[i];
       }
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("ParseException " + file + " at line " + linenr + ": " + e.getMessage());
+      throw new IllegalArgumentException("ParseException " + file.getName() + " at line " + linenr + ": " + e.getMessage());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
     if (expressionList.size() == 0) {
-      throw new IllegalArgumentException(file.getAbsolutePath()
+      throw new IllegalArgumentException(file.getName()
         + " does not contain expressions for context " + context + " (old version?)");
     }
   }


### PR DESCRIPTION
To clean something there a smaller workarounds:

- remove profile path from error message
- add some new angles on voice hints (thanks to @EssBee59) for some critical and small junctions
- added the info on turnAngleConsumed  for roundabouts

Error roundabouds look like this
![test_113](https://github.com/user-attachments/assets/ab984be1-c4bf-417b-9bf9-689b67b18fb6)

For testing error message please edit the profile in web editor, add some wrong code and try routing to see the new error message.

This is available for testing on testserver. This includes also the changes of #803 for testing.
