### PR TITLE
Preparing for Version 1.7.8

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -23,8 +23,8 @@ import btools.util.CompactLongMap;
 import btools.util.FrozenLongMap;
 
 public final class OsmTrack {
-  final public static String version = "1.7.7";
-  final public static String versionDate = "23072024";
+  final public static String version = "1.7.8";
+  final public static String versionDate = "12072025";
 
   // csv-header-line
   private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags\tTime\tEnergy";

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -18,7 +18,7 @@ android {
         namespace 'btools.routingapp'
         applicationId "btools.routingapp"
 
-        versionCode 54
+        versionCode 55
         versionName project.version
 
         resValue('string', 'app_version', defaultConfig.versionName)

--- a/buildSrc/src/main/groovy/brouter.version-conventions.gradle
+++ b/buildSrc/src/main/groovy/brouter.version-conventions.gradle
@@ -4,4 +4,4 @@
 // app: build.gradle (versionCode only)
 // OsmTrack (version and versionDate)
 // docs revisions.md (version and versionDate)
-version '1.7.7'
+version '1.7.8'

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -2,7 +2,7 @@
 
 (ZIP-Archives including APK, readme + profiles)
 
-### next version
+### [brouter-1.7.8.zip](../brouter_bin/brouter-1.7.8.zip) (current revision, 12.07.2025)
 
 Android
 
@@ -28,7 +28,7 @@ Library
 [Solved issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue+milestone%3A%22Version+1.7.8%22+is%3Aclosed)
 
 
-### [brouter-1.7.7.zip](../brouter_bin/brouter-1.7.7.zip) (current revision, 23.07.2024)
+### [brouter-1.7.7.zip](../brouter_bin/brouter-1.7.7.zip) (23.07.2024)
 
 - new Android API 34
 


### PR DESCRIPTION
Added a new version for BRouter app and library, please see [changes](https://github.com/abrensch/brouter/pulls?q=is%3Apr+milestone%3A%22Version+1.7.8%22+is%3Aclosed)