### PR TITLE
Skip workflow runs on draft pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ on:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ "master" ]
 
 env:
@@ -24,6 +25,8 @@ env:
 
 jobs:
   build:
+    # Skip draft PRs; schedule/push/dispatch events carry no pull_request payload, so they still run
+    if: ${{ !github.event.pull_request.draft }}
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,11 +7,13 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ master ]
 
 jobs:
   build:
-
+    # Skip draft PRs; push events carry no pull_request payload, so master builds still run
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     environment: BRouter
     steps:


### PR DESCRIPTION
Based on the experience on https://github.com/abrensch/brouter/pull/903 and https://github.com/abrensch/brouter/pull/948#discussion_r3572319755, draft PRs create a lot of unintentional noise. 

Both PR-triggered workflows (Java CI, Docker) ran on every push to draft PRs, burning runner minutes on work-in-progress branches.

- Gate the build jobs with `if: !github.event.pull_request.draft`; push/schedule/dispatch events carry no pull_request payload, so the expression stays true and those runs are unaffected.
- Add `ready_for_review` to the pull_request trigger types so CI starts the moment a draft is marked ready instead of waiting for the next push.

Skipped jobs count as passing for required status checks, so drafts are not blocked by branch protection.