### PR TITLE
Apk: Use profile parameter

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.zip.ZipEntry;
@@ -44,6 +45,8 @@ import btools.router.OsmTrack;
 import btools.router.RoutingContext;
 import btools.router.RoutingEngine;
 import btools.router.RoutingHelper;
+import btools.router.RoutingParamCollector;
+
 import btools.util.CheapRuler;
 
 public class BRouterView extends View {
@@ -437,6 +440,7 @@ public class BRouterView extends View {
 
   public void startProcessing(String profile) {
     rawTrackPath = null;
+    String params = null;
     if (profile.startsWith("<repeat")) {
       needsViaSelection = needsNogoSelection = needsWaypointSelection = false;
       try {
@@ -446,6 +450,7 @@ public class BRouterView extends View {
         rawTrackPath = br.readLine();
         wpList = readWpList(br, false);
         nogoList = readWpList(br, true);
+        params = br.readLine();
         br.close();
       } catch (Exception e) {
         AppLogger.log(AppLogger.formatThrowable(e));
@@ -493,6 +498,15 @@ public class BRouterView extends View {
 
       rc.localFunction = profilePath;
       rc.turnInstructionMode = cor.getTurnInstructionMode();
+
+      if (params != null || params.length() > 2) {
+        try {
+          Map<String, String> profileParamsCollection = null;
+          RoutingParamCollector routingParamCollector = new RoutingParamCollector();
+          profileParamsCollection = routingParamCollector.getUrlParams(params);
+          routingParamCollector.setProfileParams(rc, profileParamsCollection);
+        } catch (Exception e) {}
+      }
 
       int plain_distance = 0;
       int maxlon = Integer.MIN_VALUE;

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterView.java
@@ -499,7 +499,7 @@ public class BRouterView extends View {
       rc.localFunction = profilePath;
       rc.turnInstructionMode = cor.getTurnInstructionMode();
 
-      if (params != null || params.length() > 2) {
+      if (params != null && params.length() > 2) {
         try {
           Map<String, String> profileParamsCollection = null;
           RoutingParamCollector routingParamCollector = new RoutingParamCollector();

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -221,6 +221,14 @@ public class BRouterWorker {
     bw.write("\n");
     writeWPList(bw, waypoints);
     writeWPList(bw, rc.nogopoints);
+    if (rc.keyValues != null) {
+      StringBuilder sb = new StringBuilder();
+      for (Map.Entry<String, String> e : rc.keyValues.entrySet()) {
+        sb.append(sb.length()>0 ? "&" : "").append(e.getKey()).append("=").append(e.getValue());
+      }
+      bw.write(sb.toString());
+      bw.write("\n");
+    }
     bw.close();
   }
 

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -100,11 +100,19 @@ public class BRouterWorker {
     }
     routingParamCollector.setParams(rc, waypoints, theParams);
 
+    Map<String, String> profileParamsCollection = null;
+    try {
+      if (profileParams != null) {
+        profileParamsCollection = routingParamCollector.getUrlParams(profileParams);
+        routingParamCollector.setProfileParams(rc, profileParamsCollection);
+      }
+    } catch (UnsupportedEncodingException e) {
+      // ignore
+    }
     if (params.containsKey("extraParams")) {
-      Map<String, String> profileparams = null;
       try {
-        profileparams = routingParamCollector.getUrlParams(params.getString("extraParams"));
-        routingParamCollector.setProfileParams(rc, profileparams);
+        profileParamsCollection = routingParamCollector.getUrlParams(params.getString("extraParams"));
+        routingParamCollector.setProfileParams(rc, profileParamsCollection);
       } catch (UnsupportedEncodingException e) {
         // ignore
       }


### PR DESCRIPTION
In the discussion for #807 about profile and parameter we found that parameter changes made direct in BRouter are not used in routing.

I will examine `repeat:profile` function later on.