### PR TITLE
Avoid NPE on roundabouts

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -1104,10 +1104,15 @@ public class RoutingEngine extends Thread {
 
     boolean bMeetingIsOnRoundabout = ptMeeting.message.isRoundabout();
     boolean bMeetsRoundaboutStart = false;
+    int wayDistance = 0;
 
     int i;
+    OsmPathElement last_n = null;
+
     for (i = 0; i < indexEnd; i++) {
       OsmPathElement n = t.nodes.get(i);
+      if (last_n != null) wayDistance += n.calcDistance(last_n);
+      last_n = n;
       if (n.positionEquals(ptStart)) {
         indexStartFore = i;
         bMeetsRoundaboutStart = true;
@@ -1116,6 +1121,11 @@ public class RoutingEngine extends Thread {
         indexMeetingFore = i;
       }
 
+    }
+
+    if (routingContext.correctMisplacedViaPointsDistance > 0 &&
+      wayDistance > routingContext.correctMisplacedViaPointsDistance) {
+      return 0;
     }
 
     if (!bMeetsRoundaboutStart && bMeetingIsOnRoundabout) {


### PR DESCRIPTION
There was an error reported from the [Cruiser Forum](https://github.com/devemux86/cruiser/discussions/872#discussioncomment-15052507). It goes over a negative time report. 
But at the end is was a NPE in the snap-to-roundabout routine.

It should look better now when `correctMisplacedViaPoints` is true.
<img width="352" height="273" alt="test_nocorr" src="https://github.com/user-attachments/assets/fc2f8e67-cc4a-435e-9583-bb584dbf4d86" /> <img width="327" height="244" alt="test_corr" src="https://github.com/user-attachments/assets/f06bd992-c08b-4114-a8b3-502cb54200a3" />

Route goes like [this part](https://brouter.de/brouter-test/#map=13/53.8772/-0.6859/standard&lonlats=-0.685755,53.896619;-0.668624,53.883437;-0.66828,53.869006&profile=car-eco) and is ready for testing on test server.