### PR TITLE
add components.java to maven publication

### DIFF
--- a/buildSrc/src/main/groovy/brouter.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/brouter.library-conventions.gradle
@@ -16,6 +16,8 @@ publishing {
         }
     }
     publications {
-        gpr(MavenPublication)
+        gpr(MavenPublication) {
+            from components.java
+        }
     }
 }


### PR DESCRIPTION
Core builds are currently empty. This changes that