### PR TITLE
profile: Remove hikingroute always having access granted

### DIFF
--- a/misc/profiles2/hiking-mountain.brf
+++ b/misc/profiles2/hiking-mountain.brf
@@ -152,22 +152,20 @@ assign initialcost
 assign defaultaccess    switch access=    not motorroad=yes    switch or access=private access=no   0   1
 
 assign bikeaccess
-       or any_cycleroute
-          switch bicycle=
-                 switch vehicle=
-                        defaultaccess
-                        switch or vehicle=private vehicle=no
-                               0
-                               1
-                 not or bicycle=private or bicycle=no bicycle=dismount
+       switch bicycle=
+              switch vehicle=
+                     defaultaccess
+                     switch or vehicle=private vehicle=no
+                            0
+                            1
+              not or bicycle=private or bicycle=no bicycle=dismount
 
-assign footaccess     or any_hiking_route
-                      or issidewalk
+assign footaccess     or issidewalk
                       or and bikeaccess  not foot=no|use_sidepath
                       or bicycle=dismount
                       switch foot=      defaultaccess    not foot=private|no|use_sidepath
 
-assign accesspenalty switch footaccess 0 switch bikeaccess 4 switch foot=use_sidepath 10 100000
+assign accesspenalty switch footaccess 0 switch bikeaccess 4 switch foot=use_sidepath 10 switch any_hiking_route 12 switch any_cycleroute 16 100000
 
 assign badoneway = 0
 assign onewaypenalty = 0


### PR DESCRIPTION
Same as in commit e2c68117 and 35f4e331 for bicycle. See their comment.

Should solve issue https://github.com/abrensch/brouter/issues/658. Can you have a look at it @poutnikl?

Extract:

Some hiking & bicycle routes can have portions which are not accessible.

Potential reasons for this:
 - temporary construction work on the ways (sometimes for months),
 - local access change without simultaneous update of bicycle route relation (lack of mapper's knowledge or lack of time to redefine an updated route),
 - ...