### PR TITLE
Improve docker image and workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,5 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   workflow_dispatch:
   schedule:
@@ -17,11 +12,8 @@ on:
     branches: [ "master" ]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:
@@ -30,30 +22,18 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.0
-        with:
-          cosign-release: 'v2.1.1'
+      # QEMU runs the arm64 runtime stage. The jar builds once on amd64.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
@@ -62,38 +42,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
+      # Tags: master for a push, nightly for the schedule, the version and
+      # latest for a release tag.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        id: build-and-push
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      # - name: Sign the published Docker image
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   env:
-      #     # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-      #     TAGS: ${{ steps.meta.outputs.tags }}
-      #     DIGEST: ${{ steps.build-and-push.outputs.digest }}
-      #   # This step uses the identity token to provision an ephemeral certificate
-      #   # against the sigstore community Fulcio instance.
-      #   run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,33 @@
-FROM gradle:jdk17-jammy AS build
+# The build stage runs on the build host for every target platform, because
+# the jar is architecture independent. Only the runtime stage runs per
+# platform.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS build
 
 WORKDIR /brouter
 COPY . .
 
-RUN dos2unix gradlew || sed -i 's/\r$//' gradlew
-RUN ./gradlew clean build
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon clean build
 
-FROM openjdk:17.0.1-jdk-slim
+FROM eclipse-temurin:17-jre-jammy
 
-RUN mkdir /customprofiles
+RUN groupadd --gid 1000 brouter \
+    && useradd --uid 1000 --gid brouter --home-dir /app --no-create-home brouter \
+    && mkdir -p /app /segments4 /customprofiles \
+    && chown brouter:brouter /app /segments4 /customprofiles
 
 WORKDIR /app
 COPY --from=build /brouter/brouter-server/build/libs/brouter-*-all.jar /app/brouter.jar
-COPY --from=build /brouter/misc/scripts/standalone/server.sh /app/server.sh
-COPY --from=build /brouter/misc/* /profiles2/
-
-RUN sed -i 's/\r$//' /app/server.sh && chmod +x /app/server.sh
-
+COPY --from=build --chmod=755 /brouter/misc/scripts/standalone/server.sh /app/server.sh
+COPY --from=build /brouter/misc/profiles2/ /profiles2/
 
 ENV CLASSPATH=/app/brouter.jar \
     SEGMENTSPATH=/segments4 \
     PROFILESPATH=/profiles2 \
     CUSTOMPROFILESPATH=/customprofiles
 
+USER brouter
+
 EXPOSE 17777
 
-CMD ["sh", "-c", "/app/server.sh"]
-
+CMD ["/app/server.sh"]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,29 @@ Example log output:
 
 ## BRouter with Docker
 
-To build the Docker image run (in the project's top level directory):
+A ready image for amd64 and arm64 is published at `ghcr.io/abrensch/brouter`. The tag `latest`
+points to the newest release, a tag such as `v1.7.10` to that release, `nightly` to the daily
+build of master. The container runs as user 1000 and starts `server.sh`, which reads these
+variables:
+
+| Variable      | Default                                                                | Meaning                             |
+| ------------- | ---------------------------------------------------------------------- | ----------------------------------- |
+| `JAVA_OPTS`   | `-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300 -DuseRFCMimeType=false` | JVM options and the request timeout |
+| `MAXTHREADS`  | `1`                                                                    | Requests the server handles at once |
+| `PORT`        | `17777`                                                                | Listen port                         |
+| `BINDADDRESS` | all interfaces                                                         | Listen address                      |
+
+```
+docker run --rm \
+  -v ./misc/scripts/segments4:/segments4 \
+  -p 17777:17777 \
+  -e MAXTHREADS=4 \
+  -e JAVA_OPTS="-Xmx512M -DmaxRunningTime=300" \
+  --name brouter \
+  ghcr.io/abrensch/brouter:latest
+```
+
+To build the Docker image yourself run (in the project's top level directory):
 
 ```
 docker build -t brouter .

--- a/misc/scripts/standalone/server.sh
+++ b/misc/scripts/standalone/server.sh
@@ -5,7 +5,9 @@ cd "$(dirname "$0")"
 # java -cp brouter.jar btools.brouter.RouteServer <segmentdir> <profile-map> <customprofiledir> <port> <maxthreads> [bindaddress]
 
 # maxRunningTime is the request timeout in seconds, set to 0 to disable timeout
-JAVA_OPTS="-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300 -DuseRFCMimeType=false"
+JAVA_OPTS=${JAVA_OPTS:-"-Xmx128M -Xms128M -Xmn8M -DmaxRunningTime=300 -DuseRFCMimeType=false"}
+PORT=${PORT:-17777}
+MAXTHREADS=${MAXTHREADS:-1}
 
 # If paths are unset, first search in locations matching the directory structure
 # as found in the official BRouter zip archive
@@ -28,4 +30,4 @@ if [ ! -e "$CUSTOMPROFILESPATH" ]; then
     CUSTOMPROFILESPATH="../customprofiles"
 fi
 
-java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer "$SEGMENTSPATH" "$PROFILESPATH" "$CUSTOMPROFILESPATH" 17777 1 $BINDADDRESS
+exec java $JAVA_OPTS -cp $CLASSPATH btools.server.RouteServer "$SEGMENTSPATH" "$PROFILESPATH" "$CUSTOMPROFILESPATH" "$PORT" "$MAXTHREADS" $BINDADDRESS


### PR DESCRIPTION
The published image is amd64 only, runs as root on a JDK image from 2021 and server.sh hard-codes the JVM options, the port and one thread. This PR builds the image for amd64 and arm64, makes the server settings configurable through the environment and slims the image down.

Builds with these changes have ran on my fork: https://github.com/Quadrubo/brouter/actions/runs/34043044688

## Added

- arm64 image
- `server.sh` reads `JAVA_OPTS`, `PORT` and `MAXTHREADS` from the environment. Defaults stay the same as before.
- README section for the published image and its variables

## Changed

- Runtime image changed to `eclipse-temurin:17-jre-jammy` from the deprecated `openjdk:17.0.1-jdk-slim`. Results in the image size dropping from 410 MB to 265 MB.
- `server.sh` execs java so that java is the container's main process
- Uses the current action versions in the workflow, drops unused install steps and the actions layer cache

## Breaking Changes

- The container runs as user 1000 instead of root. Therefore a mounted `/customprofiles` must be writable by that user if the profile upload is used. Segment files only need to be readable.
- `/profiles2` now only contains `misc/profiles2`. The old image copied the whole `misc` tree including scripts and utils which are unnecessary in the image.
- The image uses JRE instead of JDK
- `server.sh` picks up `JAVA_OPTS` and `PORT` from the environment. Anyone with those variables already set for something else replaces BRouter's defaults. I could rename them to `BROUTER_JAVA_OPTS`, `BROUTER_PORT` and `BROUTER_MAXTHREADS` if you want
- Building the image now requires BuildKIt, this has been the default for Docker since version 23