### PR TITLE
Fix ListPreference in RoutingParameterDialog

### DIFF
--- a/brouter-routing-app/src/main/java/btools/routingapp/RoutingParameterDialog.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/RoutingParameterDialog.java
@@ -377,8 +377,8 @@ public class RoutingParameterDialog extends AppCompatActivity {
             for (String tmp : sa) {
               // Add the name and address to the ListPreference enties and entyValues
               //L.v("AFTrack", "device: "+device.getName() + " -- " + device.getAddress());
-              entryValues[i] = "" + i;
               entries[i] = tmp.trim();
+              entryValues[i] = entries[i].split("=")[0].trim();
               if (entryValues[i].equals(s)) ii = i;
               i++;
             }
@@ -394,11 +394,14 @@ public class RoutingParameterDialog extends AppCompatActivity {
             listPref.setSummary(p.description);
             listPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
               p.value = (String) newValue;
-              int iii = Integer.decode(p.value);
-              listPref.setTitle(p.name + ": " + entries[iii]);
-
+              for (int iii = 0; iii < entryValues.length; iii++) {
+                String entryValue = entryValues[iii];
+                if (entryValue.equals(p.value)) {
+                  listPref.setTitle(p.name + ": " + entries[iii]);
+                  break;
+                }
+              }
               return true;
-
             });
 
             gpsPrefCat.addPreference(listPref);


### PR DESCRIPTION
The default selection of `ListPreference` in `RoutingParameterDialog` is not correct.

We should not compare with the array index, because the index is not always 0, 1, ...

For example in the hiking profile, the parameter [consider_traffic](https://github.com/abrensch/brouter/blob/master/misc/profiles2/hiking-mountain.brf#L18) index starts from `1`.
So now it selects as default the 2nd value instead of the correct 1st value.

It's better to compare with the real index (index=value) in the values of the array.