### PR TITLE
profiles: allow bicycle access on use_sidepath with penalty

### DIFF
--- a/misc/profiles2/fastbike.brf
+++ b/misc/profiles2/fastbike.brf
@@ -117,7 +117,9 @@ assign accesspenalty
                      5
                      switch any_cycleroute
                             15
-                            10000
+                            switch bicycle=use_sidepath
+                                   25
+                                   10000
 
 #
 # handle one-ways. On primary roads, wrong-oneways should

--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -148,13 +148,14 @@ assign footaccess =
        else not foot=private|no|use_sidepath
 
 #
-# if not bike-, but foot-acess, just a moderate penalty,
+# if not bike-, but foot-access, just a moderate penalty,
 # otherwise access is forbidden
 #
 assign accesspenalty =
        if bikeaccess then 0
        else if footaccess then 4
        else if any_cycleroute then 15
+       else if bicycle=use_sidepath then 25
        else 10000
 
 #


### PR DESCRIPTION
Those changes forbid access to ways using use_sidepath access:

 - 037b3385
 - c5f6c3a6
 - a10a1932

However, because a use_sidepath access may not be as strong as a "no" access, as the OSM wiki states:

"Note that in some cases cyclist may be allowed to use bicycle=use_sidepath ways while not allowed to use bicycle=no ways in any case at all."

and because some OSM tagging may have a few inconsistencies (at least to get to the side path using the main road), and to avoid an absolutely forbidden 10000 cost to such ways (allowing user to set a waypoint on them), this change introduces an accesspenalty of 25 to such ways.

Includes a typo correction not caught by 4ccc92a1 ;)

Aims to resolve issue #831. 