### PR TITLE
profile: port of use_sidepath logic from trekking into fastbike

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -95,17 +95,16 @@ assign bikeaccess =
                  switch vehicle=
                         ( if highway=footway then false else defaultaccess )
                         not vehicle=private|no
-              not or bicycle=private or bicycle=no bicycle=dismount
+              not or bicycle=private or bicycle=no or bicycle=dismount bicycle=use_sidepath
 
 #
 # calculate logical foot access
 #
 assign footaccess =
-       or bikeaccess
-          or bicycle=dismount
-             switch foot=
-                    defaultaccess
-                    not or foot=private foot=no
+       or bicycle=dismount
+          switch foot=
+                 defaultaccess
+                 not or foot=private or foot=no foot=use_sidepath
 
 #
 # if not bike-, but foot-acess, just a moderate penalty,
@@ -150,6 +149,7 @@ assign onewaypenalty =
               cycleway:right=opposite|opposite_lane|opposite_track
                                                              ) then 0
          else if ( oneway:bicycle=no                         ) then 0
+         else if ( not footaccess                            ) then 100
          else if ( junction=roundabout|circular              ) then 60
          else if ( highway=primary|primary_link              ) then 50
          else if ( highway=secondary|secondary_link          ) then 30


### PR DESCRIPTION
Do for fastbike like in the following commits:

 - b1b9a8958
 - a10a19322
 - c5f6c3a6e

Linked to PR #745 and PR #337 

foot or bicycle tagged with value use_sidepath should be considered as not allowed, to avoid routing on those ways. Also, going against a oneway that has no foot access is heavily penalised.

This should resolve https://github.com/abrensch/brouter/issues/743 