### PR TITLE
feat: Extend lookup table. Add waterway=stream|canoe_pass and canoe=*

### DIFF
--- a/misc/profiles2/lookups.dat
+++ b/misc/profiles2/lookups.dat
@@ -507,12 +507,16 @@ waterway;0000000113 fish_pass
 waterway;0000000086 boatyard
 waterway;0000000071 fairway
 waterway;0000000059 lock_gate
+waterway;0000000002 canoe_pass
+waterway;0000000001 stream
 
 boat;0000019888 no
 boat;0000002718 yes
 boat;0000000232 private
 boat;0000000064 permissive
 boat;0000000045 designated
+
+canoe;000000001 yes true designated
 
 motorboat;0000001077 yes
 motorboat;0000000808 no


### PR DESCRIPTION
Most waterways suitable for canoeing in Germany (Spreewald) are found as waterway=stream. To use brouter to navigate these waters the following changes to the lookup table are proposed:

- Add [waterway=stream](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dstream).
- Add [waterway=canoe_pass](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dcanoe_pass)
- Add the [canoe tag](https://wiki.openstreetmap.org/wiki/Key:canoe) with `true` and `designated` as aliases for `yes`.

These additions increase the total segment files size by ~2%. This was tested for OSM data for state Brandenburg in Germany.