### PR TITLE
Trekking: Exclude under construction roads

### DIFF
--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -247,10 +247,10 @@ assign costfactor
   if ( and highway= not route=ferry ) then 10000
 
   #
-  # exclude motorways and proposed roads
+  # exclude motorways and proposed, abandoned under construction roads
   #
-  else if ( highway=motorway|motorway_link ) then   10000
-  else if ( highway=proposed|abandoned     ) then   10000
+  else if ( highway=motorway|motorway_link          ) then   10000
+  else if ( highway=proposed|abandoned|construction ) then   10000
 
   #
   # all other exclusions below (access, steps, ferries,..)


### PR DESCRIPTION
Additionally to abandoned and proposed roads, it can be beneficial to avoid under construction roads.
For now, I only added this only to the `trekking` profile, as this is what i mostly use, but if desired, I can also add it to others. It already is somehow handled in the `hiking-mountain` and `mtb` profile.
 
Real world example: https://brouter.m11n.de/#map=14/48.1870/16.4440/standard&lonlats=16.419035,48.190981;16.46225,48.177006&profile=trekking