### PR TITLE
[WIP] Replace logging with slf4j/logback

### DIFF
--- a/brouter-core/src/main/java/btools/router/AreaReader.java
+++ b/brouter-core/src/main/java/btools/router/AreaReader.java
@@ -1,5 +1,8 @@
 package btools.router;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -27,6 +30,7 @@ import btools.mapaccess.OsmNodesMap;
 import btools.mapaccess.PhysicalFile;
 
 public class AreaReader {
+  private Logger logger = LoggerFactory.getLogger(AreaReader.class);
 
   File segmentFolder;
 
@@ -135,7 +139,7 @@ public class AreaReader {
           used++;
       }
     } catch (Exception e) {
-      System.err.println("AreaReader: after " + used + "/" + count + " " + e.getMessage());
+      logger.error("error after used={} / count={}", used, count, e);
       ais.clear();
     } finally {
       if (pf != null)

--- a/brouter-core/src/main/java/btools/router/ProfileCache.java
+++ b/brouter-core/src/main/java/btools/router/ProfileCache.java
@@ -7,11 +7,15 @@ package btools.router;
 
 import java.io.File;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import btools.expressions.BExpressionContextNode;
 import btools.expressions.BExpressionContextWay;
 import btools.expressions.BExpressionMetaData;
 
 public final class ProfileCache {
+  static Logger logger = LoggerFactory.getLogger(ProfileCache.class);
 
   private static File lastLookupFile;
   private static long lastLookupTimestamp;
@@ -24,7 +28,6 @@ public final class ProfileCache {
   private long lastUseTime;
 
   private static ProfileCache[] apc = new ProfileCache[1];
-  private static boolean debug = Boolean.getBoolean("debugProfileCache");
 
   public static synchronized void setSize(int size) {
     apc = new ProfileCache[size];
@@ -48,7 +51,7 @@ public final class ProfileCache {
     // invalidate cache at lookup-table update
     if (!(lookupFile.equals(lastLookupFile) && lookupFile.lastModified() == lastLookupTimestamp)) {
       if (lastLookupFile != null) {
-        System.out.println("******** invalidating profile-cache after lookup-file update ******** ");
+        logger.info("invalidating profile-cache after lookup-file update");
       }
       apc = new ProfileCache[apc.length];
       lastLookupFile = lookupFile;
@@ -104,14 +107,12 @@ public final class ProfileCache {
       lru = new ProfileCache();
       if (unusedSlot >= 0) {
         apc[unusedSlot] = lru;
-        if (debug)
-          System.out.println("******* adding new profile at idx=" + unusedSlot + " for " + profileFile);
+        logger.debug("adding new profile at idx={} for file={}", unusedSlot, profileFile);
       }
     }
 
     if (lru.lastProfileFile != null) {
-      if (debug)
-        System.out.println("******* replacing profile of age " + ((System.currentTimeMillis() - lru.lastUseTime) / 1000L) + " sec " + lru.lastProfileFile + "->" + profileFile);
+      logger.debug("replacing profile of age={} sec {}->{}", (System.currentTimeMillis() - lru.lastUseTime) / 1000L, lru.lastProfileFile, profileFile);
     }
 
     lru.lastProfileTimestamp = rc.profileTimestamp;

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -1,5 +1,8 @@
 package btools.router;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -9,14 +12,13 @@ import java.util.Map;
 import java.util.StringTokenizer;
 
 public class RoutingParamCollector {
-
-  final static boolean DEBUG = false;
+  private Logger logger = LoggerFactory.getLogger(RoutingParamCollector.class);
 
   /**
    * get a list of points and optional extra info for the points
    *
-   * @param lonLats  linked list separated by ';' or '|'
-   * @return         a list
+   * @param lonLats linked list separated by ';' or '|'
+   * @return a list
    */
   public List<OsmNodeNamed> getWayPointList(String lonLats) {
     if (lonLats == null) throw new IllegalArgumentException("lonlats parameter not set");
@@ -51,9 +53,9 @@ public class RoutingParamCollector {
   /**
    * get a list of points (old style, positions only)
    *
-   * @param lons  array with longitudes
-   * @param lats  array with latitudes
-   * @return      a list
+   * @param lons array with longitudes
+   * @param lats array with latitudes
+   * @return a list
    */
   public List<OsmNodeNamed> readPositions(double[] lons, double[] lats) {
     List<OsmNodeNamed> wplist = new ArrayList<>();
@@ -96,9 +98,9 @@ public class RoutingParamCollector {
   /**
    * read a url like parameter list linked with '&'
    *
-   * @param url  parameter list
-   * @return     a hashmap of the parameter
-   * @throws     UnsupportedEncodingException
+   * @param url parameter list
+   * @return a hashmap of the parameter
+   * @throws UnsupportedEncodingException
    */
   public Map<String, String> getUrlParams(String url) throws UnsupportedEncodingException {
     Map<String, String> params = new HashMap<>();
@@ -121,9 +123,9 @@ public class RoutingParamCollector {
   /**
    * fill a parameter map into the routing context
    *
-   * @param rctx    the context
-   * @param wplist  the list of way points needed for 'straight' parameter
-   * @param params  the list of parameters
+   * @param rctx   the context
+   * @param wplist the list of way points needed for 'straight' parameter
+   * @param params the list of parameters
    */
   public void setParams(RoutingContext rctx, List<OsmNodeNamed> wplist, Map<String, String> params) {
     if (params != null) {
@@ -183,7 +185,7 @@ public class RoutingParamCollector {
       for (Map.Entry<String, String> e : params.entrySet()) {
         String key = e.getKey();
         String value = e.getValue();
-        if (DEBUG) System.out.println("params " + key + " " + value);
+        logger.debug("params key={} value={}", key, value);
 
         if (key.equals("straight")) {
           try {
@@ -193,7 +195,7 @@ public class RoutingParamCollector {
               if (wplist.size() > v) wplist.get(v).direct = true;
             }
           } catch (Exception ex) {
-            System.err.println("error " + ex.getStackTrace()[0].getLineNumber() + " " + ex.getStackTrace()[0] + "\n" + ex);
+            logger.error("error {}", ex.getStackTrace()[0].getLineNumber(), ex);
           }
         } else if (key.equals("pois")) {
           rctx.poipoints = readPoisList(value);
@@ -212,7 +214,7 @@ public class RoutingParamCollector {
             rctx.roundTripPoints = 5;
           }
         } else if (key.equals("allowSamewayback")) {
-          rctx.allowSamewayback = Integer.parseInt(value)==1;
+          rctx.allowSamewayback = Integer.parseInt(value) == 1;
         } else if (key.equals("alternativeidx")) {
           rctx.setAlternativeIdx(Integer.parseInt(value));
         } else if (key.equals("turnInstructionMode")) {
@@ -245,8 +247,8 @@ public class RoutingParamCollector {
   /**
    * fill profile parameter list
    *
-   * @param rctx    the routing context
-   * @param params  the list of parameters
+   * @param rctx   the routing context
+   * @param params the list of parameters
    */
   public void setProfileParams(RoutingContext rctx, Map<String, String> params) {
     if (params != null) {
@@ -255,7 +257,7 @@ public class RoutingParamCollector {
       for (Map.Entry<String, String> e : params.entrySet()) {
         String key = e.getKey();
         String value = e.getValue();
-        if (DEBUG) System.out.println("params " + key + " " + value);
+        logger.debug("params key={} value={}", key, value);
         rctx.keyValues.put(key, value);
       }
     }

--- a/brouter-core/src/test/java/btools/router/RoutingEngineTest.java
+++ b/brouter-core/src/test/java/btools/router/RoutingEngineTest.java
@@ -73,7 +73,7 @@ public class RoutingEngineTest {
 
     RoutingEngine re = new RoutingEngine(
       wd + "/" + trackname,
-      wd + "/" + trackname,
+      null,
       new File(wd, "/../../../../brouter-map-creator/build/resources/test/tmp/segments"),
       wplist,
       rctx);

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdk 36
 
     base {
-        archivesName = "BRouterApp."  + project.version
+        archivesName = "BRouterApp." + project.version
     }
 
     defaultConfig {
@@ -104,6 +104,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation 'androidx.work:work-runtime:2.10.2'
     implementation 'com.google.android.material:material:1.12.0'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
 
     implementation project(':brouter-mapaccess')
     implementation project(':brouter-core')

--- a/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
+++ b/brouter-routing-app/src/main/java/btools/routingapp/BRouterWorker.java
@@ -46,7 +46,7 @@ public class BRouterWorker {
 
     RoutingContext rc = new RoutingContext();
     rc.rawTrackPath = rawTrackPath;
-    rc.rawAreaPath = (rawTrackPath != null ? rawTrackPath.substring(0, rawTrackPath.lastIndexOf(File.separator)+1) + "rawAreaInfo.dat" : null);
+    rc.rawAreaPath = (rawTrackPath != null ? rawTrackPath.substring(0, rawTrackPath.lastIndexOf(File.separator) + 1) + "rawAreaInfo.dat" : null);
     rc.localFunction = profilePath;
 
     RoutingParamCollector routingParamCollector = new RoutingParamCollector();
@@ -142,11 +142,10 @@ public class BRouterWorker {
     }
 
     RoutingEngine cr = new RoutingEngine(null, null, segmentDir, waypoints, rc, engineMode);
-    cr.quite = true;
     cr.doRun(maxRunningTime);
 
     if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
-        engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
+      engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
       // store new reference track if any
       // (can exist for timed-out search)
       if (cr.getFoundRawTrack() != null) {

--- a/brouter-server/src/main/java/btools/server/RouteServer.java
+++ b/brouter-server/src/main/java/btools/server/RouteServer.java
@@ -205,8 +205,13 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
       }
       routingParamCollector.setParams(rc, wplist, params);
 
+//      LoggerContext loggerContext = new LoggerContext();
+//      FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
+//      fileAppender.setContext(loggerContext);
+//      fileAppender.setFile();
+//      fileAppender.start();
+
       cr = new RoutingEngine(null, null, serviceContext.segmentDir, wplist, rc, engineMode);
-      cr.quite = true;
       cr.doRun(maxRunningTime);
 
       if (cr.getErrorMessage() != null) {
@@ -223,7 +228,7 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
         String headers = encodings == null || encodings.indexOf("gzip") < 0 ? null : "Content-Encoding: gzip\r\n";
         writeHttpHeader(bw, handler.getMimeType(), handler.getFileName(), headers, HTTP_STATUS_OK);
         if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUTING ||
-            engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
+          engineMode == RoutingEngine.BROUTER_ENGINEMODE_ROUNDTRIP) {
           if (track != null) {
             if (headers != null) { // compressed
               ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -237,7 +242,7 @@ public class RouteServer extends Thread implements Comparable<RouteServer> {
             }
           }
         } else if (engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETELEV ||
-                   engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETINFO) {
+          engineMode == RoutingEngine.BROUTER_ENGINEMODE_GETINFO) {
           String s = cr.getFoundInfo();
           if (s != null) {
             bw.write(s);

--- a/buildSrc/src/main/groovy/brouter.application-conventions.gradle
+++ b/buildSrc/src/main/groovy/brouter.application-conventions.gradle
@@ -6,3 +6,7 @@ plugins {
 application {
     distTar.enabled = false
 }
+
+dependencies {
+    implementation 'ch.qos.logback:logback-classic:1.5.18'
+}

--- a/buildSrc/src/main/groovy/brouter.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/brouter.java-conventions.gradle
@@ -12,6 +12,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+
+    testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
This change replaces all logging in brouter-core with slf4j.

Why? The current logging is a mess. `RoutingEngine` implements a simple logger that doesn't preserve log levels or timestamps. Other core classes use `System.out` instead. To enable debug logs, there are sometimes static variables and sometimes config is read from system properties. To me this all seems confusing and difficult to configure, therefore I propose to replace it all with the simple, standardized and pluggable library that is slf4j.

slf4j is merely an abstraction and does not provide logging itself. This gives the user of the library the freedom to use any library of their choosing. The server, app and tests use logback to do the actual logging. Logback also supports structured logging as proposed in #702 (cc @mjaschen), I have modified many of the log messages to use the key-value syntax.

RoutingEngine used have an option to to write its log to a `debug.txt`. I've removed this because I believe a library should generally not access the disk directly. Per-profile logging could be implemented by passing a `ILoggerFactory` to RoutingContext, but I haven't implemented this yet because I wonder one thing: Do we even need this file? If we attach the profile name as structured data, one can simply grep the general log file or use a filter in an advanced system like Logstash etc. Having to locate the individual file each time honestly sounds more complicated to me. Let me know what you all think.