### PR TITLE
Lower fastbike traffic consideration & slightly enhance

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -23,7 +23,7 @@ assign allow_steps           = true   # %allow_steps% | Set to false to disallow
 assign allow_ferries         = true   # %allow_ferries% | set to false to disallow ferries | boolean
 assign allow_motorways       = false  # %allow_motorways% | Set to true to allow motorways (useful in Asia / Oceania for example) | boolean
 
-assign consider_traffic      = 0.1      # %consider_traffic% | how do you plan to drive the tour? |  [1=as cyclist alone in the week, 0.5=as cyclist alone at weekend, 0.3 =with a group of cyclists, 0.1=with a group of cyclists at week-end, 0.0=do not consider traffic]
+assign consider_traffic      = 0.1      # %consider_traffic% | avoiding roads that usually have traffic is? | [1=very important, 0.5=pretty important, 0.3=important, 0.1=slightly preferred, 0.0=do not consider traffic]
 assign consider_noise        = false  # %consider_noise% | Activate to prefer a low-noise route | boolean
 assign consider_river        = false  # %consider_river% | Activate to prefer a route along rivers, lakes, etc. | boolean
 assign consider_forest       = false  # %consider_forest% | Activate to prefer a route in forest or parks | boolean


### PR DESCRIPTION
Copy pasting some commit comment: 

> [fastbike profile: lower traffic consideration](https://github.com/abrensch/brouter/commit/475b9a60bf9a4be5d9b816cadbf04b3108cfb592)
> 
> In commit https://github.com/abrensch/brouter/commit/30bc66e7fd800a77dae5f98e0c31eba4ea18bbae, consider_traffic was enabled by default in fastbike. When
> using this profile in big cities, this made the vast majority of main ways
> very costly and so, avoided. This made big differences in routing decisions,
> especially within big cities where significantly more turns can be added to
> the route in trying to avoid primary/secondary/main ways that (when allowed
> for bicycles) are usually no *so* bad.
> 
> This commit aims to reinstate a fastbike routing behaviour closer to the
> previous experience, while considering traffic a little bit more than before.
> The user is still able to change the parameter to its preference.
> 
> Also, the current code defines hascycleway but does not use this variable at
> all while fastbike-verylowtraffic and mtb profiles use it to limit the traffic
> penalty when a cycleway is present. I believe this was not made on purpose.
> 
> Note: Avoiding traffic closer to the spirit of the trekking profile where
> consider_traffic is nevertheless disabled by default at the moment.


> [fastbike: use hascycleway to potentially limit the trafficpenalty](https://github.com/abrensch/brouter/commit/60c2a3b20244bd8211f9e0e36fd11ca2f60979de)
> 
> The hascycleway variable was computed in the profile, but never used. I
> believe this was just an oversight, so using it now.
> 
> Also, if consider_traffic is false, directly set trafficpenalty to 0 to avoid
> any useless computation, thus optimising performance.


> [fastbike: rename consider_traffic options](https://github.com/abrensch/brouter/commit/e655d886b71c094f20847c41da88c087773d508c)
> 
> Just choose how much avoiding traffic is important for your use case, instead
> of the alone, group, week and week-ends descriptions.