### PR TITLE
Round trips: restore previous implementation as an option

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
+++ b/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
@@ -49,7 +49,7 @@ public enum RoundTripAlgorithm {
    * recommended choice for a best-quality loop.
    */
   public static RoundTripAlgorithm fromString(String s) {
-    if (s == null) return AUTO;
+    if (s == null) return OLD;
     String upper = s.toUpperCase(Locale.ROOT);
     if ("FAST".equals(upper)) {
       return WAYPOINT;   // quick-preview alias
@@ -57,7 +57,7 @@ public enum RoundTripAlgorithm {
     try {
       return valueOf(upper);
     } catch (IllegalArgumentException e) {
-      return AUTO;
+      return OLD;
     }
   }
 }

--- a/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
+++ b/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
@@ -49,7 +49,7 @@ public enum RoundTripAlgorithm {
    * recommended choice for a best-quality loop.
    */
   public static RoundTripAlgorithm fromString(String s) {
-    if (s == null) return OLD;
+    if (s == null) return AUTO;
     String upper = s.toUpperCase(Locale.ROOT);
     if ("FAST".equals(upper)) {
       return WAYPOINT;   // quick-preview alias
@@ -57,7 +57,7 @@ public enum RoundTripAlgorithm {
     try {
       return valueOf(upper);
     } catch (IllegalArgumentException e) {
-      return OLD;
+      return AUTO;
     }
   }
 }

--- a/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
+++ b/brouter-core/src/main/java/btools/router/RoundTripAlgorithm.java
@@ -37,7 +37,9 @@ public enum RoundTripAlgorithm {
   /** Iterative routed-leg planner, radial candidate provider — an AUTO competitor. */
   GREEDY,
   /** Iterative routed-leg planner, isochrone-derived candidates — an AUTO competitor. */
-  ISO_GREEDY;
+  ISO_GREEDY,
+  /** Previous implementation */
+  OLD;
 
   /**
    * Parse the algorithm name. Accepts the internal enum names ({@code WAYPOINT},

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -260,7 +260,7 @@ public final class RoutingContext {
   public Integer roundTripDirectionAdd;
   public Integer roundTripPoints;
   public boolean allowSamewayback;
-  public RoundTripAlgorithm roundTripAlgorithm = RoundTripAlgorithm.OLD;
+  public RoundTripAlgorithm roundTripAlgorithm = RoundTripAlgorithm.AUTO;
   /**
    * Quality-gate strictness for generated round-trips. When {@code false}
    * (the default), a route that fails only a QUALITY check

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -260,7 +260,7 @@ public final class RoutingContext {
   public Integer roundTripDirectionAdd;
   public Integer roundTripPoints;
   public boolean allowSamewayback;
-  public RoundTripAlgorithm roundTripAlgorithm = RoundTripAlgorithm.AUTO;
+  public RoundTripAlgorithm roundTripAlgorithm = RoundTripAlgorithm.OLD;
   /**
    * Quality-gate strictness for generated round-trips. When {@code false}
    * (the default), a route that fails only a QUALITY check

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -488,7 +488,10 @@ public class RoutingEngine extends Thread {
         // untimed callers (CLI, doRun(0) tests) unbounded.
         roundTripRequestDeadline = maxRunningTime > 0
           ? this.startTime + maxRunningTime : 0;
-        doRoundTrip();
+        if (routingContext.roundTripAlgorithm == RoundTripAlgorithm.OLD)
+          doRoundTripOld();
+        else
+          doRoundTrip();
         break;
       default:
         throw new IllegalArgumentException("not a valid engine mode");
@@ -1125,6 +1128,42 @@ public class RoutingEngine extends Thread {
       logThrowable(e);
     } finally {
       cleanupRoutingResources();
+    }
+
+  }
+
+  public void doRoundTripOld() {
+    try {
+      long startTime = System.currentTimeMillis();
+
+      routingContext.useDynamicDistance = true;
+      double searchRadius = (routingContext.roundTripDistance == null ? 1500 :routingContext.roundTripDistance);
+      double direction = (routingContext.startDirection == null ? -1 :routingContext.startDirection);
+      double directionAdd = (routingContext.roundTripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD :routingContext.roundTripDirectionAdd);
+      if (direction == -1) direction = getRandomDirectionFromData(waypoints.get(0), searchRadius);
+
+      if (routingContext.allowSamewayback) {
+        int[] pos = CheapRuler.destination(waypoints.get(0).ilon, waypoints.get(0).ilat, searchRadius, direction);
+        MatchedWaypoint wpt2 = new MatchedWaypoint();
+        wpt2.waypoint = new OsmNode(pos[0], pos[1]);
+        wpt2.name = "rt1_" + direction;
+
+        OsmNodeNamed onn = new OsmNodeNamed(new OsmNode(pos[0], pos[1]));
+        onn.name = "rt1";
+        waypoints.add(onn);
+      } else {
+        buildPointsFromCircle(waypoints, direction, searchRadius, routingContext.roundTripPoints == null ? 5 : routingContext.roundTripPoints);
+      }
+
+      routingContext.waypointCatchingRange = 250;
+
+      doRouting(0);
+
+      long endTime = System.currentTimeMillis();
+      logInfo("round trip execution time = " + (endTime - startTime) / 1000. + " seconds");
+    } catch (Exception e) {
+      e.getStackTrace();
+      logException(e);
     }
 
   }

--- a/docs/features/roundtrips.md
+++ b/docs/features/roundtrips.md
@@ -18,17 +18,17 @@ and road type just like a normal A-to-B route does.
 
 You control the loop with a few request parameters:
 
-| parameter | meaning |
-| :----- | :----- |
-| `roundTripLength` | desired total loop length in meters (takes precedence over `roundTripDistance`) |
-| `roundTripDistance` | search radius in meters; the loop length is roughly `2π × radius` |
-| `roundTripPoints` | accepted for backward compatibility but ignored — the planners derive their own waypoint count |
-| `startDirection` / `heading` | compass bearing to bias the direction the loop heads out; without it the start bearing is drawn randomly, so fix it whenever the loop should be reproducible |
-| `alternativeidx` | deterministic loop variety seed (`0` = default loop, any value ≥ 0 gives a reproducible variant — see [note below](#loop-quality)) |
-| `roundTripDirectionAdd` | angle offset added to an auto-detected start bearing |
-| `roundTripAlgorithm` | `AUTO` (default — best loop) or `FAST` (quick preview); the internal engine names `WAYPOINT`, `GREEDY`, `ISO_GREEDY`, `ISOCHRONE` are also accepted for forced selection — see below |
-| `roundTripStrictQuality` | `1` hard-rejects loops that fail the quality checks; default `0` is lenient — a failing loop is still returned, tagged with a `Warning:` advisory (see [Loop quality](#loop-quality)) |
-| `allowSamewayback` | `1` lets the return leg reuse ways from the outward leg; default `0` keeps the way out and the way back distinct |
+| parameter                | meaning                                                                                                                                                                                                                 |
+|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `roundTripLength`        | desired total loop length in meters (takes precedence over `roundTripDistance`)                                                                                                                                         |
+| `roundTripDistance`      | search radius in meters; the loop length is roughly `2π × radius`                                                                                                                                                       |
+| `roundTripPoints`        | accepted for backward compatibility but ignored — the planners derive their own waypoint count                                                                                                                          |
+| `direction` / `heading`  | compass bearing to bias the direction the loop heads out; without it the start bearing is drawn randomly, so fix it whenever the loop should be reproducible                                                            |
+| `alternativeidx`         | deterministic loop variety seed (`0` = default loop, any value ≥ 0 gives a reproducible variant — see [note below](#loop-quality))                                                                                      |
+| `roundTripDirectionAdd`  | angle offset added to an auto-detected start bearing                                                                                                                                                                    |
+| `roundTripAlgorithm`     | `AUTO` (default — best loop) or `FAST` (quick preview) or `OLD` (previous implementation); the internal engine names `WAYPOINT`, `GREEDY`, `ISO_GREEDY`, `ISOCHRONE` are also accepted for forced selection — see below |
+| `roundTripStrictQuality` | `1` hard-rejects loops that fail the quality checks; default `0` is lenient — a failing loop is still returned, tagged with a `Warning:` advisory (see [Loop quality](#loop-quality))                                   |
+| `allowSamewayback`       | `1` lets the return leg reuse ways from the outward leg; default `0` keeps the way out and the way back distinct                                                                                                        |
 
 If you instead supply more than one waypoint, BRouter treats those as explicit
 [via-points](vianogo.md) the loop must pass through in order, and the generated


### PR DESCRIPTION
Use the parameter `roundTripAlgorithm=OLD`.