### PR TITLE
Add configurable unpavedPenalty parameter to trekking.brf

### DIFF
--- a/misc/profiles2/trekking.brf
+++ b/misc/profiles2/trekking.brf
@@ -56,6 +56,8 @@ assign correctMisplacedViaPointsDistance = 400 # %correctMisplacedViaPointsDista
 
 assign processUnusedTags            = false # %processUnusedTags% | Set true to output unused tags in data tab | boolean
 
+assign unpavedPenalty = 1.0 # %unpavedPenalty% | Extra penalty multiplier applied to the non-probablyGood cost of track/road/path/footway ways depending on tracktype grade | number
+
 ---context:way   # following code refers to way-tags
 
 # classifier constants
@@ -332,12 +334,12 @@ assign costfactor
   #
   else if ( highway=track|road|path|footway ) then
   (
-    if      ( tracktype=grade1 ) then ( if probablyGood then 1.0 else 1.3 )
-    else if ( tracktype=grade2 ) then ( if probablyGood then 1.1 else 2.0 )
-    else if ( tracktype=grade3 ) then ( if probablyGood then 1.5 else 3.0 )
-    else if ( tracktype=grade4 ) then ( if probablyGood then 2.0 else 5.0 )
-    else if ( tracktype=grade5 ) then ( if probablyGood then 3.0 else 5.0 )
-    else                              ( if probablyGood then 1.0 else 5.0 )
+    if      ( tracktype=grade1 ) then ( if probablyGood then 1.0 else add 1.0 multiply 0.3 unpavedPenalty )
+    else if ( tracktype=grade2 ) then ( if probablyGood then 1.1 else add 1.1 multiply 0.9 unpavedPenalty )
+    else if ( tracktype=grade3 ) then ( if probablyGood then 1.5 else add 1.5 multiply 1.5 unpavedPenalty )
+    else if ( tracktype=grade4 ) then ( if probablyGood then 2.0 else add 2.0 multiply 3.0 unpavedPenalty )
+    else if ( tracktype=grade5 ) then ( if probablyGood then 3.0 else add 3.0 multiply 2.0 unpavedPenalty )
+    else                              ( if probablyGood then 1.0 else add 1.0 multiply 4.0 unpavedPenalty )
   )
 
   #


### PR DESCRIPTION
The non-probablyGood cost values for track/road/path/footway ways (by tracktype grade) were previously hard-coded (1.3, 2.0, 3.0, 5.0, 5.0). This introduces a single unpavedPenalty multiplier so users can tune how strongly unpaved/low-quality surfaces are avoided, without editing the profile source.

Default value (1.0) reproduces the exact previous cost values, so this is a non-breaking change for existing users of the profile.