### PR TITLE
Consider traffic signals for bicycle profiles

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -322,6 +322,7 @@ assign footaccess
                         1
 
 assign initialcost
+    switch highway=traffic_signals 20
        switch bikeaccess
               0
               switch footaccess

--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -322,7 +322,7 @@ assign footaccess
                         1
 
 assign initialcost
-    switch highway=traffic_signals 20
+    switch or highway=traffic_signals and highway=crossing crossing=traffic_signals 20
        switch bikeaccess
               0
               switch footaccess

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -399,7 +399,7 @@ assign footaccess =
        else not foot=private|no
 
 assign initialcost =
-       if highway=traffic_signals then 20
+       if or highway=traffic_signals and highway=crossing crossing=traffic_signals then 20
        else
        if bikeaccess then 0
        else ( if footaccess then 100 else 1000000 )

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -399,5 +399,7 @@ assign footaccess =
        else not foot=private|no
 
 assign initialcost =
+       if highway=traffic_signals then 20
+       else
        if bikeaccess then 0
        else ( if footaccess then 100 else 1000000 )


### PR DESCRIPTION
Like what exists in `fastbike-verylowtraffic`, add a small 20 meters penalty for traffic_signals. 

This usually avoids, when 2 similar parallel ways exist, taking the way that has all the traffic lights. 