### PR TITLE
profile: refactor, refine and simplify the logic handling oneways

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -133,15 +133,23 @@ assign badoneway =
          else oneway=yes|true|1
        else oneway=-1
 
+assign hascycleway = not
+  and ( or cycleway= cycleway=no|none ) and ( or cycleway:left= cycleway:left=no ) ( or cycleway:right= cycleway:right=no )
+
 assign onewaypenalty =
        if ( badoneway ) then
        (
-         if      ( cycleway=opposite|opposite_lane|opposite_track       ) then 0
-         else if ( cycleway:left=opposite|opposite_lane|opposite_track  ) then 0
-         else if ( cycleway:right=opposite|opposite_lane|opposite_track ) then 0
+         if (
+           and hascycleway
+           or and cycleway:left=lane|track|shared_lane|share_busway
+                  cycleway:left:oneway=no|-1
+           or and cycleway:right=lane|track|shared_lane|share_busway
+                  cycleway:right:oneway=no|-1
+           or cycleway=opposite|opposite_lane|opposite_track
+           or cycleway:left=opposite|opposite_lane|opposite_track
+              cycleway:right=opposite|opposite_lane|opposite_track
+                                                             ) then 0
          else if ( oneway:bicycle=no                         ) then 0
-         else if ( cycleway:left:oneway=no                   ) then 0
-         else if ( cycleway:right:oneway=no                  ) then 0
          else if ( junction=roundabout|circular              ) then 60
          else if ( highway=primary|primary_link              ) then 50
          else if ( highway=secondary|secondary_link          ) then 30
@@ -151,9 +159,6 @@ assign onewaypenalty =
        else 0.0
 
 # Eventually compute traffic penalty
-assign hascycleway = not
-  and ( or cycleway= cycleway=no|none ) and ( or cycleway:left= cycleway:left=no ) ( or cycleway:right= cycleway:right=no )
-
 assign trafficpenalty =
       if not consider_traffic then 0
       else

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -76,27 +76,14 @@ assign is_ldcr =
      if ignore_cycleroutes then false
      else any_cycleroute
 
-assign badoneway =
-       if reversedirection=yes then
-         if oneway:bicycle=yes then true
-         else if oneway= then junction=roundabout
-         else oneway=yes|true|1
-       else oneway=-1
+# set isbike considering access, local cycle route or the presence of a cycleway on the highway
+assign hasbikerouteoraccess =
+       or bicycle_road=yes or bicycle=yes|permissive|designated lcn=yes  # also add cyclestreet=yes when lookup has it
 
-# set isbike considering access, local cycle route or the presence of a usable cycleway on the highway
-assign isbike =
-       or or bicycle_road=yes or bicycle=yes|permissive|designated lcn=yes  # also add cyclestreet=yes when lookup has it
-       or cycleway=lane|track|shared_lane|share_busway
-       or and badoneway cycleway=opposite|opposite_lane|opposite_track
-       or
-         and cycleway:left=lane|track|shared_lane|share_busway
-           switch badoneway
-             cycleway:left:oneway=no|-1
-             true
-         and cycleway:right=lane|track|shared_lane|share_busway
-           switch badoneway
-             cycleway:right:oneway=no|-1
-             true
+assign hascycleway = not
+  and ( or cycleway= cycleway=no|none ) and ( or cycleway:left= cycleway:left=no ) ( or cycleway:right= cycleway:right=no )  # also add cycleway:both when lookup has it
+
+assign isbike = or hasbikerouteoraccess hascycleway
 
 assign ispaved = or surface=paved|asphalt|concrete|paving_stones|sett smoothness=excellent|good
 assign isunpaved = not or surface= or ispaved or surface=fine_gravel|cobblestone smoothness=intermediate|bad
@@ -175,16 +162,29 @@ assign accesspenalty =
 # be close to forbidden, while on other ways we just add
 # 4 to the costfactor (making it at least 5 - you are allowed
 # to push your bike)
-#
+
+# are we against legal direction on a oneway?
+assign badoneway =
+       if reversedirection=yes then
+         if oneway:bicycle=yes then true
+         else if oneway= then junction=roundabout
+         else oneway=yes|true|1
+       else oneway=-1
+
 assign onewaypenalty =
        if ( badoneway ) then
        (
-         if      ( cycleway=opposite|opposite_lane|opposite_track       ) then 0
-         else if ( cycleway:left=opposite|opposite_lane|opposite_track  ) then 0
-         else if ( cycleway:right=opposite|opposite_lane|opposite_track ) then 0
+         if (
+           and hascycleway
+           or and cycleway:left=lane|track|shared_lane|share_busway
+                  cycleway:left:oneway=no|-1
+           or and cycleway:right=lane|track|shared_lane|share_busway
+                  cycleway:right:oneway=no|-1
+           or cycleway=opposite|opposite_lane|opposite_track
+           or cycleway:left=opposite|opposite_lane|opposite_track
+              cycleway:right=opposite|opposite_lane|opposite_track
+                                                             ) then 0
          else if ( oneway:bicycle=no                         ) then 0
-         else if ( cycleway:left:oneway=no                   ) then 0
-         else if ( cycleway:right:oneway=no                  ) then 0
          else if ( not footaccess                            ) then 100
          else if ( junction=roundabout|circular              ) then 60
          else if ( highway=primary|primary_link              ) then 50


### PR DESCRIPTION
Currently this logic is spread in `badoneway`, `isbike` and `onewaypenalty` variables, that can lead to repetition or confusion.

With this change, new intermediate variables like `hascycleway` and `hasbikerouteoraccess` may allow more precise routing rules. If Brouter engine has lazy loaging, it may also improve performance, for example, in `onewaypenalty` don't re-check every possible cycleway:xxx one by one if `hascycleway` is false anyway.

Ths `isbike` behaviour is changed in the sense that it still checks the presence of a cycleway, but it does not check any more if it's a oneway that we can legally use in the current direction. If leaves this to be handled within `onewaypenalty`.