### PR TITLE
Preparing next Version 1.7.9

### DIFF
--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -23,8 +23,8 @@ import btools.util.CompactLongMap;
 import btools.util.FrozenLongMap;
 
 public final class OsmTrack {
-  final public static String version = "1.7.8";
-  final public static String versionDate = "12072025";
+  final public static String version = "1.7.9";
+  final public static String versionDate = "XX032026";
 
   // csv-header-line
   private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags\tTime\tEnergy";

--- a/brouter-core/src/main/java/btools/router/OsmTrack.java
+++ b/brouter-core/src/main/java/btools/router/OsmTrack.java
@@ -24,7 +24,7 @@ import btools.util.FrozenLongMap;
 
 public final class OsmTrack {
   final public static String version = "1.7.9";
-  final public static String versionDate = "XX032026";
+  final public static String versionDate = "22042026";
 
   // csv-header-line
   private static final String MESSAGES_HEADER = "Longitude\tLatitude\tElevation\tDistance\tCostPerKm\tElevCost\tTurnCost\tNodeCost\tInitialCost\tWayTags\tNodeTags\tTime\tEnergy";

--- a/brouter-routing-app/build.gradle
+++ b/brouter-routing-app/build.gradle
@@ -18,7 +18,7 @@ android {
         namespace 'btools.routingapp'
         applicationId "btools.routingapp"
 
-        versionCode 55
+        versionCode 56
         versionName project.version
 
         resValue('string', 'app_version', defaultConfig.versionName)

--- a/buildSrc/src/main/groovy/brouter.version-conventions.gradle
+++ b/buildSrc/src/main/groovy/brouter.version-conventions.gradle
@@ -4,4 +4,4 @@
 // app: build.gradle (versionCode only)
 // OsmTrack (version and versionDate)
 // docs revisions.md (version and versionDate)
-version '1.7.8'
+version '1.7.9'

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -2,7 +2,28 @@
 
 (ZIP-Archives including APK, readme + profiles)
 
-### [brouter-1.7.8.zip](../brouter_bin/brouter-1.7.8.zip) (current revision, 12.07.2025)
+### [brouter-1.7.9.zip](../brouter_bin/brouter-1.7.9.zip) (current revision, XX.03.2026)
+
+Android
+
+- add more languages #836, #845, #851
+
+
+Library
+
+- Enable database access for pseudo way tags #828
+- Enable database access for pseudo node tags #884
+- Matched way points have a type now #849
+- Kinematic class update for cost (experimental) #860
+
+Profiles
+
+- [several rule updates](https://github.com/abrensch/brouter/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%22Version+1.7.9%22+label%3Aprofiles)
+
+[Solved issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue+milestone%3A%22Version+1.7.9%22+is%3Aclosed)
+
+
+### [brouter-1.7.8.zip](../brouter_bin/brouter-1.7.8.zip) (12.07.2025)
 
 Android
 

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -14,9 +14,11 @@ Library
 - Enable database access for pseudo way tags #828
 - Enable database access for pseudo node tags #884
 - Matched way points have a type now #849
-- Kinematic class update for cost (experimental) #860
+- Kinematic class update for cost (old classes become backup) #860
 
 Profiles
+
+- car profiles now can use the pseudo way tags like forest, river, town
 
 - [several rule updates](https://github.com/abrensch/brouter/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%22Version+1.7.9%22+label%3Aprofiles)
 

--- a/docs/revisions.md
+++ b/docs/revisions.md
@@ -2,7 +2,7 @@
 
 (ZIP-Archives including APK, readme + profiles)
 
-### [brouter-1.7.9.zip](../brouter_bin/brouter-1.7.9.zip) (current revision, XX.03.2026)
+### [brouter-1.7.9.zip](../brouter_bin/brouter-1.7.9.zip) (current revision, 22.04.2026)
 
 Android
 
@@ -21,6 +21,7 @@ Profiles
 - car profiles now can use the pseudo way tags like forest, river, town
 
 - [several rule updates](https://github.com/abrensch/brouter/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%22Version+1.7.9%22+label%3Aprofiles)
+  or [issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A%22Lookup%20Version%2011.1%22)
 
 [Solved issues](https://github.com/abrensch/brouter/issues?q=is%3Aissue+milestone%3A%22Version+1.7.9%22+is%3Aclosed)
 


### PR DESCRIPTION
Added a new version for BRouter app, library and profiles, please see [changes](https://github.com/abrensch/brouter/pulls?q=is%3Apr+milestone%3A%22Version+1.7.9%22+is%3Aclosed).