### PR TITLE
New Roundtrip Waypoint Type and new parameter for lonlats

### DIFF
--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -220,6 +220,7 @@ public final class RoutingContext {
   public Integer startDirection;
   public boolean startDirectionValid;
   public boolean forceUseStartDirection;
+  public Integer roundTripStartDirection;
   public Integer roundTripDistance;
   public Integer roundTripDirectionAdd;
   public Integer roundTripPoints;

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -171,6 +171,12 @@ public class RoutingEngine extends Thread {
 
     switch (engineMode) {
       case BROUTER_ENGINEMODE_ROUTING:
+        if (waypoints.size() == 1 && waypoints.get(0).wpttype == MatchedWaypoint.WAYPOINT_TYPE_ROUNDTRIP) {
+          engineMode = BROUTER_ENGINEMODE_ROUNDTRIP;
+          routingContext.waypointCatchingRange = 250;
+          doRouting(maxRunningTime);
+          break;
+        }
         if (waypoints.size() < 2) {
           throw new IllegalArgumentException("we need two lat/lon points at least!");
         }
@@ -220,6 +226,30 @@ public class RoutingEngine extends Thread {
           waypoints.addAll(newpoints);
         }
       }
+
+      // check for round trip
+      List<OsmNodeNamed> tmppoints = new ArrayList<>();
+      for (OsmNodeNamed onn: waypoints) {
+        if (onn.wpttype == MatchedWaypoint.WAYPOINT_TYPE_ROUNDTRIP) {
+          double searchRadius = (routingContext.roundTripDistance == null ? 1500 :routingContext.roundTripDistance);
+          double direction = (routingContext.roundTripStartDirection == null ? -1 :routingContext.roundTripStartDirection);
+          double directionAdd = (routingContext.roundTripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD :routingContext.roundTripDirectionAdd);
+          if (direction == -1) direction = getRandomDirectionFromData(onn, searchRadius);
+          routingContext.useDynamicDistance = true;
+          routingContext.waypointCatchingRange = 250;
+
+          List<OsmNodeNamed> newpoints = new ArrayList<>();
+          onn.name = "from_rt";
+          newpoints.add(onn);
+          buildPointsFromCircle(newpoints, direction, searchRadius, routingContext.roundTripPoints == null ? 5 : routingContext.roundTripPoints);
+          tmppoints.addAll(newpoints);
+        } else {
+          tmppoints.add(onn);
+        }
+      }
+
+      waypoints.clear();
+      waypoints.addAll(tmppoints);
 
       int nsections = waypoints.size() - 1;
       OsmTrack[] refTracks = new OsmTrack[nsections]; // used ways for alternatives
@@ -490,7 +520,7 @@ public class RoutingEngine extends Thread {
 
       routingContext.useDynamicDistance = true;
       double searchRadius = (routingContext.roundTripDistance == null ? 1500 :routingContext.roundTripDistance);
-      double direction = (routingContext.startDirection == null ? -1 :routingContext.startDirection);
+      double direction = (routingContext.roundTripStartDirection == null ? -1 :routingContext.roundTripStartDirection);
       double directionAdd = (routingContext.roundTripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD :routingContext.roundTripDirectionAdd);
       if (direction == -1) direction = getRandomDirectionFromData(waypoints.get(0), searchRadius);
 
@@ -504,6 +534,7 @@ public class RoutingEngine extends Thread {
         onn.name = "rt1";
         waypoints.add(onn);
       } else {
+        waypoints.get(0).name = "from_rt";
         buildPointsFromCircle(waypoints, direction, searchRadius, routingContext.roundTripPoints == null ? 5 : routingContext.roundTripPoints);
       }
 
@@ -903,7 +934,14 @@ public class RoutingEngine extends Thread {
       hasDirectRouting = true;
     }
     for (OsmNodeNamed wp : waypoints) {
-      if (hasInfo()) logInfo("wp=" + wp + (wp.wpttype == MatchedWaypoint.WAYPOINT_TYPE_DIRECT ? " beeline" : (wp.wpttype == MatchedWaypoint.WAYPOINT_TYPE_MEETING ? " via" : "")));
+      String type = "";
+      switch (wp.wpttype) {
+        case MatchedWaypoint.WAYPOINT_TYPE_DIRECT: type = " beeline"; break;
+        case MatchedWaypoint.WAYPOINT_TYPE_MEETING: type = " via"; break;
+        case MatchedWaypoint.WAYPOINT_TYPE_ROUNDTRIP: type = " roundtrip"; break;
+        default: break;
+      }
+      if (hasInfo()) logInfo("wp=" + wp + type);
       if (wp.wpttype == MatchedWaypoint.WAYPOINT_TYPE_DIRECT) hasDirectRouting = true;
     }
 
@@ -940,8 +978,16 @@ public class RoutingEngine extends Thread {
       }
 
       for (MatchedWaypoint mwp : matchedWaypoints) {
-        if (hasInfo() && matchedWaypoints.size() != nUnmatched)
-          logInfo("new wp=" + mwp.waypoint + " " + mwp.crosspoint + (mwp.wpttype == MatchedWaypoint.WAYPOINT_TYPE_DIRECT ? " beeline" : (mwp.wpttype == MatchedWaypoint.WAYPOINT_TYPE_MEETING ? " via" : "")));
+        if (hasInfo() && matchedWaypoints.size() != nUnmatched) {
+          String type = "";
+          switch (mwp.wpttype) {
+            case MatchedWaypoint.WAYPOINT_TYPE_DIRECT: type = " beeline"; break;
+            case MatchedWaypoint.WAYPOINT_TYPE_MEETING: type = " via"; break;
+            case MatchedWaypoint.WAYPOINT_TYPE_ROUNDTRIP: type = " roundtrip"; break;
+            default: break;
+          }
+          logInfo("new wp=" + mwp.waypoint + " " + mwp.crosspoint + type);
+        }
       }
 
       routingContext.checkMatchedWaypointAgainstNogos(matchedWaypoints);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -520,7 +520,7 @@ public class RoutingEngine extends Thread {
 
       routingContext.useDynamicDistance = true;
       double searchRadius = (routingContext.roundTripDistance == null ? 1500 :routingContext.roundTripDistance);
-      double direction = (routingContext.roundTripStartDirection == null ? -1 :routingContext.roundTripStartDirection);
+      double direction = (routingContext.roundTripStartDirection == null ? (routingContext.startDirection == null ? -1 : routingContext.startDirection) : routingContext.roundTripStartDirection);
       double directionAdd = (routingContext.roundTripDirectionAdd == null ? ROUNDTRIP_DEFAULT_DIRECTIONADD :routingContext.roundTripDirectionAdd);
       if (direction == -1) direction = getRandomDirectionFromData(waypoints.get(0), searchRadius);
 

--- a/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
+++ b/brouter-core/src/main/java/btools/router/RoutingParamCollector.java
@@ -38,6 +38,8 @@ public class RoutingParamCollector {
           wplist.get(wplist.size() - 1).wpttype = MatchedWaypoint.WAYPOINT_TYPE_DIRECT;
         } else if (lonLat[2].equals("m")) {
           wplist.get(wplist.size() - 1).wpttype = MatchedWaypoint.WAYPOINT_TYPE_MEETING;
+        } else if (lonLat[2].equals("r")) {
+          wplist.get(wplist.size() - 1).wpttype = MatchedWaypoint.WAYPOINT_TYPE_ROUNDTRIP;
         } else {
           wplist.get(wplist.size() - 1).name = lonLat[2];
           wplist.get(wplist.size() - 1).wpttype = MatchedWaypoint.WAYPOINT_TYPE_MEETING;
@@ -207,6 +209,8 @@ public class RoutingParamCollector {
           rctx.forceUseStartDirection = true;
         } else if (key.equals("direction")) {
           rctx.startDirection = Integer.valueOf(value);
+        } else if (key.equals("roundTripStartDirection")) {
+          rctx.roundTripStartDirection = Integer.valueOf(value);
         } else if (key.equals("roundTripDistance")) {
           rctx.roundTripDistance = Integer.valueOf(value);
         } else if (key.equals("roundTripDirectionAdd")) {

--- a/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
+++ b/brouter-mapaccess/src/main/java/btools/mapaccess/MatchedWaypoint.java
@@ -13,9 +13,10 @@ import java.util.ArrayList;
 
 public final class MatchedWaypoint {
 
-  public static final byte WAYPOINT_TYPE_SHAPING = 1;  // route next to this point
-  public static final byte WAYPOINT_TYPE_MEETING = 2;  // visit this point
-  public static final byte WAYPOINT_TYPE_DIRECT  = 3;  // from this point go direct to next = beeline routing
+  public static final byte WAYPOINT_TYPE_SHAPING    = 1;  // route next to this point
+  public static final byte WAYPOINT_TYPE_MEETING    = 2;  // visit this point
+  public static final byte WAYPOINT_TYPE_DIRECT     = 3;  // from this point go direct to next = beeline routing
+  public static final byte WAYPOINT_TYPE_ROUNDTRIP  = 4;  // from this point start round trip routing
 
   public OsmNode node1;
   public OsmNode node2;

--- a/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
+++ b/brouter-routing-app/src/main/aidl/btools/routingapp/IBRouterService.aidl
@@ -24,6 +24,7 @@ interface IBRouterService {
     //                      variantes: lon,lat,d|... (from this point to the next  do a direct line)
     //                                 lon,lat,m|... (route point has no name and works as a meeting point)
     //                                 lon,lat,name|... (route point has a name and should not be ignored)
+    //                                 lon,lat,r|... (from this point start a round trip)
     //  "straight"        = idx1,idx2,.. (optional, minimum one value, index of a direct routing point in the waypoint list)
     //  "nogos"           = lon,lat,radius,weight|... (optional, list of lon, lat, radius in meters, weight (optional))
     //  "polylines"       = lon,lat,lon,lat,...,weight|... (unlimited list of lon,lat and weight (optional), lists separated by |)


### PR DESCRIPTION
At the moment round trips are fixed to `engineMode=4`.
This enables the round trip on the `engineMode=0` as well. This is done by the call
`... lonlats=8.784465,49.779428,r  ...
`
and now we can build combinations for this
```
... lonlats=8.7806257,49.7698181;8.784465,49.779428,r ...
... lonlats=8.784465,49.779428,r;8.7806257,49.7698181 ...
... lonlats=8.7806257,49.7698181;8.784465,49.779428,r;8.7806257,49.7698181 ...
```
It should not be more then one round trip in the combinations.
To make it clearer, a new parameter is added: `roundTripStartDirection`
No reuse of `direction` parameter from now.

`engineMode=4` is still working as expected.
`buildPointsFromCircle` is still the entry point for generation of round trip points.
In the future it would be nice to have a call for BRouter Web like this:
https://brouter.de/brouter-web/#map=14/49.7801/8.7917/standard&lonlats=8.784465,49.779428,r